### PR TITLE
Support repeatable directives in introspection

### DIFF
--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/directive/Directive.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/directive/Directive.kt
@@ -16,7 +16,8 @@ data class Directive(
     override val locations: List<DirectiveLocation>,
     val execution: DirectiveExecution,
     override val description: String?,
-    val arguments: List<InputValue<*>>
+    val arguments: List<InputValue<*>>,
+    override val isRepeatable: Boolean?
 ) : __Directive {
 
     override val args: List<__InputValue>
@@ -26,14 +27,16 @@ data class Directive(
         val name: String,
         val locations: List<DirectiveLocation>,
         val execution: DirectiveExecution,
-        val description: String? = null
+        val description: String? = null,
+        val isRepeatable: Boolean? = null
     ) {
         fun toDirective(inputValues: List<InputValue<*>>) = Directive(
             name = this.name,
             locations = this.locations,
             execution = this.execution,
             description = this.description,
-            arguments = inputValues
+            arguments = inputValues,
+            isRepeatable = isRepeatable
         )
     }
 

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/introspection/__Directive.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/introspection/__Directive.kt
@@ -7,4 +7,6 @@ interface __Directive : __Described {
     val locations: List<DirectiveLocation>
 
     val args: List<__InputValue>
+
+    val isRepeatable: Boolean?
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/BaseSchemaTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/BaseSchemaTest.kt
@@ -38,6 +38,7 @@ abstract class BaseSchemaTest {
                         args(includeDeprecated: true) {
                             ...InputValue
                         }
+                        isRepeatable
                     }
                 }
             }


### PR DESCRIPTION
Resolves https://github.com/stuebingerb/KGraphQL/issues/3. Repeatable directives may or may not work (haven't tested) but at least the introspection query supports the property. Parsing already supported the keyword apparently.