### PR TITLE
build: define dependencies in version catalog

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 dependencies {
-    implementation(kotlin("gradle-plugin", "2.0.21"))
-    implementation("dev.adamko.dokkatoo:dokkatoo-plugin:2.4.0")
-    implementation("com.vanniktech.maven.publish:com.vanniktech.maven.publish.gradle.plugin:0.30.0")
+    implementation(libs.kotlin.gradle)
+    implementation(libs.dokkatoo.gradle)
+    implementation(libs.mavenPublish.gradle)
 }

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,1 +1,9 @@
 rootProject.name = "buildSrc"
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,27 +1,2 @@
-# Gradle configuration
 org.gradle.parallel=true
 org.gradle.caching=true
-# Dependencies
-coroutine_version=1.9.0
-jackson_version=2.18.0
-caffeine_version=3.1.8
-serialization_version=1.7.3
-kDataLoader_version=0.5.1
-deferredJsonBuilder_version=1.0.0
-ktor_version=2.3.12
-# Test-Dependencies
-kotlin_html_version=0.7.5
-netty_version=4.1.114.Final
-junit_version=5.11.2
-kluent_version=1.73
-hamcrest_version=3.0
-# Gradle Plugin, ... versions
-jmhGradlePlugin_version=0.7.2
-jmh_version=1.37
-coverallsGradlePlugin_version=2.12.2
-jacoco_version=0.8.12
-# Example Dependencies
-exposed_version=0.32.1
-logback_version=1.5.8
-h2_version=1.4.200
-hikari_version=6.0.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,47 @@
+[versions]
+kotlin = "2.0.21"
+kotlinx-coroutines = "1.9.0"
+kotlinx-serialization = "1.7.3"
+jackson = "2.18.0"
+ktor = "2.3.12"
+junit-jupiter = "5.11.2"
+exposed = "0.32.1"
+
+[plugins]
+serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+
+[libraries]
+kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+dokkatoo-gradle = { module = "dev.adamko.dokkatoo:dokkatoo-plugin", version = "2.4.0" }
+mavenPublish-gradle = { module = "com.vanniktech.maven.publish:com.vanniktech.maven.publish.gradle.plugin", version = "0.30.0" }
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-jdk8 = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-debug = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-debug", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
+jackson-core-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
+jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
+caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version = "3.1.8" }
+deferredJsonBuilder = { module = "com.apurebase:DeferredJsonBuilder", version = "1.0.0" }
+ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
+ktor-server-auth = { module = "io.ktor:ktor-server-auth", version.ref = "ktor" }
+ktor-server-test-host = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor" }
+hamcrest = { module = "org.hamcrest:hamcrest", version = "3.0" }
+kluent = { module = "org.amshove.kluent:kluent", version = "1.73" }
+junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit-jupiter" }
+junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit-jupiter" }
+junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit-jupiter" }
+
+#region kgraphql-example
+ktor-server-netty = { module = "io.ktor:ktor-server-netty", version.ref = "ktor" }
+logback-classic = { module = "ch.qos.logback:logback-classic", version = "1.5.8" }
+exposed-core = { module = "org.jetbrains.exposed:exposed-core", version.ref = "exposed" }
+exposed-jdbc = { module = "org.jetbrains.exposed:exposed-jdbc", version.ref = "exposed" }
+exposed-javaTime = { module = "org.jetbrains.exposed:exposed-java-time", version.ref = "exposed" }
+h2 = { module = "com.h2database:h2", version = "1.4.200" }
+hikari = { module = "com.zaxxer:HikariCP", version = "6.0.0" }
+#endregion
+
+#region test-source-examples
+netty = { module = "io.netty:netty-all", version = "4.1.114.Final" }
+#endregion

--- a/kgraphql-example/build.gradle.kts
+++ b/kgraphql-example/build.gradle.kts
@@ -7,25 +7,18 @@ kotlin {
     jvmToolchain(21)
 }
 
-val ktor_version: String by project
-val logback_version: String by project
-val exposed_version: String by project
-val h2_version: String by project
-val hikari_version: String by project
-val junit_version: String by project
-
 application {
     mainClass.set("io.ktor.server.netty.EngineMain")
 }
 
 dependencies {
     implementation(project(":kgraphql-ktor"))
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-auth:$ktor_version")
-    implementation("ch.qos.logback:logback-classic:$logback_version")
-    implementation("org.jetbrains.exposed:exposed-core:$exposed_version")
-    implementation("org.jetbrains.exposed:exposed-jdbc:$exposed_version")
-    implementation("org.jetbrains.exposed:exposed-java-time:$exposed_version")
-    implementation("com.h2database:h2:$h2_version")
-    implementation("com.zaxxer:HikariCP:$hikari_version")
+    implementation(libs.ktor.server.netty)
+    implementation(libs.ktor.server.auth)
+    implementation(libs.logback.classic)
+    implementation(libs.exposed.core)
+    implementation(libs.exposed.jdbc)
+    implementation(libs.exposed.javaTime)
+    implementation(libs.h2)
+    implementation(libs.hikari)
 }

--- a/kgraphql-ktor/build.gradle.kts
+++ b/kgraphql-ktor/build.gradle.kts
@@ -1,34 +1,19 @@
 plugins {
     id("library-conventions")
-    kotlin("plugin.serialization") version "2.0.21"
+    alias(libs.plugins.serialization)
 }
-
-val caffeine_version: String by project
-val kDataLoader_version: String by project
-val kotlin_version: String by project
-val serialization_version: String by project
-val coroutine_version: String by project
-val jackson_version: String by project
-val ktor_version: String by project
-
-val netty_version: String by project
-val hamcrest_version: String by project
-val kluent_version: String by project
-val junit_version: String by project
 
 val isReleaseVersion = !version.toString().endsWith("SNAPSHOT")
 
 dependencies {
-    implementation(kotlin("stdlib-jdk8"))
     api(project(":kgraphql"))
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-serialization:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:$ktor_version")
-    implementation("com.github.salomonbrys.kotson:kotson:2.5.0")
+    implementation(kotlin("stdlib-jdk8"))
+    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.ktor.server.core)
 
-    testImplementation("org.junit.jupiter:junit-jupiter-api:$junit_version")
-    testImplementation("org.amshove.kluent:kluent:$kluent_version")
-    testImplementation("io.ktor:ktor-server-test-host:$ktor_version")
-    testImplementation("io.ktor:ktor-server-auth:$ktor_version")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junit_version")
+    testImplementation(libs.junit.jupiter.api)
+    testImplementation(libs.kluent)
+    testImplementation(libs.ktor.server.test.host)
+    testImplementation(libs.ktor.server.auth)
+    testRuntimeOnly(libs.junit.jupiter.engine)
 }

--- a/kgraphql/build.gradle.kts
+++ b/kgraphql/build.gradle.kts
@@ -2,40 +2,25 @@ plugins {
     id("library-conventions")
 }
 
-val caffeine_version: String by project
-val kDataLoader_version: String by project
-val deferredJsonBuilder_version: String by project
-val kotlin_version: String by project
-val serialization_version: String by project
-val coroutine_version: String by project
-val jackson_version: String by project
-val netty_version: String by project
-val hamcrest_version: String by project
-val kluent_version: String by project
-val junit_version: String by project
-
 val isReleaseVersion = !version.toString().endsWith("SNAPSHOT")
 
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
     implementation(kotlin("reflect"))
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.coroutines.jdk8)
+    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.jackson.core.databind)
+    implementation(libs.jackson.module.kotlin)
+    implementation(libs.caffeine)
+    implementation(libs.deferredJsonBuilder)
 
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutine_version")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:$coroutine_version")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$serialization_version") // JVM dependency
-
-    implementation("com.fasterxml.jackson.core:jackson-databind:$jackson_version")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_version")
-
-    implementation("com.github.ben-manes.caffeine:caffeine:$caffeine_version")
-    implementation("com.apurebase:DeferredJsonBuilder:$deferredJsonBuilder_version")
-
-    testImplementation("io.netty:netty-all:$netty_version")
-    testImplementation("org.hamcrest:hamcrest:$hamcrest_version")
-    testImplementation("org.amshove.kluent:kluent:$kluent_version")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:$junit_version")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:$junit_version")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-debug:$coroutine_version")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutine_version")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junit_version")
+    testImplementation(libs.netty)
+    testImplementation(libs.hamcrest)
+    testImplementation(libs.kluent)
+    testImplementation(libs.junit.jupiter.api)
+    testImplementation(libs.junit.jupiter.params)
+    testImplementation(libs.kotlinx.coroutines.debug)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testRuntimeOnly(libs.junit.jupiter.engine)
 }


### PR DESCRIPTION
The [version catalog](https://docs.gradle.org/current/userguide/platforms.html) is a Gradle standard feature to define dependency versions in a single source in multi-module projects.

Using a standard features has two major benefits:
* Easier to understand for contributors
* Tooling support (e.g. for automating dependency updates)

Also remove unused third party dependencies from `kgraphql-ktor`.