### PR TITLE
Fix: NoSuchFieldError in Ktor 3.0.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ kotlin = "2.0.21"
 kotlinx-coroutines = "1.9.0"
 kotlinx-serialization = "1.7.3"
 jackson = "2.18.0"
-ktor = "2.3.12"
+ktor = "3.0.0"
 junit-jupiter = "5.11.2"
 exposed = "0.32.1"
 

--- a/kgraphql-ktor/src/main/kotlin/com/apurebase/kgraphql/KtorFeature.kt
+++ b/kgraphql-ktor/src/main/kotlin/com/apurebase/kgraphql/KtorFeature.kt
@@ -9,7 +9,6 @@ import io.ktor.server.application.Application
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.ApplicationCallPipeline
 import io.ktor.server.application.Plugin
-import io.ktor.server.application.call
 import io.ktor.server.application.install
 import io.ktor.server.application.pluginOrNull
 import io.ktor.server.request.receiveText
@@ -17,6 +16,7 @@ import io.ktor.server.response.respondBytes
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.Routing
+import io.ktor.server.routing.RoutingRoot
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
@@ -103,7 +103,7 @@ class GraphQL(val schema: Schema) {
                 config.wrapWith?.invoke(this, routing) ?: routing(this)
             }
 
-            pipeline.pluginOrNull(Routing)?.apply(routing) ?: pipeline.install(Routing, routing)
+            pipeline.pluginOrNull(RoutingRoot)?.apply(routing) ?: pipeline.install(RoutingRoot, routing)
 
             pipeline.intercept(ApplicationCallPipeline.Monitoring) {
                 try {


### PR DESCRIPTION
Updated Ktor version to 3.0.0 and fixed the bug that causes NoSuchFieldError.

NoSuchFieldError will be thrown when using Ktor 3.0.0 and the latest KGQL 0.21.0.

```
Exception in thread "main" java.lang.NoSuchFieldError: Plugin
	at com.apurebase.kgraphql.GraphQL$FeatureInstance.install(KtorFeature.kt:106)
	at com.apurebase.kgraphql.GraphQL$Feature.install(KtorFeature.kt:60)
	at com.apurebase.kgraphql.GraphQL$Feature.install(KtorFeature.kt:54)
	at io.ktor.server.application.ApplicationPluginKt.install(ApplicationPlugin.kt:100)
	at cn.taskeren.explode.plugins.KGraphQLKt.configureKGraphQL(KGraphQL.kt:8)
	at cn.taskeren.explode.ApplicationKt.module(Application.kt:23)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at kotlin.reflect.jvm.internal.calls.CallerImpl$Method.callMethod(CallerImpl.kt:97)
	at kotlin.reflect.jvm.internal.calls.CallerImpl$Method$Static.call(CallerImpl.kt:106)
	at kotlin.reflect.jvm.internal.KCallableImpl.callDefaultMethod$kotlin_reflection(KCallableImpl.kt:207)
	at kotlin.reflect.jvm.internal.KCallableImpl.callBy(KCallableImpl.kt:112)
	at io.ktor.server.engine.internal.CallableUtilsKt.callFunctionWithInjection(CallableUtils.kt:120)
	at io.ktor.server.engine.internal.CallableUtilsKt.executeModuleFunction(CallableUtils.kt:36)
	at io.ktor.server.engine.EmbeddedServer.launchModuleByName$lambda$26(EmbeddedServerJvm.kt:354)
	at io.ktor.server.engine.EmbeddedServer.avoidingDoubleStartupFor(EmbeddedServerJvm.kt:378)
	at io.ktor.server.engine.EmbeddedServer.launchModuleByName(EmbeddedServerJvm.kt:353)
	at io.ktor.server.engine.EmbeddedServer.instantiateAndConfigureApplication$lambda$25(EmbeddedServerJvm.kt:334)
	at io.ktor.server.engine.EmbeddedServer.avoidingDoubleStartup(EmbeddedServerJvm.kt:360)
	at io.ktor.server.engine.EmbeddedServer.instantiateAndConfigureApplication(EmbeddedServerJvm.kt:332)
	at io.ktor.server.engine.EmbeddedServer.createApplication(EmbeddedServerJvm.kt:142)
	at io.ktor.server.engine.EmbeddedServer.start(EmbeddedServerJvm.kt:271)
	at io.ktor.server.netty.EngineMain.main(EngineMain.kt:25)
```

Just noticed that this fixed error occurred in #20.