### PR TITLE
ci: unblock docs and examples only pull requests

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -2,8 +2,6 @@ name: Tests (Examples)
 
 on:
   push:
-    paths-ignore:
-      - 'docs/**'
 
 jobs:
   ktor:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,6 @@ name: Tests (Library)
 
 on:
   push:
-    paths-ignore:
-      - 'docs/**'
-      - 'examples/**'
 
 jobs:
   test:


### PR DESCRIPTION
Required checks need to run for pull-requests to be merge-able.