### PR TITLE
refactor: Migrate to test suites

### DIFF
--- a/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
@@ -1,22 +1,19 @@
-import org.gradle.api.tasks.testing.Test
-import org.gradle.api.tasks.testing.logging.TestExceptionFormat
-import org.gradle.api.tasks.testing.logging.TestLogEvent
+@file:Suppress("UnstableApiUsage")
+
 import org.gradle.kotlin.dsl.kotlin
 import org.gradle.kotlin.dsl.withType
 
 plugins {
     id("kgraphql-base")
     kotlin("jvm")
+    `java-library`
+    `jvm-test-suite`
 }
 
-tasks
-    .withType<Test>()
-    .configureEach {
-        useJUnitPlatform()
-        testLogging {
-            showExceptions = true
-            showStandardStreams = true
-            events = setOf(TestLogEvent.FAILED, TestLogEvent.PASSED, TestLogEvent.SKIPPED)
-            exceptionFormat = TestExceptionFormat.FULL
+testing {
+    suites {
+        withType<JvmTestSuite> {
+            useJUnitJupiter()
         }
     }
+}

--- a/buildSrc/src/main/kotlin/library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/library-conventions.gradle.kts
@@ -7,7 +7,6 @@ plugins {
     id("kotlin-conventions")
     id("dev.adamko.dokkatoo-html")
     id("com.vanniktech.maven.publish")
-    `java-library`
 }
 
 group = "de.stuebingerb"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,4 +29,3 @@ hamcrest = { module = "org.hamcrest:hamcrest", version = "3.0" }
 kluent = { module = "org.amshove.kluent:kluent", version = "1.73" }
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit-jupiter" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit-jupiter" }
-junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit-jupiter" }

--- a/kgraphql-ktor/build.gradle.kts
+++ b/kgraphql-ktor/build.gradle.kts
@@ -15,5 +15,4 @@ dependencies {
     testImplementation(libs.kluent)
     testImplementation(libs.ktor.server.test.host)
     testImplementation(libs.ktor.server.auth)
-    testRuntimeOnly(libs.junit.jupiter.engine)
 }

--- a/kgraphql/build.gradle.kts
+++ b/kgraphql/build.gradle.kts
@@ -21,5 +21,4 @@ dependencies {
     testImplementation(libs.junit.jupiter.params)
     testImplementation(libs.kotlinx.coroutines.debug)
     testImplementation(libs.kotlinx.coroutines.test)
-    testRuntimeOnly(libs.junit.jupiter.engine)
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaBuilderTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaBuilderTest.kt
@@ -41,9 +41,9 @@ import kotlin.reflect.typeOf
  * Tests for SchemaBuilder behaviour, not request execution
  */
 class SchemaBuilderTest {
+    @Suppress("UNCHECKED_CAST")
     @Test
     fun `DSL created UUID scalar support`() {
-
         val testedSchema = defaultSchema {
             stringScalar<UUID> {
                 description = "unique identifier of object"


### PR DESCRIPTION
Migrate to test suites to get rid of deprecation warnings and as Gradle's way forward of testing.

Resolves #48