### PR TITLE
fix: Fix error handling for input values

### DIFF
--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/ArgumentTransformer.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/ArgumentTransformer.kt
@@ -25,6 +25,10 @@ open class ArgumentTransformer(val schema: DefaultSchema) {
                 }
             }
 
+            type.isList() && value !is ValueNode.ListValueNode -> {
+                throw GraphQLError("argument '${value.valueNodeName}' is not valid value of type List", value)
+            }
+
             value is ValueNode.ObjectValueNode -> {
                 val constructor = type.unwrapped().kClass!!.primaryConstructor ?: throw GraphQLError(
                     "Java class '${type.unwrapped().kClass!!.simpleName}' as inputType are not supported",
@@ -54,7 +58,7 @@ open class ArgumentTransformer(val schema: DefaultSchema) {
 
                 if (missingNonOptionalInputs.isNotEmpty()) {
                     val inputs = missingNonOptionalInputs.map { it.name }.joinToString(",")
-                    throw GraphQLError("You are missing non optional input fields: $inputs", value)
+                    throw GraphQLError("You are missing non-optional input fields: $inputs", value)
                 }
 
                 constructor.callBy(valueMap)
@@ -71,7 +75,7 @@ open class ArgumentTransformer(val schema: DefaultSchema) {
                 }
             }
 
-            value is ValueNode.ListValueNode && type.isList() -> {
+            value is ValueNode.ListValueNode -> {
                 if (type.isNotList()) {
                     throw GraphQLError(
                         "argument '${value.valueNodeName}' is not valid value of type ${type.unwrapped().name}",
@@ -94,7 +98,7 @@ open class ArgumentTransformer(val schema: DefaultSchema) {
 
         fun throwInvalidEnumValue(enumType: Type.Enum<*>) {
             throw GraphQLError(
-                "Invalid enum ${schema.model.enums[kClass]?.name} value. Expected one of ${enumType.values}", value
+                "Invalid enum ${schema.model.enums[kClass]?.name} value. Expected one of ${enumType.values.map { it.value }}", value
             )
         }
 

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/ast/ValueNode.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/ast/ValueNode.kt
@@ -39,9 +39,8 @@ sealed class ValueNode(override val loc: Location?) : ASTNode() {
             is BooleanValueNode -> "$value"
             is NullValueNode -> "null"
             is EnumValueNode -> value
-            is ListValueNode -> values.joinToString(prefix = "[", postfix = "]")
+            is ListValueNode -> values.joinToString(prefix = "[", postfix = "]") { it.valueNodeName }
             is ObjectValueNode -> fields.joinToString { "${it.name.value}: ${it.value.valueNodeName}" }
             is ObjectValueNode.ObjectFieldNode -> value.valueNodeName
         }
-
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/InputValuesSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/InputValuesSpecificationTest.kt
@@ -14,10 +14,13 @@ import org.amshove.kluent.withMessage
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 
 @Specification("2.9 Input Values")
 class InputValuesSpecificationTest {
 
+    @Suppress("unused")
     enum class FakeEnum {
         ENUM1, ENUM2
     }
@@ -44,24 +47,24 @@ class InputValuesSpecificationTest {
     @Specification("2.9.1 Int Value")
     fun `Int input value`() {
         val input = 4356
-        val response = deserialize(schema.executeBlocking("{Int(value : $input)}"))
+        val response = deserialize(schema.executeBlocking("{ Int(value: $input) }"))
         assertThat(response.extract<Int>("data/Int"), equalTo(input))
     }
 
     @Test
     @Specification("2.9.2 Float Value")
     fun `Float input value`() {
-        val input: Double = 4356.34
-        val response = deserialize(schema.executeBlocking("{Float(value : $input)}"))
+        val input = 4356.34
+        val response = deserialize(schema.executeBlocking("{ Float(value: $input) }"))
         assertThat(response.extract<Double>("data/Float"), equalTo(input))
     }
 
     @Test
     @Specification("2.9.2 Float Value")
     fun `Double input value`() {
-        //GraphQL Float is Kotlin Double
+        // GraphQL Float is Kotlin Double
         val input = 4356.34
-        val response = deserialize(schema.executeBlocking("{Double(value : $input)}"))
+        val response = deserialize(schema.executeBlocking("{ Double(value: $input) }"))
         assertThat(response.extract<Double>("data/Double"), equalTo(input))
     }
 
@@ -69,8 +72,25 @@ class InputValuesSpecificationTest {
     @Specification("2.9.2 Float Value")
     fun `Double with exponential input value`() {
         val input = 4356.34e2
-        val response = deserialize(schema.executeBlocking("{Double(value : $input)}"))
+        val response = deserialize(schema.executeBlocking("{ Double(value: $input) }"))
         assertThat(response.extract<Double>("data/Double"), equalTo(input))
+    }
+
+    @Test
+    @Specification("2.9.3 Boolean Value")
+    fun `Boolean input value`() {
+        val input = true
+        val response = deserialize(schema.executeBlocking("{ Boolean(value: $input) }"))
+        assertThat(response.extract<Boolean>("data/Boolean"), equalTo(input))
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["null", "42", "\"foo\"", "[\"foo\", \"bar\"]"])
+    @Specification("2.9.3 Boolean Value")
+    fun `Invalid Boolean input value`(value: String) {
+        invoking {
+            deserialize(schema.executeBlocking("{ Boolean(value: $value) }"))
+        } shouldThrow GraphQLError::class withMessage "argument '$value' is not valid value of type Boolean"
     }
 
     @Test
@@ -78,63 +98,83 @@ class InputValuesSpecificationTest {
     fun `String input value`() {
         val input = "\\\\Ala ma kota \\n\\\\kot ma Alę"
         val expected = "\\Ala ma kota \n\\kot ma Alę"
-        val response = deserialize(schema.executeBlocking("{String(value : \"$input\")}"))
+        val response = deserialize(schema.executeBlocking("{ String(value: \"$input\") }"))
         assertThat(response.extract<String>("data/String"), equalTo(expected))
     }
 
     @Test
-    @Specification("2.9.3 Boolean Value")
-    fun `Boolean input value`() {
-        val input = true
-        val response = deserialize(schema.executeBlocking("{Boolean(value : $input)}"))
-        assertThat(response.extract<Boolean>("data/Boolean"), equalTo(input))
+    @Specification("2.9.4 String Value")
+    fun `String block input value`() {
+        val input = "\\Ala ma kota \n\\kot ma Alę"
+        val expected = "\\Ala ma kota \n\\kot ma Alę"
+        val response = deserialize(schema.executeBlocking("{ String(value: \"\"\"$input\"\"\") }"))
+        assertThat(response.extract<String>("data/String"), equalTo(expected))
     }
 
-    @Test
-    @Specification("2.9.3 Boolean Value")
-    fun `Invalid Boolean input value`() {
+    @ParameterizedTest
+    @ValueSource(strings = ["null", "true", "42", "[\"foo\", \"bar\"]"])
+    @Specification("2.9.4 String Value")
+    fun `Invalid String input value`(value: String) {
         invoking {
-            deserialize(schema.executeBlocking("{Boolean(value : null)}"))
-        } shouldThrow GraphQLError::class withMessage "argument 'null' is not valid value of type Boolean"
+            deserialize(schema.executeBlocking("{ String(value: $value) }"))
+        } shouldThrow GraphQLError::class withMessage "argument '$value' is not valid value of type String"
     }
 
     @Test
     @Specification("2.9.5 Null Value")
     fun `Null input value`() {
-        val response = deserialize(schema.executeBlocking("{Null(value : null)}"))
+        val response = deserialize(schema.executeBlocking("{ Null(value: null) }"))
         assertThat(response.extract<Nothing?>("data/Null"), equalTo(null))
     }
 
     @Test
     @Specification("2.9.6 Enum Value")
     fun `Enum input value`() {
-        val response = deserialize(schema.executeBlocking("{Enum(value : ENUM1)}"))
+        val response = deserialize(schema.executeBlocking("{ Enum(value: ENUM1) }"))
         assertThat(response.extract<String>("data/Enum"), equalTo(FakeEnum.ENUM1.toString()))
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["ENUM3"])
+    @Specification("2.9.6 Enum Value")
+    fun `Invalid Enum input value`(value: String) {
+        invoking {
+            deserialize(schema.executeBlocking("{ Enum(value: $value) }"))
+        } shouldThrow GraphQLError::class withMessage "Invalid enum ${FakeEnum::class.simpleName} value. Expected one of [ENUM1, ENUM2]"
     }
 
     @Test
     @Specification("2.9.7 List Value")
     fun `List input value`() {
-        val response = deserialize(schema.executeBlocking("{List(value : [23, 3, 23])}"))
+        val response = deserialize(schema.executeBlocking("{ List(value: [23, 3, 23]) }"))
         assertThat(response.extract<List<Int>>("data/List"), equalTo(listOf(23, 3, 23)))
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["null", "true", "42", "\"foo\""])
+    @Specification("2.9.7 List Value")
+    fun `Invalid List input value`(value: String) {
+        invoking {
+            deserialize(schema.executeBlocking("{ List(value: $value) }"))
+        } shouldThrow GraphQLError::class withMessage "argument '$value' is not valid value of type List"
     }
 
     @Test
     @Specification("2.9.8 Object Value")
     fun `Literal object input value`() {
         val response = deserialize(
-            schema.executeBlocking(
-                """
-            {
-                Object(value: {number: 232, description: "little number"})
-            }
-        """
-            )
+            schema.executeBlocking("{ Object(value: { number: 232, description: \"little number\" }) }")
         )
-        assertThat(
-            response.extract<Int>("data/Object"),
-            equalTo(232)
-        )
+        assertThat(response.extract<Int>("data/Object"), equalTo(232))
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["null", "true", "42", "\"foo\""])
+    @Specification("2.9.8 Object Value")
+    fun `Invalid Literal object input value`(value: String) {
+        invoking {
+            schema.executeBlocking("{ Object(value: { number: 232, description: \"little number\", list: $value }) }")
+        } shouldThrow GraphQLError::class withMessage "argument '$value' is not valid value of type List"
     }
 
     @Test
@@ -143,16 +183,16 @@ class InputValuesSpecificationTest {
         val response = deserialize(
             schema.executeBlocking(
                 """
-            {
-                ObjectList(
-                    value: {
-                        number: 232,
-                        description: "little number",
-                        list: ["number", "description", "little number"]
-                    }
-                )
-            }
-        """.trimIndent()
+                {
+                    ObjectList(
+                        value: {
+                            number: 232,
+                            description: "little number",
+                            list: ["number", "description", "little number"]
+                        }
+                    )
+                }
+                """.trimIndent()
             )
         )
         assertThat(
@@ -166,8 +206,8 @@ class InputValuesSpecificationTest {
     fun `Object input value`() {
         val response = deserialize(
             schema.executeBlocking(
-                "query(\$object: FakeData!){Object(value: \$object)}",
-                "{ \"object\" : {\"number\":232, \"description\":\"little number\"}}"
+                request = "query(\$object: FakeData!) { Object(value: \$object) }",
+                variables = "{ \"object\": { \"number\": 232, \"description\": \"little number\" } }"
             )
         )
         assertThat(response.extract<Int>("data/Object"), equalTo(232))
@@ -178,8 +218,8 @@ class InputValuesSpecificationTest {
     fun `Object input value with list field`() {
         val response = deserialize(
             schema.executeBlocking(
-                "query(\$object: FakeData!){ObjectList(value: \$object)}",
-                "{ \"object\" : {\"number\":232, \"description\":\"little number\", \"list\" : [\"number\",\"description\",\"little number\"]}}"
+                request = "query(\$object: FakeData!){ ObjectList(value: \$object) }",
+                variables = "{ \"object\": { \"number\": 232, \"description\": \"little number\", \"list\": [\"number\", \"description\", \"little number\"] } }"
             )
         )
         assertThat(
@@ -200,7 +240,7 @@ class InputValuesSpecificationTest {
                     list: ["number", ${d}description, "little number"]
                 })
             }
-        """.trimIndent(), """{"description": "Custom description"}"""
+        """.trimIndent(), """{ "description": "Custom description" }"""
         ).deserialize()
 
         assertThat(
@@ -213,7 +253,7 @@ class InputValuesSpecificationTest {
     @Specification("2.9.8 Object Value")
     fun `Unknown object input value type`() {
         invoking {
-            schema.executeBlocking("query(\$object: FakeDate){Object(value: \$object)}")
+            schema.executeBlocking("query(\$object: FakeDate) { Object(value: \$object) }")
         } shouldThrow GraphQLError::class with {
             println(prettyPrint())
             message shouldBeEqualTo "Invalid variable \$object argument type FakeDate, expected FakeData!"

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/NonNullSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/NonNullSpecificationTest.kt
@@ -130,7 +130,7 @@ class NonNullSpecificationTest {
             """
             )
         } shouldThrow GraphQLError::class with {
-            message shouldBeEqualTo "You are missing non optional input fields: value2"
+            message shouldBeEqualTo "You are missing non-optional input fields: value2"
         }
     }
 


### PR DESCRIPTION
This resolves #59 and some related issues with error handling. In particular:

- Providing incorrect data types for input values (e.g. an object for a list) no longer causes HTTP 500 responses but results in proper GraphQL errors
- Existing validation for list values no longer show "type null" but "type List"
- Lists and enum values in error messages no longer show object references but their actual values