### PR TITLE
refactor: Make valueNode of ScalarCoercion required

### DIFF
--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/types/BooleanScalarDSL.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/types/BooleanScalarDSL.kt
@@ -17,7 +17,7 @@ class BooleanScalarDSL<T : Any>(kClass: KClass<T>) : ScalarDSL<T, Boolean>(kClas
 
             override fun serialize(instance: T): Boolean = serializeImpl(instance)
 
-            override fun deserialize(raw: Boolean, valueNode: ValueNode?): T = deserializeImpl(raw)
+            override fun deserialize(raw: Boolean, valueNode: ValueNode): T = deserializeImpl(raw)
         }
     }
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/types/DoubleScalarDSL.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/types/DoubleScalarDSL.kt
@@ -17,7 +17,7 @@ class DoubleScalarDSL<T : Any>(kClass: KClass<T>) : ScalarDSL<T, Double>(kClass)
 
             override fun serialize(instance: T): Double = serializeImpl(instance)
 
-            override fun deserialize(raw: Double, valueNode: ValueNode?): T = deserializeImpl(raw)
+            override fun deserialize(raw: Double, valueNode: ValueNode): T = deserializeImpl(raw)
         }
     }
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/types/IntScalarDSL.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/types/IntScalarDSL.kt
@@ -17,7 +17,7 @@ class IntScalarDSL<T : Any>(kClass: KClass<T>) : ScalarDSL<T, Int>(kClass) {
 
             override fun serialize(instance: T): Int = serializeImpl(instance)
 
-            override fun deserialize(raw: Int, valueNode: ValueNode?): T = deserializeImpl(raw)
+            override fun deserialize(raw: Int, valueNode: ValueNode): T = deserializeImpl(raw)
         }
     }
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/types/LongScalarDSL.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/types/LongScalarDSL.kt
@@ -17,7 +17,7 @@ class LongScalarDSL<T : Any>(kClass: KClass<T>) : ScalarDSL<T, Long>(kClass) {
 
             override fun serialize(instance: T): Long = serializeImpl(instance)
 
-            override fun deserialize(raw: Long, valueNode: ValueNode?): T = deserializeImpl(raw)
+            override fun deserialize(raw: Long, valueNode: ValueNode): T = deserializeImpl(raw)
         }
     }
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/types/ShortScalarDSL.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/types/ShortScalarDSL.kt
@@ -17,7 +17,7 @@ class ShortScalarDSL<T : Any>(kClass: KClass<T>) : ScalarDSL<T, Short>(kClass) {
 
             override fun serialize(instance: T): Short = serializeImpl(instance)
 
-            override fun deserialize(raw: Short, valueNode: ValueNode?): T = deserializeImpl(raw)
+            override fun deserialize(raw: Short, valueNode: ValueNode): T = deserializeImpl(raw)
         }
     }
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/types/StringScalarDSL.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/types/StringScalarDSL.kt
@@ -17,7 +17,7 @@ class StringScalarDSL<T : Any>(kClass: KClass<T>) : ScalarDSL<T, String>(kClass)
 
             override fun serialize(instance: T): String = serializeImpl(instance)
 
-            override fun deserialize(raw: String, valueNode: ValueNode?): T = deserializeImpl(raw)
+            override fun deserialize(raw: String, valueNode: ValueNode): T = deserializeImpl(raw)
         }
     }
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/scalar/Coercion.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/scalar/Coercion.kt
@@ -25,7 +25,7 @@ private typealias JsonValueNode = com.fasterxml.jackson.databind.node.ValueNode
 fun <T : Any> deserializeScalar(scalar: Type.Scalar<T>, value: ValueNode): T {
     try {
         return when (scalar.coercion) {
-            //built in scalars
+            // built-in scalars
             STRING_COERCION -> STRING_COERCION.deserialize(value.valueNodeName, value as StringValueNode) as T
             FLOAT_COERCION -> FLOAT_COERCION.deserialize(value.valueNodeName, value) as T
             DOUBLE_COERCION -> DOUBLE_COERCION.deserialize(value.valueNodeName, value) as T

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/scalar/ScalarCoercion.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/scalar/ScalarCoercion.kt
@@ -16,6 +16,6 @@ interface ScalarCoercion<Scalar, Raw> {
     /**
      * strategy for scalar deserialization
      */
-    fun deserialize(raw: Raw, valueNode: ValueNode? = null): Scalar
+    fun deserialize(raw: Raw, valueNode: ValueNode): Scalar
 }
 

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/TestClasses.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/TestClasses.kt
@@ -25,7 +25,7 @@ class Id(val literal: String, val numeric: Int)
 class IdScalarSupport : StringScalarCoercion<Id> {
     override fun serialize(instance: Id): String = "${instance.literal}:${instance.numeric}"
 
-    override fun deserialize(raw: String, valueNode: ValueNode?) = Id(raw.split(':')[0], raw.split(':')[1].toInt())
+    override fun deserialize(raw: String, valueNode: ValueNode) = Id(raw.split(':')[0], raw.split(':')[1].toInt())
 }
 
 enum class FilmType { FULL_LENGTH, SHORT_LENGTH }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaBuilderTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaBuilderTest.kt
@@ -17,6 +17,7 @@ import com.apurebase.kgraphql.schema.dsl.SchemaBuilder
 import com.apurebase.kgraphql.schema.dsl.types.TypeDSL
 import com.apurebase.kgraphql.schema.execution.DefaultGenericTypeResolver
 import com.apurebase.kgraphql.schema.introspection.TypeKind
+import com.apurebase.kgraphql.schema.model.ast.ValueNode
 import com.apurebase.kgraphql.schema.scalar.StringScalarCoercion
 import com.apurebase.kgraphql.schema.structure.Field
 import kotlinx.coroutines.Dispatchers
@@ -41,22 +42,6 @@ import kotlin.reflect.typeOf
  * Tests for SchemaBuilder behaviour, not request execution
  */
 class SchemaBuilderTest {
-    @Suppress("UNCHECKED_CAST")
-    @Test
-    fun `DSL created UUID scalar support`() {
-        val testedSchema = defaultSchema {
-            stringScalar<UUID> {
-                description = "unique identifier of object"
-                deserialize = { uuid: String -> UUID.fromString(uuid) }
-                serialize = UUID::toString
-            }
-        }
-
-        val uuidScalar = testedSchema.model.scalars[UUID::class]!!.coercion as StringScalarCoercion<UUID>
-        val testUuid = UUID.randomUUID()
-        assertThat(uuidScalar.serialize(testUuid), equalTo(testUuid.toString()))
-        assertThat(uuidScalar.deserialize(testUuid.toString()), equalTo(testUuid))
-    }
 
     @Test
     fun `ignored property DSL`() {
@@ -107,7 +92,6 @@ class SchemaBuilderTest {
                 resolver { -> Scenario(Id("GKalus", 234234), "Gamil Kalus", "TOO LONG") }
             }
             type<Scenario> {
-
                 transformation(Scenario::content) { content: String, capitalized: Boolean? ->
                     if (capitalized == true) content.replaceFirstChar { it.uppercase() } else content
                 }
@@ -140,7 +124,6 @@ class SchemaBuilderTest {
 
         assertThat(scenarioType.kind, equalTo(TypeKind.OBJECT))
         assertThat(scenarioType["pdf"], notNullValue())
-
     }
 
     @Test
@@ -239,7 +222,7 @@ class SchemaBuilderTest {
     }
 
     @Test
-    fun ` _ is allowed as receiver argument name`() {
+    fun ` _ should be allowed as receiver argument name`() {
         val schema = defaultSchema {
             query("actor") {
                 resolver { -> Actor("Boguś Linda", 4343) }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/InputValuesSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/InputValuesSpecificationTest.kt
@@ -15,6 +15,7 @@ import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.ValueSource
 
 @Specification("2.9 Input Values")
@@ -76,12 +77,26 @@ class InputValuesSpecificationTest {
         assertThat(response.extract<Double>("data/Double"), equalTo(input))
     }
 
-    @Test
+    @ParameterizedTest
+    @CsvSource(
+        value = [
+            "true, true",
+            "false, false",
+            "\"true\", true",
+            "\"false\", false",
+            "\"TRUE\", true",
+            "\"FALSE\", false",
+            "\"tRuE\", true",
+            "\"faLSe\", false",
+            "1, true",
+            "0, false",
+            "-1, false"
+        ]
+    )
     @Specification("2.9.3 Boolean Value")
-    fun `Boolean input value`() {
-        val input = true
+    fun `Boolean input value`(input: String, expected: Boolean) {
         val response = deserialize(schema.executeBlocking("{ Boolean(value: $input) }"))
-        assertThat(response.extract<Boolean>("data/Boolean"), equalTo(input))
+        assertThat(response.extract<Boolean>("data/Boolean"), equalTo(expected))
     }
 
     @ParameterizedTest


### PR DESCRIPTION
The `valueNode` of `ScalarCoercion` was nullable, leading to explicit `null` cases in various places. However, the code always calls it with a non-null `ValueNode`, cf. https://github.com/stuebingerb/KGraphQL/blob/main/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/scalar/Coercion.kt#L25