### PR TITLE
feat: Create dedicated Introspection class

### DIFF
--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/request/Introspection.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/request/Introspection.kt
@@ -1,0 +1,252 @@
+package com.apurebase.kgraphql.request
+
+import com.apurebase.kgraphql.schema.introspection.__Type
+import com.apurebase.kgraphql.schema.model.TypeDef
+
+/**
+ * Functionality regarding schema introspection and its types.
+ */
+object Introspection {
+    /**
+     * Level of specification according to https://spec.graphql.org/. Different levels
+     * will support different features, and the introspection query should adapt.
+     */
+    enum class SpecLevel {
+        October2021, WorkingDraft
+    }
+
+    /**
+     * Returns whether the given [request] is considered an introspection query, i.e.
+     * contains any of ("__schema", "__type").
+     */
+    fun isIntrospection(request: String) = request.contains("__schema") || request.contains("__type")
+
+    /**
+     * Returns the introspection query corresponding to the given [specLevel].
+     */
+    fun query(specLevel: SpecLevel = SpecLevel.October2021) = when (specLevel) {
+        // Default introspection query from GraphiQL
+        SpecLevel.October2021 ->
+            """
+            query IntrospectionQuery {
+              __schema {
+                queryType { name }
+                mutationType { name }
+                subscriptionType { name }
+                types {
+                  ...FullType
+                }
+                directives {
+                  name
+                  description
+                  locations
+                  args {
+                    ...InputValue
+                  }
+                }
+              }
+            }
+            
+            fragment FullType on __Type {
+              kind
+              name
+              description
+              fields(includeDeprecated: true) {
+                name
+                description
+                args {
+                  ...InputValue
+                }
+                type {
+                  ...TypeRef
+                }
+                isDeprecated
+                deprecationReason
+              }
+              inputFields {
+                ...InputValue
+              }
+              interfaces {
+                ...TypeRef
+              }
+              enumValues(includeDeprecated: true) {
+                name
+                description
+                isDeprecated
+                deprecationReason
+              }
+              possibleTypes {
+                ...TypeRef
+              }
+            }
+            
+            fragment InputValue on __InputValue {
+              name
+              description
+              type { ...TypeRef }
+              defaultValue
+            }
+            
+            fragment TypeRef on __Type {
+              kind
+              name
+              ofType {
+                kind
+                name
+                ofType {
+                  kind
+                  name
+                  ofType {
+                    kind
+                    name
+                    ofType {
+                      kind
+                      name
+                      ofType {
+                        kind
+                        name
+                        ofType {
+                          kind
+                          name
+                          ofType {
+                            kind
+                            name
+                            ofType {
+                              kind
+                              name
+                              ofType {
+                                kind
+                                name
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            """
+
+        // SpecLevel.October2021 with supported extensions from the current draft
+        SpecLevel.WorkingDraft ->
+            """
+            query IntrospectionQuery {
+              __schema {
+                queryType { name }
+                mutationType { name }
+                subscriptionType { name }
+                types {
+                  ...FullType
+                }
+                directives {
+                  name
+                  description
+                  locations
+                  args(includeDeprecated: true) {
+                    ...InputValue
+                  }
+                  isRepeatable
+                }
+              }
+            }
+            
+            fragment FullType on __Type {
+              kind
+              name
+              description
+              fields(includeDeprecated: true) {
+                name
+                description
+                args(includeDeprecated: true) {
+                  ...InputValue
+                }
+                type {
+                  ...TypeRef
+                }
+                isDeprecated
+                deprecationReason
+              }
+              inputFields(includeDeprecated: true) {
+                ...InputValue
+              }
+              interfaces {
+                ...TypeRef
+              }
+              enumValues(includeDeprecated: true) {
+                name
+                description
+                isDeprecated
+                deprecationReason
+              }
+              possibleTypes {
+                ...TypeRef
+              }
+            }
+            
+            fragment InputValue on __InputValue {
+              name
+              description
+              type { ...TypeRef }
+              defaultValue
+              isDeprecated
+              deprecationReason
+            }
+            
+            fragment TypeRef on __Type {
+              kind
+              name
+              ofType {
+                kind
+                name
+                ofType {
+                  kind
+                  name
+                  ofType {
+                    kind
+                    name
+                    ofType {
+                      kind
+                      name
+                      ofType {
+                        kind
+                        name
+                        ofType {
+                          kind
+                          name
+                          ofType {
+                            kind
+                            name
+                            ofType {
+                              kind
+                              name
+                              ofType {
+                                kind
+                                name
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            """
+    }
+}
+
+/**
+ * Returns whether the given [__Type] is an introspection type (i.e. has a name
+ * starting with "__")
+ */
+fun __Type.isIntrospectionType() = name?.startsWith("__") == true
+
+/**
+ * Returns whether the given [TypeDef] is an introspection type (i.e. has a name
+ * starting with "__")
+ */
+fun TypeDef.isIntrospectionType() = name.startsWith("__")
+

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/DefaultSchema.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/DefaultSchema.kt
@@ -3,6 +3,7 @@ package com.apurebase.kgraphql.schema
 import com.apurebase.kgraphql.Context
 import com.apurebase.kgraphql.ValidationException
 import com.apurebase.kgraphql.configuration.SchemaConfiguration
+import com.apurebase.kgraphql.request.Introspection
 import com.apurebase.kgraphql.request.Parser
 import com.apurebase.kgraphql.request.VariablesJson
 import com.apurebase.kgraphql.schema.execution.DataLoaderPreparedRequestExecutor
@@ -52,7 +53,7 @@ class DefaultSchema(
             ?.let { VariablesJson.Defined(configuration.objectMapper, variables) }
             ?: VariablesJson.Empty()
 
-        if (!configuration.introspection && request.isIntrospection()) {
+        if (!configuration.introspection && Introspection.isIntrospection(request)) {
             throw ValidationException("GraphQL introspection is not allowed")
         }
 
@@ -66,8 +67,6 @@ class DefaultSchema(
             context = context
         )
     }
-
-    private fun String.isIntrospection() = contains("__schema") || contains("__type")
 
     override fun typeByKClass(kClass: KClass<*>): Type? = model.queryTypes[kClass]
 

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/SchemaCompilation.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/SchemaCompilation.kt
@@ -7,6 +7,7 @@ import com.apurebase.kgraphql.configuration.SchemaConfiguration
 import com.apurebase.kgraphql.defaultKQLTypeName
 import com.apurebase.kgraphql.getIterableElementType
 import com.apurebase.kgraphql.isIterable
+import com.apurebase.kgraphql.request.isIntrospectionType
 import com.apurebase.kgraphql.schema.DefaultSchema
 import com.apurebase.kgraphql.schema.SchemaException
 import com.apurebase.kgraphql.schema.directive.Directive
@@ -274,7 +275,11 @@ class SchemaCompilation(
         val objectDef = objectDefs.find { it.kClass == kClass } ?: TypeDef.Object(kClass.defaultKQLTypeName(), kClass)
 
         // treat introspection types as objects -> adhere to reference implementation behaviour
-        val kind = if (kClass.isFinal || objectDef.name.startsWith("__")) TypeKind.OBJECT else TypeKind.INTERFACE
+        val kind = if (kClass.isFinal || objectDef.isIntrospectionType()) {
+            TypeKind.OBJECT
+        } else {
+            TypeKind.INTERFACE
+        }
 
         val objectType = if (kind == TypeKind.OBJECT) {
             Type.Object(objectDef)

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/BaseSchemaTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/BaseSchemaTest.kt
@@ -17,121 +17,13 @@ import com.apurebase.kgraphql.schema.execution.ExecutionOptions
 import org.junit.jupiter.api.AfterEach
 
 abstract class BaseSchemaTest {
-
-    companion object {
-        const val INTROSPECTION_QUERY = """
-            query IntrospectionQuery {
-                __schema {
-                    queryType { name description kind}
-                    mutationType { name description kind }
-                    subscriptionType { name description kind }
-                    types {
-                        name
-                        kind
-                        description
-                        ...FullType
-                    }
-                    directives {
-                        name
-                        description
-                        locations
-                        args(includeDeprecated: true) {
-                            ...InputValue
-                        }
-                        isRepeatable
-                    }
-                }
-            }
-
-            fragment FullType on __Type {
-                fields(includeDeprecated: true) {
-                    name
-                    description
-                    args(includeDeprecated: true) {
-                        ...InputValue
-                    }
-                    type {
-                        ...TypeRef
-                    }
-                    isDeprecated
-                    deprecationReason
-                }
-                inputFields(includeDeprecated: true) {
-                    ...InputValue
-                }
-                interfaces {
-                    ...TypeRef
-                }
-                enumValues(includeDeprecated: true) {
-                    name
-                    description
-                    isDeprecated
-                    deprecationReason
-                }
-                possibleTypes {
-                    ...TypeRef
-                }
-            }
-
-            fragment InputValue on __InputValue {
-                name
-                description
-                type { ...TypeRef }
-                defaultValue
-                isDeprecated
-                deprecationReason
-            }
-
-            fragment TypeRef on __Type {
-                kind
-                name
-                description
-                ofType {
-                    kind
-                    name
-                    description
-                    ofType {
-                        kind
-                        name
-                        description
-                        ofType {
-                            kind
-                            name
-                            description
-                            ofType {
-                                kind
-                                name
-                                description
-                                ofType {
-                                    kind
-                                    name
-                                    description
-                                    ofType {
-                                        kind
-                                        name
-                                        description
-                                        ofType {
-                                            kind
-                                            name
-                                            description
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        """
-    }
-
-    //test film 1
+    // test film 1
     val tomHardy = Actor("Tom Hardy", 232)
     val christianBale = Actor("Christian Bale", 232)
     val christopherNolan = Director("Christopher Nolan", 43, listOf(tomHardy, christianBale))
     val prestige = Film(Id("Prestige", 2006), 2006, "Prestige", christopherNolan)
 
-    //test film 2
+    // test film 2
     val bradPitt = Actor("Brad Pitt", 763)
     val morganFreeman = Actor("Morgan Freeman", 1212)
     val kevinSpacey = Actor("Kevin Spacey", 2132)
@@ -141,7 +33,7 @@ abstract class BaseSchemaTest {
 
     val rickyGervais = Actor("Ricky Gervais", 58)
 
-    //new actors created via mutations in schema
+    // new actors created via mutations in schema
     val createdActors = mutableListOf<Actor>()
 
     val testedSchema = defaultSchema {

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/FragmentsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/FragmentsSpecificationTest.kt
@@ -9,7 +9,7 @@ import com.apurebase.kgraphql.deserialize
 import com.apurebase.kgraphql.executeEqualQueries
 import com.apurebase.kgraphql.extract
 import com.apurebase.kgraphql.integration.BaseSchemaTest
-import com.apurebase.kgraphql.integration.BaseSchemaTest.Companion.INTROSPECTION_QUERY
+import com.apurebase.kgraphql.request.Introspection
 import org.amshove.kluent.invoking
 import org.amshove.kluent.shouldThrow
 import org.amshove.kluent.withMessage
@@ -130,7 +130,7 @@ class FragmentsSpecificationTest {
 
     @Test
     fun `multiple nested fragments are handled`() {
-        val map = baseTestSchema.execute(INTROSPECTION_QUERY)
+        val map = baseTestSchema.execute(Introspection.query())
         val fields = map.extract<List<Map<String, *>>>("data/__schema/types[0]/fields")
 
         fields.forEach { field ->


### PR DESCRIPTION
This creates a dedicated `Introspection` class to hold functionality regarding schema introspection.

As added benefit, we now provide introspection queries for (currently) two different levels of the GraphQL specification.

This is supposed to be a starting point for future refactoring, as a) there are still parts left in other places of the code, and b) the way how that introspection query is composed leaves... room for improvement (graphql-java for example has a configurable builder).