### PR TITLE
feat: Export schema in SDL

### DIFF
--- a/docs/content/Plugins/ktor.md
+++ b/docs/content/Plugins/ktor.md
@@ -90,3 +90,44 @@ schema {
   }  
 }
 ```
+
+## Schema Definition Language (SDL)
+
+The [Schema Definition Language](https://graphql.org/learn/schema/#type-language) (or Type System Definition Language) is a human-readable, language-agnostic
+representation of a GraphQL schema.
+
+See the following comparison:
+
+=== "KGraphQL"
+    ```kotlin
+    schema {
+        data class SampleData(
+            val id: Int,
+            val stringData: String,
+            val optionalList: List<String>?
+        )
+        
+        query("getSampleData") {
+            resolver { quantity: Int ->
+                (1..quantity).map { SampleData(it, "sample-$it", emptyList()) }
+            }.withArgs {
+                arg<Int> { name = "quantity"; defaultValue = 10 }
+            }
+        }
+    }
+    ```
+=== "SDL"
+    ```
+    type Query {
+        getSampleData(quantity: Int! = 10): [SampleData!]!
+    }
+    
+    type SampleData {
+        id: Int!
+        optionalList: [String!]
+        stringData: String!
+    }
+    ```
+
+If schema introspection is enabled, the ktor feature will expose the current schema in Schema Definition
+Language under [http://localhost:8080/graphql?schema](http://localhost:8080/graphql?schema).

--- a/kgraphql-ktor/src/test/kotlin/com/apurebase/kgraphql/KtorMultipleEndpoints.kt
+++ b/kgraphql-ktor/src/test/kotlin/com/apurebase/kgraphql/KtorMultipleEndpoints.kt
@@ -57,7 +57,7 @@ class KtorMultipleEndpoints : KtorTest() {
             }
         }
 
-        client.get("/graphql").status shouldBeEqualTo HttpStatusCode.MethodNotAllowed
+        client.get("/graphql").status shouldBeEqualTo HttpStatusCode.NotFound
     }
 
     @Test
@@ -78,5 +78,39 @@ class KtorMultipleEndpoints : KtorTest() {
         val response = client.get("/graphql")
         response.status shouldBeEqualTo HttpStatusCode.OK
         response.bodyAsText() shouldBeEqualTo playgroundHtml
+    }
+
+    @Test
+    fun `SDL should be provided by default`() = testApplication {
+        install(GraphQL) {
+            schema {
+                query("check") {
+                    resolver { -> "OK" }
+                }
+            }
+        }
+
+        val response = client.get("/graphql?schema")
+        response.status shouldBeEqualTo HttpStatusCode.OK
+        response.bodyAsText() shouldBeEqualTo """
+            type Query {
+              check: String!
+            }
+            
+        """.trimIndent()
+    }
+
+    @Test
+    fun `SDL should not be provided when introspection is disabled`() = testApplication {
+        install(GraphQL) {
+            introspection = false
+            schema {
+                query("check") {
+                    resolver { -> "OK" }
+                }
+            }
+        }
+
+        client.get("/graphql?schema").status shouldBeEqualTo HttpStatusCode.NotFound
     }
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/configuration/SchemaConfiguration.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/configuration/SchemaConfiguration.kt
@@ -18,9 +18,10 @@ data class SchemaConfiguration(
     val wrapErrors: Boolean,
     val executor: Executor,
     val timeout: Long?,
+    // allow schema introspection
     val introspection: Boolean = true,
     val plugins: MutableMap<KClass<*>, Any>,
-    val genericTypeResolver: GenericTypeResolver,
+    val genericTypeResolver: GenericTypeResolver
 ) {
     @Suppress("UNCHECKED_CAST")
     operator fun <T : Any> get(type: KClass<T>) = plugins[type] as T?

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/request/Parser.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/request/Parser.kt
@@ -178,7 +178,11 @@ open class Parser {
         return VariableDefinitionNode(
             variable = parseVariable(),
             type = expectToken(COLON).let { parseTypeReference() },
-            defaultValue = if (expectOptionalToken(EQUALS) != null) parseValueLiteral(true) else null,
+            defaultValue = if (expectOptionalToken(EQUALS) != null) {
+                parseValueLiteral(true)
+            } else {
+                null
+            },
             directives = parseDirectives(true),
             loc = loc(start)
         )
@@ -545,7 +549,11 @@ open class Parser {
      */
     private fun parseTypeSystemDefinition(): DefinitionNode.TypeSystemDefinitionNode {
         // Many definitions begin with a description and require a lookahead.
-        val keywordToken = if (peekDescription()) lexer.lookahead() else lexer.token
+        val keywordToken = if (peekDescription()) {
+            lexer.lookahead()
+        } else {
+            lexer.token
+        }
 
         if (keywordToken.kind == NAME) {
             return when (keywordToken.value) {
@@ -937,6 +945,7 @@ open class Parser {
      *   `FRAGMENT_DEFINITION`
      *   `FRAGMENT_SPREAD`
      *   `INLINE_FRAGMENT`
+     *   `VARIABLE_DEFINITION`
      *
      * TypeSystemDirectiveLocation : one of
      *   `SCHEMA`

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/DefaultSchema.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/DefaultSchema.kt
@@ -68,6 +68,8 @@ class DefaultSchema(
         )
     }
 
+    override fun printSchema() = SchemaPrinter().print(model)
+
     override fun typeByKClass(kClass: KClass<*>): Type? = model.queryTypes[kClass]
 
     override fun typeByKType(kType: KType): Type? = typeByKClass(kType.jvmErasure)

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/Schema.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/Schema.kt
@@ -25,4 +25,9 @@ interface Schema : __Schema {
         options: ExecutionOptions = ExecutionOptions(),
         operationName: String? = null
     ) = runBlocking { execute(request, variables, context, options, operationName) }
+
+    /**
+     * Prints the current schema in schema definition language (SDL)
+     */
+    fun printSchema(): String
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/SchemaPrinter.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/SchemaPrinter.kt
@@ -1,0 +1,294 @@
+package com.apurebase.kgraphql.schema
+
+import com.apurebase.kgraphql.request.isIntrospectionType
+import com.apurebase.kgraphql.schema.builtin.BuiltInScalars
+import com.apurebase.kgraphql.schema.directive.Directive
+import com.apurebase.kgraphql.schema.introspection.TypeKind
+import com.apurebase.kgraphql.schema.introspection.__Described
+import com.apurebase.kgraphql.schema.introspection.__Directive
+import com.apurebase.kgraphql.schema.introspection.__InputValue
+import com.apurebase.kgraphql.schema.introspection.__Schema
+import com.apurebase.kgraphql.schema.introspection.__Type
+import com.apurebase.kgraphql.schema.introspection.typeReference
+import com.apurebase.kgraphql.schema.model.Depreciable
+
+data class SchemaPrinterConfig(
+    /**
+     * Whether to *always* include the schema itself. Otherwise, it will only be included
+     * if required by the spec.
+     */
+    val includeSchemaDefinition: Boolean = false,
+
+    /**
+     * Whether to include descriptions.
+     */
+    val includeDescriptions: Boolean = false,
+
+    /**
+     * Whether to include built-in directives.
+     */
+    val includeBuiltInDirectives: Boolean = false
+)
+
+class SchemaPrinter(private val config: SchemaPrinterConfig = SchemaPrinterConfig()) {
+    /**
+     * Returns the given [schema] in schema definition language (SDL). Types and fields are sorted
+     * ascending by their name and appear in order of their corresponding spec section, i.e.
+     *
+     *  - 3.3 Schema
+     *  - 3.4 Types
+     *    - Scalars
+     *    - Objects
+     *    - Interfaces
+     *    - Unions
+     *    - Enums
+     *    - Input Types
+     *  - 3.13 Directives
+     *
+     * If descriptions are included, they will use single quotes, broken up on newlines, e.g.
+     *
+     * ```
+     *     "This is a long comment,"
+     *     "spanning over multiple"
+     *     "lines."
+     *     scalar DescriptedScalar
+     * ```
+     */
+    fun print(schema: __Schema): String {
+        // All actual (non-introspection) types of the schema
+        val schemaTypes =
+            schema.types.filterNot { it.isIntrospectionType() || it.name == null }.sortedByName().groupBy { it.kind }
+
+        // Schema
+        //   https://spec.graphql.org/draft/#sec-Root-Operation-Types.Default-Root-Operation-Type-Names
+        val schemaDefinition = if (includeSchemaDefinition(schema)) {
+            buildString {
+                appendLine("schema {")
+                val indentation = "  "
+                // The query root operation type must always be provided
+                appendDescription(schema.queryType, indentation)
+                appendLine("${indentation}query: ${schema.queryType.name}")
+                // The mutation root operation type is optional; if it is not provided, the service does not support mutations
+                schema.mutationType?.let {
+                    appendDescription(it, indentation)
+                    appendLine("${indentation}mutation: ${it.name}")
+                }
+                // Similarly, the subscription root operation type is also optional; if it is not provided, the service does not support subscriptions
+                schema.subscriptionType?.let {
+                    appendDescription(it, indentation)
+                    appendLine("${indentation}subscription: ${it.name}")
+                }
+                appendLine("}")
+            }
+        } else {
+            ""
+        }
+
+        // Scalars
+        //   https://spec.graphql.org/draft/#sec-Scalars.Built-in-Scalars
+        //   "When representing a GraphQL schema using the type system definition language, all built-in scalars must be omitted for brevity."
+        val scalars = buildString {
+            schemaTypes[TypeKind.SCALAR]?.filter { !it.isBuiltInScalar() }?.forEachIndexed { index, type ->
+                if (index > 0) {
+                    appendLine()
+                }
+                appendDescription(type)
+                appendLine("scalar ${type.name}")
+            }
+        }
+
+        // Objects (includes Query, Mutation, and Subscription) with non-empty fields
+        //  https://spec.graphql.org/draft/#sec-Objects
+        val objects = buildString {
+            schemaTypes[TypeKind.OBJECT]?.filter { !it.fields.isNullOrEmpty() }?.forEachIndexed { index, type ->
+                if (index > 0) {
+                    appendLine()
+                }
+                appendDescription(type)
+                appendLine("type ${type.name}${type.implements()} {")
+                appendFields(type)
+                appendLine("}")
+            }
+        }
+
+        // Interfaces
+        //   https://spec.graphql.org/draft/#sec-Interfaces
+        val interfaces = buildString {
+            schemaTypes[TypeKind.INTERFACE]?.forEachIndexed { index, type ->
+                if (index > 0) {
+                    appendLine()
+                }
+                appendDescription(type)
+                appendLine("interface ${type.name}${type.implements()} {")
+                appendFields(type)
+                appendLine("}")
+            }
+        }
+
+        // Unions
+        //   https://spec.graphql.org/draft/#sec-Unions
+        val unions = buildString {
+            schemaTypes[TypeKind.UNION]?.forEachIndexed { index, type ->
+                if (index > 0) {
+                    appendLine()
+                }
+                appendDescription(type)
+                val possibleTypes = type.possibleTypes.sortedByName().map { it.name }
+                appendLine("union ${type.name} = ${possibleTypes.joinToString(" | ")}")
+            }
+        }
+
+        // Enums
+        //  https://spec.graphql.org/draft/#sec-Enums
+        val enums = buildString {
+            schemaTypes[TypeKind.ENUM]?.forEachIndexed { index, type ->
+                if (index > 0) {
+                    appendLine()
+                }
+                appendDescription(type)
+                appendLine("enum ${type.name} {")
+                val indentation = "  "
+                type.enumValues.sortedByName().forEach { enumValue ->
+                    appendDescription(enumValue, indentation)
+                    appendLine("${indentation}${enumValue.name}${enumValue.deprecationInfo()}")
+                }
+                appendLine("}")
+            }
+        }
+
+        // Input Types
+        //  https://spec.graphql.org/draft/#sec-Input-Objects
+        val inputTypes = buildString {
+            schemaTypes[TypeKind.INPUT_OBJECT]?.filter { !it.inputFields.isNullOrEmpty() }
+                ?.forEachIndexed { index, type ->
+                    if (index > 0) {
+                        appendLine()
+                    }
+                    appendDescription(type)
+                    appendLine("input ${type.name}${type.implements()} {")
+                    val indentation = "  "
+                    type.inputFields.sortedByName().forEach { field ->
+                        appendDescription(field, indentation)
+                        appendLine("${indentation}${field.name}: ${field.type.typeReference()}${field.deprecationInfo()}")
+                    }
+                    appendLine("}")
+                }
+        }
+
+        // Directives
+        //   https://spec.graphql.org/draft/#sec-Type-System.Directives.Built-in-Directives
+        //   "When representing a GraphQL schema using the type system definition language any built-in directive may be omitted for brevity."
+        val directives = buildString {
+            schema.directives.filter { config.includeBuiltInDirectives || !it.isBuiltIn() }.sortedByName()
+                .forEachIndexed { index, directive ->
+                    if (index > 0) {
+                        appendLine()
+                    }
+                    val args = directive.args.takeIf { it.isNotEmpty() }
+                        ?.joinToString(", ", prefix = "(", postfix = ")") { arg ->
+                            arg.name + ": " + arg.type.typeReference() + arg.defaultInfo()
+                        } ?: ""
+                    appendLine("directive @${directive.name}$args on ${directive.locations.joinToString(" | ") { it.name }}")
+                }
+        }
+
+        return listOf(
+            schemaDefinition,
+            scalars,
+            objects,
+            interfaces,
+            unions,
+            enums,
+            inputTypes,
+            directives
+        ).filterNot { it.isBlank() }.joinToString("\n")
+    }
+
+    // Computes whether the schema definition should be included. Returns `true` if enforced by the configuration, or if
+    // required by the spec:
+    //   "The type system definition language can omit the schema definition when each root operation type uses its respective default root type name and no other type uses any default root type name."
+    //   "Likewise, when representing a GraphQL schema using the type system definition language, a schema definition should be omitted if each root operation type uses its respective default root type name and no other type uses any default root type name."
+    private fun includeSchemaDefinition(schema: __Schema): Boolean =
+        config.includeSchemaDefinition || schema.hasRootOperationTypeWithNonDefaultName() || schema.hasRegularTypeWithDefaultRootTypeName()
+
+    private fun __Schema.hasRootOperationTypeWithNonDefaultName(): Boolean = queryType.name != "Query" ||
+        (mutationType != null && mutationType?.name != "Mutation") ||
+        (subscriptionType != null && subscriptionType?.name != "Subscription")
+
+    private fun __Schema.hasRegularTypeWithDefaultRootTypeName() = types.any {
+        (it != queryType && it.name == "Query") ||
+            (it != mutationType && it.name == "Mutation") ||
+            (it != subscriptionType && it.name == "Subscription")
+    }
+
+    private fun Depreciable.deprecationInfo(): String = if (isDeprecated) {
+        " @deprecated(reason: \"$deprecationReason\")"
+    } else {
+        ""
+    }
+
+    private fun __Directive.isBuiltIn(): Boolean =
+        name in setOf(Directive.DEPRECATED.name, Directive.INCLUDE.name, Directive.SKIP.name)
+
+    private fun __Type.isBuiltInScalar(): Boolean = name in BuiltInScalars.entries.map { it.typeDef.name }
+
+    private fun __Type.implements(): String =
+        interfaces
+            .sortedByName()
+            .mapNotNull { it.name }
+            .takeIf { it.isNotEmpty() }
+            ?.joinToString(separator = " & ", prefix = " implements ") ?: ""
+
+    private fun Any.description(): List<String>? = when (this) {
+        is __Described -> description?.takeIf { it.isNotBlank() }?.lines()
+        is __Type -> description?.takeIf { it.isNotBlank() }?.lines()
+        else -> null
+    }
+
+    // https://spec.graphql.org/October2021/#sec-Descriptions
+    private fun StringBuilder.appendDescription(type: Any, indentation: String = ""): StringBuilder {
+        type.description()?.takeIf { config.includeDescriptions }?.let { description ->
+            description.forEach {
+                appendLine("$indentation\"$it\"")
+            }
+        }
+        return this
+    }
+
+    private fun StringBuilder.appendFields(type: __Type): StringBuilder {
+        val indentation = "  "
+        type.fields.sortedByName().forEach { field ->
+            appendDescription(field, indentation)
+            // Write each field arg in it's own line if we have to add directives or description,
+            // otherwise print them on a single line
+            if (field.args.any { it.isDeprecated || (config.includeDescriptions && !it.description.isNullOrBlank()) }) {
+                appendLine("${indentation}${field.name}(")
+                field.args.forEach { arg ->
+                    val argsIndentation = "$indentation$indentation"
+                    appendDescription(arg, argsIndentation)
+                    appendLine("$argsIndentation${arg.name}: ${arg.type.typeReference()}${arg.defaultInfo()}${arg.deprecationInfo()}")
+                }
+                appendLine("${indentation}): ${field.type.typeReference()}${field.deprecationInfo()}")
+            } else {
+                val args =
+                    field.args.takeIf { it.isNotEmpty() }?.joinToString(", ", prefix = "(", postfix = ")") { arg ->
+                        arg.name + ": " + arg.type.typeReference() + arg.defaultInfo()
+                    } ?: ""
+                appendLine("${indentation}${field.name}$args: ${field.type.typeReference()}${field.deprecationInfo()}")
+            }
+        }
+        return this
+    }
+
+    private fun __InputValue.defaultInfo(): String = defaultValue?.let {
+        " = $it"
+    } ?: ""
+
+    @JvmName("sortedTypesByName")
+    private fun List<__Type>?.sortedByName() =
+        orEmpty().sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.name.toString() })
+
+    @JvmName("sortedDescribedByName")
+    private fun <T : __Described> List<T>?.sortedByName() =
+        orEmpty().sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.name })
+}

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/directive/Directive.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/directive/Directive.kt
@@ -1,8 +1,12 @@
 package com.apurebase.kgraphql.schema.directive
 
+import com.apurebase.kgraphql.schema.directive.DirectiveLocation.ARGUMENT_DEFINITION
+import com.apurebase.kgraphql.schema.directive.DirectiveLocation.ENUM_VALUE
 import com.apurebase.kgraphql.schema.directive.DirectiveLocation.FIELD
+import com.apurebase.kgraphql.schema.directive.DirectiveLocation.FIELD_DEFINITION
 import com.apurebase.kgraphql.schema.directive.DirectiveLocation.FRAGMENT_SPREAD
 import com.apurebase.kgraphql.schema.directive.DirectiveLocation.INLINE_FRAGMENT
+import com.apurebase.kgraphql.schema.directive.DirectiveLocation.INPUT_FIELD_DEFINITION
 import com.apurebase.kgraphql.schema.introspection.__Directive
 import com.apurebase.kgraphql.schema.introspection.__InputValue
 import com.apurebase.kgraphql.schema.model.FunctionWrapper
@@ -42,8 +46,10 @@ data class Directive(
 
     companion object {
         /**
-         * The @skip directive may be provided for fields, fragment spreads, and inline fragments.
-         * Allows for conditional exclusion during execution as described by the if argument.
+         * https://spec.graphql.org/draft/#sec--skip
+         *
+         * The `@skip` built-in directive may be provided for fields, fragment spreads, and inline fragments,
+         * and allows for conditional exclusion during execution as described by the `if` argument.
          */
         val SKIP = Partial(
             "skip",
@@ -52,13 +58,29 @@ data class Directive(
         )
 
         /**
-         * The @include directive may be provided for fields, fragment spreads, and inline fragments.
-         * Allows for conditional inclusion during execution as described by the if argument.
+         * https://spec.graphql.org/draft/#sec--include
+         *
+         * The `@include` built-in directive may be provided for fields, fragment spreads, and inline fragments,
+         * and allows for conditional inclusion during execution as described by the `if` argument.
          */
         val INCLUDE = Partial(
             "include",
             listOf(FIELD, FRAGMENT_SPREAD, INLINE_FRAGMENT),
             DirectiveExecution(FunctionWrapper.on { `if`: Boolean -> DirectiveResult(`if`) })
+        )
+
+        /**
+         * https://spec.graphql.org/draft/#sec--deprecated
+         *
+         * The `@deprecated` built-in directive is used within the type system definition language to indicate
+         * deprecated portions of a GraphQL service's schema, such as deprecated fields on a type, arguments on
+         * a field, input fields on an input type, or values of an enum type.
+         */
+        val DEPRECATED = Partial(
+            "deprecated",
+            listOf(FIELD_DEFINITION, ARGUMENT_DEFINITION, INPUT_FIELD_DEFINITION, ENUM_VALUE),
+            // DirectiveExecution is a no-op, since it cannot be used during execution.
+            DirectiveExecution(FunctionWrapper.on { reason: String? -> DirectiveResult(true) })
         )
     }
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/directive/DirectiveLocation.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/directive/DirectiveLocation.kt
@@ -1,13 +1,28 @@
 package com.apurebase.kgraphql.schema.directive
 
 enum class DirectiveLocation {
+    // ExecutableDirectiveLocation
     QUERY,
     MUTATION,
     SUBSCRIPTION,
     FIELD,
     FRAGMENT_DEFINITION,
     FRAGMENT_SPREAD,
-    INLINE_FRAGMENT;
+    INLINE_FRAGMENT,
+    VARIABLE_DEFINITION,
+
+    // TypeSystemDirectiveLocation
+    SCHEMA,
+    SCALAR,
+    OBJECT,
+    FIELD_DEFINITION,
+    ARGUMENT_DEFINITION,
+    INTERFACE,
+    UNION,
+    ENUM,
+    ENUM_VALUE,
+    INPUT_OBJECT,
+    INPUT_FIELD_DEFINITION;
 
     companion object {
         fun from(str: String) = str.lowercase().let { lowered ->

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/ArgumentTransformer.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/ArgumentTransformer.kt
@@ -5,6 +5,7 @@ import com.apurebase.kgraphql.InvalidInputValueException
 import com.apurebase.kgraphql.request.Variables
 import com.apurebase.kgraphql.schema.DefaultSchema
 import com.apurebase.kgraphql.schema.introspection.TypeKind
+import com.apurebase.kgraphql.schema.introspection.typeReference
 import com.apurebase.kgraphql.schema.model.ast.ArgumentNodes
 import com.apurebase.kgraphql.schema.model.ast.ValueNode
 import com.apurebase.kgraphql.schema.model.ast.ValueNode.ObjectValueNode
@@ -46,7 +47,7 @@ open class ArgumentTransformer(val schema: DefaultSchema) {
                 value == null && parameter.type.kind != TypeKind.NON_NULL -> parameter.default
                 value == null && parameter.type.kind == TypeKind.NON_NULL -> {
                     parameter.default ?: throw InvalidInputValueException(
-                        "argument '${parameter.name}' of type ${schema.typeReference(parameter.type)} on field '$funName' is not nullable, value cannot be null",
+                        "argument '${parameter.name}' of type ${parameter.type.typeReference()} on field '$funName' is not nullable, value cannot be null",
                         executionNode.selectionNode
                     )
                 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/introspection/SchemaProxy.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/introspection/SchemaProxy.kt
@@ -57,4 +57,6 @@ class SchemaProxy(
     ): String {
         return getProxied().execute(request, variables, context, options, operationName)
     }
+
+    override fun printSchema(): String = getProxied().printSchema()
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/introspection/__Type.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/introspection/__Type.kt
@@ -7,42 +7,29 @@ package com.apurebase.kgraphql.schema.introspection
 interface __Type {
     val kind: TypeKind
     val name: String?
-    val description: String
+    val description: String?
 
-    //OBJECT and INTERFACE only
+    // OBJECT and INTERFACE only
     val fields: List<__Field>?
 
-    //OBJECT and INTERFACE only
+    // OBJECT and INTERFACE only
     val interfaces: List<__Type>?
 
-    //INTERFACE and UNION only
+    // INTERFACE and UNION only
     val possibleTypes: List<__Type>?
 
-    //ENUM only
+    // ENUM only
     val enumValues: List<__EnumValue>?
 
-    //INPUT_OBJECT only
+    // INPUT_OBJECT only
     val inputFields: List<__InputValue>?
 
-    //NON_NULL and LIST only
+    // NON_NULL and LIST only
     val ofType: __Type?
 }
 
-fun __Type.asString() = buildString {
-    append(kind)
-    append(" : ")
-    append(name)
-    append(" ")
-
-    if (fields != null) {
-        append("[")
-        fields?.forEach { field ->
-            append(field.name).append(" : ").append(field.type.name ?: field.type.kind).append(" ")
-        }
-        append("]")
-    }
-
-    if (ofType != null) {
-        append(" => ").append(ofType?.name)
-    }
+fun __Type.typeReference(): String = when (kind) {
+    TypeKind.NON_NULL -> "${ofType?.typeReference()}!"
+    TypeKind.LIST -> "[${ofType?.typeReference()}]"
+    else -> name ?: ""
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/MutableSchemaDefinition.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/MutableSchemaDefinition.kt
@@ -46,7 +46,8 @@ data class MutableSchemaDefinition(
     private val unions: ArrayList<TypeDef.Union> = arrayListOf(),
     private val directives: ArrayList<Directive.Partial> = arrayListOf(
         Directive.SKIP,
-        Directive.INCLUDE
+        Directive.INCLUDE,
+        Directive.DEPRECATED
     ),
     private val inputObjects: ArrayList<TypeDef.Input<*>> = arrayListOf()
 ) {
@@ -87,7 +88,7 @@ data class MutableSchemaDefinition(
         if (scalars.any { it.kClass == member } || enums.any { it.kClass == member }) {
             throw SchemaException(
                 "The member types of a Union type must all be Object base types; " +
-                        "Scalar, Interface and Union types may not be member types of a Union"
+                    "Scalar, Interface and Union types may not be member types of a Union"
             )
         }
 
@@ -120,7 +121,7 @@ data class MutableSchemaDefinition(
 
     fun addSubscription(subscription: SubscriptionDef<*>) {
         if (subscription.checkEqualName(subscriptions)) {
-            throw SchemaException("Cannot add mutation with duplicated name ${subscription.name}")
+            throw SchemaException("Cannot add subscription with duplicated name ${subscription.name}")
         }
         subscriptions.add(subscription)
     }
@@ -135,7 +136,7 @@ data class MutableSchemaDefinition(
 
     fun addInputObject(input: TypeDef.Input<*>) = addType(input, inputObjects, "Input")
 
-    fun <T : Definition> addType(type: T, target: ArrayList<T>, typeCategory: String) {
+    private fun <T : Definition> addType(type: T, target: ArrayList<T>, typeCategory: String) {
         if (type.name.startsWith("__")) {
             throw SchemaException("Type name starting with \"__\" are excluded for introspection system")
         }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/LookupSchema.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/LookupSchema.kt
@@ -3,7 +3,6 @@ package com.apurebase.kgraphql.schema.structure
 import com.apurebase.kgraphql.isIterable
 import com.apurebase.kgraphql.request.TypeReference
 import com.apurebase.kgraphql.schema.Schema
-import com.apurebase.kgraphql.schema.introspection.TypeKind
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.jvm.jvmErasure
@@ -43,11 +42,4 @@ interface LookupSchema : Schema {
             return TypeReference(name, kType.isMarkedNullable)
         }
     }
-
-    fun typeReference(type: Type) = TypeReference(
-        name = type.unwrapped().name!!,
-        isNullable = type.isNullable(),
-        isList = type.isList(),
-        isElementNullable = type.isList() && type.unwrapList().ofType?.kind == TypeKind.NON_NULL
-    )
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/SchemaModel.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/SchemaModel.kt
@@ -33,7 +33,7 @@ data class SchemaModel(
             // workaround on the fact that Double and Float are treated as GraphQL Float
             .filterNot { it is Type.Scalar<*> && it.kClass == Float::class }
             .filterNot { it.kClass?.findAnnotation<NotIntrospected>() != null }
-            // query and mutation must be present in introspection 'types' field for introspection tools
+            // query must be present in introspection 'types' field for introspection tools
             .plus(query)
             .toMutableList()
         if (mutation != null) {

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/Type.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/Type.kt
@@ -7,7 +7,6 @@ import com.apurebase.kgraphql.schema.introspection.__EnumValue
 import com.apurebase.kgraphql.schema.introspection.__Field
 import com.apurebase.kgraphql.schema.introspection.__InputValue
 import com.apurebase.kgraphql.schema.introspection.__Type
-import com.apurebase.kgraphql.schema.introspection.asString
 import com.apurebase.kgraphql.schema.model.TypeDef
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
@@ -77,7 +76,7 @@ interface Type : __Type {
 
     class OperationObject(
         override val name: String,
-        override val description: String,
+        override val description: String?,
         fields: List<Field>
     ) : ComplexType(fields) {
 
@@ -110,7 +109,7 @@ interface Type : __Type {
 
         override val name: String = definition.name
 
-        override val description: String = definition.description ?: ""
+        override val description: String? = definition.description
 
         override val enumValues: List<__EnumValue>? = null
 
@@ -136,7 +135,7 @@ interface Type : __Type {
 
         override val name: String = definition.name
 
-        override val description: String = definition.description ?: ""
+        override val description: String? = definition.description
 
         override val enumValues: List<__EnumValue>? = null
 
@@ -159,7 +158,7 @@ interface Type : __Type {
 
         override val name: String = kqlType.name
 
-        override val description: String = kqlType.description ?: ""
+        override val description: String? = kqlType.description
 
         override val enumValues: List<__EnumValue>? = null
 
@@ -188,7 +187,7 @@ interface Type : __Type {
 
         override val name: String = kqlType.name
 
-        override val description: String = kqlType.description ?: ""
+        override val description: String? = kqlType.description
 
         override val enumValues: List<__EnumValue> = values
 
@@ -214,7 +213,7 @@ interface Type : __Type {
 
         override val name: String = kqlType.name
 
-        override val description: String = kqlType.description ?: ""
+        override val description: String? = kqlType.description
 
         override val enumValues: List<__EnumValue>? = null
 
@@ -238,7 +237,7 @@ interface Type : __Type {
 
         override val name: String = kqlType.name
 
-        override val description: String = kqlType.description ?: ""
+        override val description: String? = kqlType.description
 
         override val enumValues: List<__EnumValue>? = null
 
@@ -260,7 +259,7 @@ interface Type : __Type {
 
         override val name: String? = null
 
-        override val description: String = ""
+        override val description: String? = null
 
         override val enumValues: List<__EnumValue>? = null
 
@@ -282,7 +281,7 @@ interface Type : __Type {
 
         override val name: String? = null
 
-        override val description: String = ""
+        override val description: String? = null
 
         override val enumValues: List<__EnumValue>? = null
 
@@ -317,8 +316,6 @@ interface Type : __Type {
 
         override val inputFields: List<__InputValue>? = null
 
-        override fun toString(): String = asString()
-
         override fun isInstance(value: Any?): Boolean = false
     }
 
@@ -343,8 +340,6 @@ interface Type : __Type {
         override val enumValues: List<__EnumValue>? = null
 
         override val inputFields: List<__InputValue>? = null
-
-        override fun toString() = asString()
 
         override fun isInstance(value: Any?): Boolean = false
     }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/TypeProxy.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/TypeProxy.kt
@@ -20,7 +20,7 @@ open class TypeProxy(var proxied: Type) : Type {
     override val name: String?
         get() = proxied.name
 
-    override val description: String
+    override val description: String?
         get() = proxied.description
 
     override val fields: List<__Field>?

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaPrinterTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaPrinterTest.kt
@@ -1,0 +1,658 @@
+package com.apurebase.kgraphql.schema
+
+import com.apurebase.kgraphql.KGraphQL
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.util.UUID
+import kotlin.random.Random
+import kotlin.reflect.typeOf
+
+class SchemaPrinterTest {
+
+    data class Author(val name: String, val books: List<Book>)
+    data class Book(val title: String?, val author: Author)
+    data class Scenario(val author: String, val content: String)
+    data class InputObject(val id: Int, val stringInput: String, val intInput: Int, val optional: String?)
+    data class TestObject(val name: String)
+    enum class TestEnum {
+        TYPE1, TYPE2
+    }
+
+    data class DeprecatedObject(
+        val old: String,
+        val new: String
+    )
+
+    interface BaseInterface {
+        val base: String
+    }
+
+    interface SimpleInterface : BaseInterface {
+        val simple: String
+    }
+
+    interface OtherInterface {
+        val other1: String?
+        val other2: List<String?>?
+    }
+
+    data class Simple(override val base: String, override val simple: String, val extra: String) : SimpleInterface
+    data class Complex(
+        override val base: String,
+        override val other1: String?,
+        override val other2: List<String?>?,
+        val extra: Int
+    ) : BaseInterface, OtherInterface
+
+    data class NestedLists(
+        val nested1: List<List<String?>>,
+        val nested2: List<List<List<List<List<String>?>>?>>,
+        val nested3: List<List<List<List<List<List<List<String?>>?>>>>>?
+    )
+
+    @Test
+    fun `schema with types should be printed as expected`() {
+        val schema = KGraphQL.schema {
+            type<Book>()
+            type<Author>()
+        }
+
+        SchemaPrinter().print(schema) shouldBeEqualTo """
+            type Author {
+              books: [Book!]!
+              name: String!
+            }
+
+            type Book {
+              author: Author!
+              title: String
+            }
+
+        """.trimIndent()
+    }
+
+    @Test
+    fun `schema with nested lists should be printed as expected`() {
+        val schema = KGraphQL.schema {
+            type<NestedLists>()
+        }
+
+        SchemaPrinter().print(schema) shouldBeEqualTo """
+            type NestedLists {
+              nested1: [[String]!]!
+              nested2: [[[[[String!]]!]]!]!
+              nested3: [[[[[[[String]!]]!]!]!]!]
+            }
+
+        """.trimIndent()
+    }
+
+    @Test
+    fun `schema with union types should be printed as expected`() {
+        val schema = KGraphQL.schema {
+            query("scenario") {
+                resolver { -> Scenario("Gamil Kalus", "TOO LONG") }
+            }
+
+            val linked = unionType("Linked") {
+                type<Author>()
+                type<Scenario>()
+            }
+
+            type<Scenario> {
+                unionProperty("pdf") {
+                    returnType = linked
+                    description = "link to pdf representation of scenario"
+                    resolver { scenario: Scenario ->
+                        if (scenario.author.startsWith("Gamil")) {
+                            Scenario("gambino", "nope")
+                        } else {
+                            Author("Chance", emptyList())
+                        }
+                    }
+                }
+            }
+        }
+
+        SchemaPrinter().print(schema) shouldBeEqualTo """
+            type Author {
+              books: [Book!]!
+              name: String!
+            }
+            
+            type Book {
+              author: Author!
+              title: String
+            }
+
+            type Query {
+              scenario: Scenario!
+            }
+
+            type Scenario {
+              author: String!
+              content: String!
+              pdf: Linked
+            }
+            
+            union Linked = Author | Scenario
+            
+        """.trimIndent()
+    }
+
+    @Test
+    fun `schema with interfaces should be printed as expected`() {
+        val schema = KGraphQL.schema {
+            type<Simple>()
+            type<Complex>()
+            type<BaseInterface>()
+            type<SimpleInterface>()
+            type<OtherInterface>()
+        }
+
+        SchemaPrinter().print(schema) shouldBeEqualTo """
+            type Complex implements BaseInterface & OtherInterface {
+              base: String!
+              extra: Int!
+              other1: String
+              other2: [String]
+            }
+            
+            type Simple implements BaseInterface & SimpleInterface {
+              base: String!
+              extra: String!
+              simple: String!
+            }
+            
+            interface BaseInterface {
+              base: String!
+            }
+            
+            interface OtherInterface {
+              other1: String
+              other2: [String]
+            }
+            
+            interface SimpleInterface implements BaseInterface {
+              base: String!
+              simple: String!
+            }
+            
+        """.trimIndent()
+    }
+
+    @Test
+    fun `schema with input types should be printed as expected`() {
+        val schema = KGraphQL.schema {
+            mutation("add") {
+                resolver { inputObject: InputObject -> inputObject.id }
+            }
+        }
+
+        SchemaPrinter().print(schema) shouldBeEqualTo """
+            type Mutation {
+              add(inputObject: InputObject!): Int!
+            }
+            
+            input InputObject {
+              id: Int!
+              intInput: Int!
+              optional: String
+              stringInput: String!
+            }
+            
+        """.trimIndent()
+    }
+
+    @Test
+    fun `schema with custom scalars should be printed as expected`() {
+        val schema = KGraphQL.schema {
+            stringScalar<UUID> {
+                deserialize = UUID::fromString
+                serialize = UUID::toString
+            }
+            stringScalar<LocalDate> {
+                deserialize = LocalDate::parse
+                serialize = LocalDate::toString
+            }
+        }
+
+        SchemaPrinter().print(schema) shouldBeEqualTo """
+            scalar LocalDate
+            
+            scalar UUID
+            
+        """.trimIndent()
+    }
+
+    @Test
+    fun `schema with custom type extensions should be printed as expected`() {
+        val schema = KGraphQL.schema {
+            type<TestObject> {
+                property("addedProperty") {
+                    resolver { _ -> "added" }
+                }
+            }
+        }
+
+        SchemaPrinter().print(schema) shouldBeEqualTo """
+            type TestObject {
+              addedProperty: String!
+              name: String!
+            }
+            
+        """.trimIndent()
+    }
+
+    @Test
+    fun `schema with queries should be printed as expected`() {
+        val schema = KGraphQL.schema {
+            query("getString") {
+                resolver { -> "foo" }
+            }
+            query("randomString") {
+                resolver { possibleReturns: List<String> -> possibleReturns.random() }
+            }
+            query("randomInt") {
+                resolver { min: Int, max: Int? -> Random.nextInt(min, max ?: Integer.MAX_VALUE) }
+            }
+            query("getNullString") {
+                resolver<String?> { null }
+            }
+            query("getObject") {
+                resolver { nullObject: Boolean ->
+                    if (nullObject) {
+                        null
+                    } else {
+                        TestObject("foo")
+                    }
+                }
+            }
+        }
+
+        SchemaPrinter().print(schema) shouldBeEqualTo """
+            type Query {
+              getNullString: String
+              getObject(nullObject: Boolean!): TestObject
+              getString: String!
+              randomInt(min: Int!, max: Int): Int!
+              randomString(possibleReturns: [String!]!): String!
+            }
+            
+            type TestObject {
+              name: String!
+            }
+            
+        """.trimIndent()
+    }
+
+    @Test
+    fun `schema with mutations should be printed as expected`() {
+        val schema = KGraphQL.schema {
+            mutation("addString") {
+                resolver { string: String -> string }
+            }
+            mutation("addFloat") {
+                // Float is Kotlin Double
+                resolver { float: Double -> float }
+            }
+        }
+
+        SchemaPrinter().print(schema) shouldBeEqualTo """
+            type Mutation {
+              addFloat(float: Float!): Float!
+              addString(string: String!): String!
+            }
+            
+        """.trimIndent()
+    }
+
+    @Test
+    fun `schema with enums should be printed as expected`() {
+        val schema = KGraphQL.schema {
+            enum<TestEnum>()
+        }
+
+        SchemaPrinter().print(schema) shouldBeEqualTo """
+            enum TestEnum {
+              TYPE1
+              TYPE2
+            }
+
+        """.trimIndent()
+    }
+
+    @Test
+    fun `schema with default values should be printed as expected`() {
+        val schema = KGraphQL.schema {
+            enum<TestEnum>()
+
+            query("getStringWithDefault") {
+                resolver { type: TestEnum, string: String -> type.name + string }.withArgs {
+                    arg<TestEnum> { name = "type"; defaultValue = TestEnum.TYPE1 }
+                }
+            }
+            query("getStringsForTypes") {
+                resolver { types: List<TestEnum>? -> types.orEmpty().map { it.name } }.withArgs {
+                    arg(List::class, typeOf<List<TestEnum>?>()) {
+                        name = "types"; defaultValue = listOf(TestEnum.TYPE1, TestEnum.TYPE2)
+                    }
+                }
+            }
+            mutation("addStringWithDefault") {
+                resolver { prefix: String, string: String, suffix: String? -> prefix + string + suffix }.withArgs {
+                    arg<String> { name = "prefix"; defaultValue = "\"_\"" }
+                    arg(String::class, typeOf<String?>()) { name = "suffix"; defaultValue = null }
+                }
+            }
+        }
+
+        SchemaPrinter().print(schema) shouldBeEqualTo """
+            type Mutation {
+              addStringWithDefault(prefix: String! = "_", string: String!, suffix: String): String!
+            }
+            
+            type Query {
+              getStringsForTypes(types: [TestEnum!] = [TYPE1, TYPE2]): [String!]!
+              getStringWithDefault(type: TestEnum! = TYPE1, string: String!): String!
+            }
+            
+            enum TestEnum {
+              TYPE1
+              TYPE2
+            }
+            
+        """.trimIndent()
+    }
+
+    @Test
+    fun `schema with deprecations should be printed as expected`() {
+        val schema = KGraphQL.schema {
+            type<DeprecatedObject> {
+                property(DeprecatedObject::old) {
+                    deprecate("deprecated old value")
+                }
+            }
+            enum<TestEnum> {
+                value(TestEnum.TYPE2) {
+                    deprecate("deprecated enum value")
+                }
+            }
+            mutation("doStuff") {
+                resolver { inputObject: InputObject -> inputObject.id }
+            }
+            inputType<InputObject> {
+                InputObject::optional.configure {
+                    deprecate("deprecated old input value")
+                }
+            }
+            query("data") {
+                resolver { oldOptional: String?, new: String -> "" }.withArgs {
+                    arg(String::class, typeOf<String?>()) {
+                        name = "oldOptional"; defaultValue = "\"\""; deprecate("deprecated arg")
+                    }
+                    arg<String> { name = "new" }
+                }
+            }
+        }
+
+        SchemaPrinter().print(schema) shouldBeEqualTo """
+            type DeprecatedObject {
+              new: String!
+              old: String! @deprecated(reason: "deprecated old value")
+            }
+            
+            type Mutation {
+              doStuff(inputObject: InputObject!): Int!
+            }
+            
+            type Query {
+              data(
+                oldOptional: String = "" @deprecated(reason: "deprecated arg")
+                new: String!
+              ): String!
+            }
+            
+            enum TestEnum {
+              TYPE1
+              TYPE2 @deprecated(reason: "deprecated enum value")
+            }
+            
+            input InputObject {
+              id: Int!
+              intInput: Int!
+              optional: String @deprecated(reason: "deprecated old input value")
+              stringInput: String!
+            }
+            
+        """.trimIndent()
+    }
+
+    @Test
+    fun `schema with descriptions should be printed as expected if descriptions are included`() {
+        val schema = KGraphQL.schema {
+            type<TestObject> {
+                property(TestObject::name) {
+                    description = "This is the name"
+                }
+            }
+            enum<TestEnum> {
+                value(TestEnum.TYPE1) {
+                    description = "Enum value description"
+                }
+            }
+            query("getObject") {
+                description = "Get a test object"
+                resolver { name: String -> TestObject(name) }.withArgs {
+                    arg<String> { name = "name"; description = "The desired name" }
+                }
+            }
+            mutation("addObject") {
+                description = """
+                    Add a test object
+                    With some multi-line description
+                    (& special characters like " and \n)
+                """.trimIndent()
+                resolver { toAdd: TestObject -> toAdd }
+            }
+            subscription("subscribeObject") {
+                description = "Subscribe to an object"
+                resolver { -> TestObject("name") }
+            }
+        }
+
+        SchemaPrinter(
+            SchemaPrinterConfig(
+                includeSchemaDefinition = true,
+                includeDescriptions = true
+            )
+        ).print(schema) shouldBeEqualTo """
+            schema {
+              "Query object"
+              query: Query
+              "Mutation object"
+              mutation: Mutation
+              "Subscription object"
+              subscription: Subscription
+            }
+            
+            "Mutation object"
+            type Mutation {
+              "Add a test object"
+              "With some multi-line description"
+              "(& special characters like " and \n)"
+              addObject(toAdd: TestObject!): TestObject!
+            }
+            
+            "Query object"
+            type Query {
+              "Get a test object"
+              getObject(
+                "The desired name"
+                name: String!
+              ): TestObject!
+            }
+            
+            "Subscription object"
+            type Subscription {
+              "Subscribe to an object"
+              subscribeObject: TestObject!
+            }
+            
+            type TestObject {
+              "This is the name"
+              name: String!
+            }
+            
+            enum TestEnum {
+              "Enum value description"
+              TYPE1
+              TYPE2
+            }
+            
+            input TestObject {
+              name: String!
+            }
+            
+        """.trimIndent()
+    }
+
+    @Test
+    fun `schema with descriptions should be printed as expected if descriptions are excluded`() {
+        val schema = KGraphQL.schema {
+            type<TestObject> {
+                property(TestObject::name) {
+                    description = "This is the name"
+                }
+            }
+            enum<TestEnum> {
+                value(TestEnum.TYPE1) {
+                    description = "Enum value description"
+                }
+            }
+            query("getObject") {
+                description = "Get a test object"
+                resolver { -> TestObject("name") }
+            }
+            mutation("addObject") {
+                description = """
+                    Add a test object
+                    With some multi-line description
+                    (& special characters like " and \n)
+                """.trimIndent()
+                resolver { toAdd: TestObject -> toAdd }
+            }
+            subscription("subscribeObject") {
+                description = "Subscribe to an object"
+                resolver { -> TestObject("name") }
+            }
+        }
+
+        SchemaPrinter(SchemaPrinterConfig(includeDescriptions = false)).print(schema) shouldBeEqualTo """
+            type Mutation {
+              addObject(toAdd: TestObject!): TestObject!
+            }
+            
+            type Query {
+              getObject: TestObject!
+            }
+            
+            type Subscription {
+              subscribeObject: TestObject!
+            }
+            
+            type TestObject {
+              name: String!
+            }
+            
+            enum TestEnum {
+              TYPE1
+              TYPE2
+            }
+            
+            input TestObject {
+              name: String!
+            }
+            
+        """.trimIndent()
+    }
+
+    @Test
+    fun `schema built-in directives should be printed as expected if built-in directives are included`() {
+        val schema = KGraphQL.schema {
+            type<TestObject>()
+        }
+
+        SchemaPrinter(SchemaPrinterConfig(includeBuiltInDirectives = true)).print(schema) shouldBeEqualTo """
+            type TestObject {
+              name: String!
+            }
+            
+            directive @deprecated(reason: String) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | ENUM_VALUE
+
+            directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+            directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+            
+        """.trimIndent()
+    }
+
+    @Test
+    fun `schema itself should be included if enforced`() {
+        val schema = KGraphQL.schema {
+            type<TestObject>()
+        }
+
+        SchemaPrinter(SchemaPrinterConfig(includeSchemaDefinition = true)).print(schema) shouldBeEqualTo """
+            schema {
+              query: Query
+            }
+            
+            type TestObject {
+              name: String!
+            }
+            
+        """.trimIndent()
+    }
+
+    @Test
+    fun `schema itself should by default be included if required - other type named Mutation`() {
+        val schema = KGraphQL.schema {
+            type<TestObject> {
+                name = "Mutation"
+            }
+        }
+
+        SchemaPrinter().print(schema) shouldBeEqualTo """
+            schema {
+              query: Query
+            }
+            
+            type Mutation {
+              name: String!
+            }
+            
+        """.trimIndent()
+    }
+
+    @Test
+    fun `schema itself should by default be included if required - other type named Subscription`() {
+        val schema = KGraphQL.schema {
+            type<TestObject> {
+                name = "Subscription"
+            }
+        }
+
+        SchemaPrinter().print(schema) shouldBeEqualTo """
+            schema {
+              query: Query
+            }
+            
+            type Subscription {
+              name: String!
+            }
+            
+        """.trimIndent()
+    }
+}


### PR DESCRIPTION
Adds support for exporting an existing schema in the human-readable schema definition language (SDL). The Ktor feature by default provides it via `GET /<endpoint>?schema`.

SDL follows introspection config, so if introspection queries are disabled, export in SDL will also be disabled.

As implementations that support SDL have to provide the `@deprecated` directive, this also adds that directive to the built-in directives (without attempting to fix existing issues there).

Lastly, this fixes a small inconsistency with the spec by making the `description` of a `__Type` optional (and subsequently gets rid of some artificial empty string defaults).

Resolves #79