### PR TITLE
fix: Fix exception type for undeclared variables

### DIFF
--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/request/Variables.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/request/Variables.kt
@@ -2,6 +2,7 @@ package com.apurebase.kgraphql.request
 
 import com.apurebase.kgraphql.ExecutionException
 import com.apurebase.kgraphql.InvalidInputValueException
+import com.apurebase.kgraphql.ValidationException
 import com.apurebase.kgraphql.getIterableElementType
 import com.apurebase.kgraphql.isIterable
 import com.apurebase.kgraphql.schema.model.ast.TypeNode
@@ -28,8 +29,9 @@ data class Variables(
         keyNode: ValueNode.VariableNode,
         transform: (value: ValueNode) -> Any?
     ): T? {
-        val variable = requireNotNull(variables?.firstOrNull { keyNode.name.value == it.variable.name.value }) {
-            "Variable '$${keyNode.name.value}' was not declared for this operation"
+        val variable = variables?.firstOrNull { keyNode.name.value == it.variable.name.value }
+        if (variable == null) {
+            throw ValidationException("Variable '$${keyNode.name.value}' was not declared for this operation", listOf(keyNode))
         }
 
         val isIterable = kClass.isIterable()

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/ast/VariableDefinitionNode.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/ast/VariableDefinitionNode.kt
@@ -1,10 +1,8 @@
 package com.apurebase.kgraphql.schema.model.ast
 
-import com.apurebase.kgraphql.schema.model.ast.ValueNode.*
-
 data class VariableDefinitionNode(
     override val loc: Location?,
-    val variable: VariableNode,
+    val variable: ValueNode.VariableNode,
     val type: TypeNode,
     val defaultValue: ValueNode?,
     val directives: List<DirectiveNode>?

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/VariablesSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/VariablesSpecificationTest.kt
@@ -1,6 +1,7 @@
 package com.apurebase.kgraphql.specification.language
 
 import com.apurebase.kgraphql.Specification
+import com.apurebase.kgraphql.ValidationException
 import com.apurebase.kgraphql.assertNoErrors
 import com.apurebase.kgraphql.expect
 import com.apurebase.kgraphql.extract
@@ -83,7 +84,7 @@ class VariablesSpecificationTest : BaseSchemaTest() {
 
     @Test
     fun `fragment with missing variable`() {
-        expect<IllegalArgumentException>("Variable '\$big' was not declared for this operation") {
+        expect<ValidationException>("Variable '\$big' was not declared for this operation") {
             execute(
                 query = "mutation(\$name: String = \"Boguś Linda\", \$age : Int!) {createActor(name: \$name, age: \$age){...Linda}}" +
                         "fragment Linda on Actor {picture(big: \$big)}",
@@ -175,7 +176,6 @@ class VariablesSpecificationTest : BaseSchemaTest() {
         """.trimIndent()
 
         val result = execute(request, variables)
-
 
         assertNoErrors(result)
         assertThat(result.extract("data/agesFirst/name"), equalTo("Someone"))


### PR DESCRIPTION
`IllegalArgumentException`s are not handled as GraphQL errors and thus lead to nasty surprises. This likely affects more places.