### PR TITLE
refactor: Reduce coupling with Type

### DIFF
--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/DefaultSchema.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/DefaultSchema.kt
@@ -71,4 +71,6 @@ class DefaultSchema(
     override fun typeByKClass(kClass: KClass<*>): Type? = model.queryTypes[kClass]
 
     override fun inputTypeByKClass(kClass: KClass<*>): Type? = model.inputTypes[kClass]
+
+    override fun findTypeByName(name: String): Type? = model.allTypesByName[name]
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/SchemaPrinter.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/SchemaPrinter.kt
@@ -9,7 +9,6 @@ import com.apurebase.kgraphql.schema.introspection.__Directive
 import com.apurebase.kgraphql.schema.introspection.__InputValue
 import com.apurebase.kgraphql.schema.introspection.__Schema
 import com.apurebase.kgraphql.schema.introspection.__Type
-import com.apurebase.kgraphql.schema.introspection.typeReference
 import com.apurebase.kgraphql.schema.model.Depreciable
 
 data class SchemaPrinterConfig(

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/ArgumentTransformer.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/ArgumentTransformer.kt
@@ -5,7 +5,6 @@ import com.apurebase.kgraphql.InvalidInputValueException
 import com.apurebase.kgraphql.request.Variables
 import com.apurebase.kgraphql.schema.introspection.TypeKind
 import com.apurebase.kgraphql.schema.introspection.__Schema
-import com.apurebase.kgraphql.schema.introspection.typeReference
 import com.apurebase.kgraphql.schema.model.ast.ArgumentNodes
 import com.apurebase.kgraphql.schema.model.ast.ValueNode
 import com.apurebase.kgraphql.schema.model.ast.ValueNode.ObjectValueNode

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/Execution.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/Execution.kt
@@ -2,8 +2,8 @@ package com.apurebase.kgraphql.schema.execution
 
 import com.apurebase.kgraphql.schema.directive.Directive
 import com.apurebase.kgraphql.schema.introspection.NotIntrospected
+import com.apurebase.kgraphql.schema.introspection.__Type
 import com.apurebase.kgraphql.schema.structure.Field
-import com.apurebase.kgraphql.schema.structure.Type
 import com.apurebase.kgraphql.schema.model.ast.ArgumentNodes
 import com.apurebase.kgraphql.schema.model.ast.SelectionNode
 import com.apurebase.kgraphql.schema.model.ast.VariableDefinitionNode
@@ -37,7 +37,7 @@ sealed class Execution {
     class Union(
         node: SelectionNode,
         val unionField: Field.Union<*>,
-        val memberChildren: Map<Type, Collection<Execution>>,
+        val memberChildren: Map<__Type, Collection<Execution>>,
         key: String,
         alias: String? = null,
         condition: TypeCondition? = null,
@@ -51,7 +51,7 @@ sealed class Execution {
         typeCondition = condition,
         directives = directives
     ) {
-        fun memberExecution(type: Type): Node {
+        fun memberExecution(type: __Type): Node {
             return Node(
                 selectionNode = selectionNode,
                 field = field,

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/TypeCondition.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/TypeCondition.kt
@@ -1,8 +1,6 @@
 package com.apurebase.kgraphql.schema.execution
 
-import com.apurebase.kgraphql.schema.structure.Type
-
 /**
  * type conditions can be declared on fragments
  */
-class TypeCondition(val type: Type)
+class TypeCondition(val onType: String)

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/introspection/SchemaProxy.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/introspection/SchemaProxy.kt
@@ -26,6 +26,4 @@ class SchemaProxy(
 
     override val directives: List<__Directive>
         get() = getProxied().directives
-
-    override fun findTypeByName(name: String): __Type? = getProxied().findTypeByName(name)
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/introspection/__Schema.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/introspection/__Schema.kt
@@ -1,7 +1,6 @@
 package com.apurebase.kgraphql.schema.introspection
 
 interface __Schema {
-
     val types: List<__Type>
 
     val queryType: __Type
@@ -11,6 +10,4 @@ interface __Schema {
     val subscriptionType: __Type?
 
     val directives: List<__Directive>
-
-    fun findTypeByName(name: String): __Type?
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/introspection/__Type.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/introspection/__Type.kt
@@ -26,10 +26,28 @@ interface __Type {
 
     // NON_NULL and LIST only
     val ofType: __Type?
-}
 
-fun __Type.typeReference(): String = when (kind) {
-    TypeKind.NON_NULL -> "${ofType?.typeReference()}!"
-    TypeKind.LIST -> "[${ofType?.typeReference()}]"
-    else -> name ?: ""
+    operator fun get(name: String): __Field? = null
+
+    fun isList(): Boolean = when {
+        kind == TypeKind.LIST -> true
+        ofType == null -> false
+        else -> (ofType as __Type).isList()
+    }
+
+    fun typeReference(): String = when (kind) {
+        TypeKind.NON_NULL -> "${ofType?.typeReference()}!"
+        TypeKind.LIST -> "[${ofType?.typeReference()}]"
+        else -> name ?: ""
+    }
+
+    fun unwrapped(): __Type = when (kind) {
+        TypeKind.NON_NULL, TypeKind.LIST -> ofType!!.unwrapped()
+        else -> this
+    }
+
+    fun unwrapList(): __Type = when (kind) {
+        TypeKind.LIST -> ofType as __Type
+        else -> ofType?.unwrapList() ?: throw NoSuchElementException("this type does not wrap list element")
+    }
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/TypeDef.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/TypeDef.kt
@@ -47,7 +47,7 @@ interface TypeDef {
         fun toScalarType(): Type.Scalar<T> = Type.Scalar(this)
     }
 
-    //To avoid circular dependencies etc. union type members are resolved in runtime
+    // To avoid circular dependencies etc. union type members are resolved in runtime
     class Union(
         name: String,
         val members: Set<KClass<*>>,

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/Field.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/Field.kt
@@ -20,7 +20,7 @@ sealed class Field : __Field {
     override val args: List<__InputValue>
         get() = arguments.filterNot { it.type.kClass?.findAnnotation<NotIntrospected>() != null }
 
-    abstract val returnType: Type
+    abstract val returnType: __Type
 
     override val type: __Type
         get() = returnType
@@ -28,7 +28,7 @@ sealed class Field : __Field {
     abstract fun checkAccess(parent: Any?, ctx: Context)
 
     open class Function<T, R>(
-        kql: BaseOperationDef<T, R>,
+        private val kql: BaseOperationDef<T, R>,
         override val returnType: Type,
         override val arguments: List<InputValue<*>>
     ) : Field(), FunctionWrapper<R> by kql {
@@ -41,10 +41,8 @@ sealed class Field : __Field {
 
         override val deprecationReason: String? = kql.deprecationReason
 
-        val accessRule: ((T?, Context) -> Exception?)? = kql.accessRule
-
         override fun checkAccess(parent: Any?, ctx: Context) {
-            accessRule?.invoke(parent as T?, ctx)?.let { throw it }
+            kql.accessRule?.invoke(parent as T?, ctx)?.let { throw it }
         }
     }
 
@@ -65,7 +63,7 @@ sealed class Field : __Field {
     }
 
     class Kotlin<T : Any, R>(
-        kql: PropertyDef.Kotlin<T, R>,
+        private val kql: PropertyDef.Kotlin<T, R>,
         override val returnType: Type,
         override val arguments: List<InputValue<*>>,
         val transformation: Transformation<T, R>?
@@ -81,15 +79,13 @@ sealed class Field : __Field {
 
         override val deprecationReason: String? = kql.deprecationReason
 
-        val accessRule: ((T?, Context) -> Exception?)? = kql.accessRule
-
         override fun checkAccess(parent: Any?, ctx: Context) {
-            accessRule?.invoke(parent as T?, ctx)?.let { throw it }
+            kql.accessRule?.invoke(parent as T?, ctx)?.let { throw it }
         }
     }
 
     class Union<T>(
-        kql: PropertyDef.Union<T>,
+        private val kql: PropertyDef.Union<T>,
         override val returnType: Type,
         override val arguments: List<InputValue<*>>
     ) : Field(), FunctionWrapper<Any?> by kql {
@@ -102,10 +98,8 @@ sealed class Field : __Field {
 
         override val deprecationReason: String? = kql.deprecationReason
 
-        val accessRule: ((T?, Context) -> Exception?)? = kql.accessRule
-
         override fun checkAccess(parent: Any?, ctx: Context) {
-            accessRule?.invoke(parent as T?, ctx)?.let { throw it }
+            kql.accessRule?.invoke(parent as T?, ctx)?.let { throw it }
         }
     }
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/LookupSchema.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/LookupSchema.kt
@@ -3,6 +3,7 @@ package com.apurebase.kgraphql.schema.structure
 import com.apurebase.kgraphql.isIterable
 import com.apurebase.kgraphql.request.TypeReference
 import com.apurebase.kgraphql.schema.Schema
+import com.apurebase.kgraphql.schema.introspection.__Type
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.jvm.jvmErasure
@@ -34,4 +35,6 @@ interface LookupSchema : Schema {
             return TypeReference(name, kType.isMarkedNullable)
         }
     }
+
+    fun findTypeByName(name: String): __Type?
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/SchemaCompilation.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/SchemaCompilation.kt
@@ -150,6 +150,8 @@ class SchemaCompilation(
             definition.mutations.map { handleOperation(it) } + __typenameField)
     }
 
+    // https://spec.graphql.org/October2021/#sec-Type-Name-Introspection
+    //      "__typename may not be included as a root field in a subscription operation."
     private suspend fun handleSubscriptions(): Type {
         // https://spec.graphql.org/October2021/#sec-Type-Name-Introspection
         //      "__typename may not be included as a root field in a subscription operation."
@@ -165,7 +167,7 @@ class SchemaCompilation(
 
     private suspend fun introspectionTypeQuery() = handleOperation(
         QueryDef("__type", FunctionWrapper.on { name: String ->
-            schemaProxy.findTypeByName(name)
+            schemaProxy.types.firstOrNull { it.name == name }
         })
     )
 

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/SchemaModel.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/SchemaModel.kt
@@ -45,7 +45,5 @@ data class SchemaModel(
     override val mutationType: __Type? = mutation
 
     override val subscriptionType: __Type? = subscription
-
-    override fun findTypeByName(name: String): __Type? = allTypesByName[name]
 }
 

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/Type.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/Type.kt
@@ -15,9 +15,9 @@ import kotlin.reflect.full.createType
 
 interface Type : __Type {
 
-    operator fun get(name: String): Field? = null
+    override operator fun get(name: String): Field? = null
 
-    fun unwrapped(): Type = when (kind) {
+    override fun unwrapped(): Type = when (kind) {
         TypeKind.NON_NULL, TypeKind.LIST -> (ofType as Type).unwrapped()
         else -> this
     }
@@ -26,15 +26,9 @@ interface Type : __Type {
 
     fun isNotNullable() = kind == TypeKind.NON_NULL
 
-    fun unwrapList(): Type = when (kind) {
+    override fun unwrapList(): Type = when (kind) {
         TypeKind.LIST -> ofType as Type
         else -> (ofType as Type?)?.unwrapList() ?: throw NoSuchElementException("this type does not wrap list element")
-    }
-
-    fun isList(): Boolean = when {
-        kind == TypeKind.LIST -> true
-        ofType == null -> false
-        else -> (ofType as Type).isList()
     }
 
     fun isNotList(): Boolean = !isList()

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/Validation.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/Validation.kt
@@ -3,12 +3,14 @@ package com.apurebase.kgraphql.schema.structure
 import com.apurebase.kgraphql.ValidationException
 import com.apurebase.kgraphql.schema.SchemaException
 import com.apurebase.kgraphql.schema.introspection.TypeKind
+import com.apurebase.kgraphql.schema.introspection.__Field
+import com.apurebase.kgraphql.schema.introspection.__Type
 import com.apurebase.kgraphql.schema.model.ast.ArgumentNode
 import com.apurebase.kgraphql.schema.model.ast.SelectionNode.FieldNode
 import kotlin.reflect.KClass
 import kotlin.reflect.full.isSubclassOf
 
-fun validatePropertyArguments(parentType: Type, field: Field, requestNode: FieldNode) {
+fun validatePropertyArguments(parentType: __Type, field: __Field, requestNode: FieldNode) {
     val argumentValidationExceptions = field.validateArguments(requestNode.arguments, parentType.name)
 
     if (argumentValidationExceptions.isNotEmpty()) {
@@ -18,8 +20,8 @@ fun validatePropertyArguments(parentType: Type, field: Field, requestNode: Field
     }
 }
 
-fun Field.validateArguments(selectionArgs: List<ArgumentNode>?, parentTypeName: String?): List<ValidationException> {
-    if (!(arguments.isNotEmpty() || selectionArgs?.isNotEmpty() != true)) {
+fun __Field.validateArguments(selectionArgs: List<ArgumentNode>?, parentTypeName: String?): List<ValidationException> {
+    if (!(args.isNotEmpty() || selectionArgs?.isNotEmpty() != true)) {
         return listOf(
             ValidationException(
                 message = "Property $name on type $parentTypeName has no arguments, found: ${selectionArgs.map { it.name.value }}",
@@ -30,7 +32,7 @@ fun Field.validateArguments(selectionArgs: List<ArgumentNode>?, parentTypeName: 
 
     val exceptions = mutableListOf<ValidationException>()
 
-    val parameterNames = arguments.map { it.name }
+    val parameterNames = args.map { it.name }
     val invalidArguments = selectionArgs?.filter { it.name.value !in parameterNames }
 
     if (!invalidArguments.isNullOrEmpty()) {
@@ -41,7 +43,7 @@ fun Field.validateArguments(selectionArgs: List<ArgumentNode>?, parentTypeName: 
         )
     }
 
-    arguments.forEach { arg ->
+    args.forEach { arg ->
         val value = selectionArgs?.firstOrNull { arg.name == it.name.value }
         if (value == null && arg.type.kind == TypeKind.NON_NULL && arg.defaultValue == null) {
             exceptions.add(


### PR DESCRIPTION
The current implementation is heavily coupled to `Type` which itself is heavily coupled to actual Kotlin classes. This tries to move away from `Type` when it is not needed to simplify working with non-Kotlin schemas (like schemas created from SDL or introspection queries).