### PR TITLE
refactor: Cleanup `SchemaProxy`

### DIFF
--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/Extensions.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/Extensions.kt
@@ -7,22 +7,19 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlin.reflect.KClass
-import kotlin.reflect.KParameter
 import kotlin.reflect.KType
 import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.jvm.jvmErasure
 
 internal fun <T : Any> KClass<T>.defaultKQLTypeName() = this.simpleName!!
 
-internal fun KType.defaultKQLTypeName() = this.jvmErasure.defaultKQLTypeName()
-
-internal fun String.dropQuotes(): String = if (isLiteral()) drop(1).dropLast(1) else this
+internal fun String.dropQuotes(): String = if (isLiteral()) {
+    drop(1).dropLast(1)
+} else {
+    this
+}
 
 internal fun String.isLiteral(): Boolean = startsWith('\"') && endsWith('\"')
-
-internal fun KParameter.isNullable() = type.isMarkedNullable
-
-internal fun KParameter.isNotNullable() = !type.isMarkedNullable
 
 internal fun KClass<*>.isIterable() = isSubclassOf(Iterable::class)
 

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/ArgumentTransformer.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/ArgumentTransformer.kt
@@ -167,7 +167,7 @@ open class ArgumentTransformer(val schema: DefaultSchema) {
 
         fun throwInvalidEnumValue(enumType: Type.Enum<*>) {
             throw InvalidInputValueException(
-                "Invalid enum ${schema.model.enums[kClass]?.name} value. Expected one of ${enumType.values.map { it.value }}",
+                "Invalid enum ${enumType.name} value. Expected one of ${enumType.values.map { it.value }}",
                 value
             )
         }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/introspection/SchemaProxy.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/introspection/SchemaProxy.kt
@@ -1,17 +1,11 @@
 package com.apurebase.kgraphql.schema.introspection
 
-import com.apurebase.kgraphql.Context
-import com.apurebase.kgraphql.configuration.SchemaConfiguration
-import com.apurebase.kgraphql.schema.execution.ExecutionOptions
-import com.apurebase.kgraphql.schema.structure.LookupSchema
-import com.apurebase.kgraphql.schema.structure.Type
-import kotlin.reflect.KClass
-
+/**
+ * Wrapper for [proxiedSchema] to resolve introspection types
+ */
 class SchemaProxy(
-    override val configuration: SchemaConfiguration,
-    var proxiedSchema: LookupSchema? = null
-) : LookupSchema {
-
+    var proxiedSchema: __Schema? = null
+) : __Schema {
     companion object {
         const val ILLEGAL_STATE_MESSAGE = "Missing proxied __Schema instance"
     }
@@ -34,20 +28,4 @@ class SchemaProxy(
         get() = getProxied().directives
 
     override fun findTypeByName(name: String): __Type? = getProxied().findTypeByName(name)
-
-    override fun typeByKClass(kClass: KClass<*>): Type? = getProxied().typeByKClass(kClass)
-
-    override fun inputTypeByKClass(kClass: KClass<*>): Type? = inputTypeByKClass(kClass)
-
-    override suspend fun execute(
-        request: String,
-        variables: String?,
-        context: Context,
-        options: ExecutionOptions,
-        operationName: String?
-    ): String {
-        return getProxied().execute(request, variables, context, options, operationName)
-    }
-
-    override fun printSchema(): String = getProxied().printSchema()
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/Type.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/Type.kt
@@ -15,10 +15,6 @@ import kotlin.reflect.full.createType
 
 interface Type : __Type {
 
-    fun hasField(name: String): Boolean {
-        return fields?.any { it.name == name } ?: false
-    }
-
     operator fun get(name: String): Field? = null
 
     fun unwrapped(): Type = when (kind) {
@@ -68,8 +64,6 @@ interface Type : __Type {
         private val fieldsByName = allFields.associateBy { it.name }
 
         override val fields: List<__Field>? = allFields.filterNot { it.name.startsWith("__") }
-
-        override fun hasField(name: String): Boolean = fieldsByName[name] != null
 
         override fun get(name: String): Field? = fieldsByName[name]
     }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/introspection/IntrospectionSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/introspection/IntrospectionSpecificationTest.kt
@@ -81,6 +81,26 @@ class IntrospectionSpecificationTest {
         } shouldThrow GraphQLError::class withMessage "Property __typename on String does not exist"
     }
 
+    enum class SampleEnum {
+        VALUE
+    }
+    data class EnumData(val enum: SampleEnum)
+
+    @Test
+    fun `__typename field cannot be used on enums`() {
+        val schema = defaultSchema {
+            enum<SampleEnum>()
+
+            query("sample") {
+                resolver { -> EnumData(SampleEnum.VALUE) }
+            }
+        }
+
+        invoking {
+            schema.executeBlocking("{sample{enum{__typename}}}")
+        } shouldThrow GraphQLError::class withMessage "Property __typename on SampleEnum does not exist"
+    }
+
     data class Union1(val one: String)
 
     data class Union2(val two: String)
@@ -416,7 +436,7 @@ class IntrospectionSpecificationTest {
 
     @Test
     fun `all available SpecLevels of the introspection query should return without errors`() {
-        Introspection.SpecLevel.entries.forEach {
+        Introspection.SpecLevel.entries.forEach { _ ->
             val schema = defaultSchema {
                 query("sample") {
                     resolver { -> "Ronaldinho" }


### PR DESCRIPTION
`SchemaProxy` is (from my understanding) only a wrapper for schema introspection, and as such should not need to deal with Kotlin classes or offer execution options. This commit also removes some more unused code.