### PR TITLE
refactor: Back to actual types

### DIFF
--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/DataLoaderPreparedRequestExecutor.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/DataLoaderPreparedRequestExecutor.kt
@@ -9,8 +9,6 @@ import com.apurebase.kgraphql.request.Variables
 import com.apurebase.kgraphql.request.VariablesJson
 import com.apurebase.kgraphql.schema.DefaultSchema
 import com.apurebase.kgraphql.schema.introspection.TypeKind
-import com.apurebase.kgraphql.schema.introspection.__Field
-import com.apurebase.kgraphql.schema.introspection.__Type
 import com.apurebase.kgraphql.schema.model.FunctionWrapper
 import com.apurebase.kgraphql.schema.model.ast.ArgumentNodes
 import com.apurebase.kgraphql.schema.scalar.serializeScalar
@@ -78,7 +76,7 @@ class DataLoaderPreparedRequestExecutor(val schema: DefaultSchema) : RequestExec
         applyKeyToElement(ctx, result, node, node.field.returnType, 1)
     }
 
-    private fun Any?.toPrimitive(node: Execution.Node, returnType: __Type): JsonElement = when {
+    private fun Any?.toPrimitive(node: Execution.Node, returnType: Type): JsonElement = when {
         this == null -> createNullNode(node, returnType.unwrapList())
         this is Collection<*> || this is Array<*> -> when (this) {
             is Array<*> -> toList()
@@ -99,7 +97,7 @@ class DataLoaderPreparedRequestExecutor(val schema: DefaultSchema) : RequestExec
         ctx: ExecutionContext,
         value: T?,
         node: Execution.Node,
-        returnType: __Type,
+        returnType: Type,
         parentCount: Long
     ) {
         return when {
@@ -164,7 +162,7 @@ class DataLoaderPreparedRequestExecutor(val schema: DefaultSchema) : RequestExec
         }
     }
 
-    private fun <T> createSimpleValueNode(returnType: __Type, value: T, node: Execution.Node): JsonElement {
+    private fun <T> createSimpleValueNode(returnType: Type, value: T, node: Execution.Node): JsonElement {
         return when (val unwrapped = returnType.unwrapped()) {
             is Type.Scalar<*> -> {
                 serializeScalar(unwrapped, value, node)
@@ -179,7 +177,7 @@ class DataLoaderPreparedRequestExecutor(val schema: DefaultSchema) : RequestExec
         ctx: ExecutionContext,
         value: T,
         node: Execution.Node,
-        type: __Type,
+        type: Type,
         parentCount: Long
     ) {
         node.children.map { child ->
@@ -228,7 +226,7 @@ class DataLoaderPreparedRequestExecutor(val schema: DefaultSchema) : RequestExec
         ctx: ExecutionContext,
         value: T,
         child: Execution,
-        type: __Type,
+        type: Type,
         parentCount: Long
     ) {
         when (child) {
@@ -291,7 +289,7 @@ class DataLoaderPreparedRequestExecutor(val schema: DefaultSchema) : RequestExec
         ctx: ExecutionContext,
         parentValue: T,
         node: Execution.Node,
-        field: __Field,
+        field: Field,
         parentCount: Long
     ) {
         node.field.checkAccess(parentValue, ctx.requestContext)
@@ -396,7 +394,7 @@ class DataLoaderPreparedRequestExecutor(val schema: DefaultSchema) : RequestExec
             result.await().toString()
         }
 
-    private fun createNullNode(node: Execution.Node, returnType: __Type): JsonNull =
+    private fun createNullNode(node: Execution.Node, returnType: Type): JsonNull =
         if (returnType.kind != TypeKind.NON_NULL) {
             JsonNull
         } else {

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/Execution.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/Execution.kt
@@ -2,11 +2,11 @@ package com.apurebase.kgraphql.schema.execution
 
 import com.apurebase.kgraphql.schema.directive.Directive
 import com.apurebase.kgraphql.schema.introspection.NotIntrospected
-import com.apurebase.kgraphql.schema.introspection.__Type
-import com.apurebase.kgraphql.schema.structure.Field
 import com.apurebase.kgraphql.schema.model.ast.ArgumentNodes
 import com.apurebase.kgraphql.schema.model.ast.SelectionNode
 import com.apurebase.kgraphql.schema.model.ast.VariableDefinitionNode
+import com.apurebase.kgraphql.schema.structure.Field
+import com.apurebase.kgraphql.schema.structure.Type
 
 sealed class Execution {
     abstract val selectionNode: SelectionNode
@@ -36,7 +36,7 @@ sealed class Execution {
     class Union(
         node: SelectionNode,
         val unionField: Field.Union<*>,
-        val memberChildren: Map<__Type, Collection<Execution>>,
+        val memberChildren: Map<Type, Collection<Execution>>,
         key: String,
         alias: String?,
         directives: Map<Directive, ArgumentNodes?>?
@@ -48,7 +48,7 @@ sealed class Execution {
         alias = alias,
         directives = directives
     ) {
-        fun memberExecution(type: __Type): Node {
+        fun memberExecution(type: Type): Node {
             return Node(
                 selectionNode = selectionNode,
                 field = field,

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/ParallelRequestExecutor.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/ParallelRequestExecutor.kt
@@ -7,8 +7,6 @@ import com.apurebase.kgraphql.request.Variables
 import com.apurebase.kgraphql.request.VariablesJson
 import com.apurebase.kgraphql.schema.DefaultSchema
 import com.apurebase.kgraphql.schema.introspection.TypeKind
-import com.apurebase.kgraphql.schema.introspection.__Field
-import com.apurebase.kgraphql.schema.introspection.__Type
 import com.apurebase.kgraphql.schema.model.FunctionWrapper
 import com.apurebase.kgraphql.schema.model.ast.ArgumentNodes
 import com.apurebase.kgraphql.schema.scalar.serializeScalar
@@ -131,7 +129,7 @@ class ParallelRequestExecutor(val schema: DefaultSchema) : RequestExecutor {
         ctx: ExecutionContext,
         value: T?,
         node: Execution.Node,
-        returnType: __Type
+        returnType: Type
     ): JsonNode {
         if (value == null) {
             return createNullNode(node, returnType)
@@ -180,7 +178,7 @@ class ParallelRequestExecutor(val schema: DefaultSchema) : RequestExecutor {
         }
     }
 
-    private fun <T> createSimpleValueNode(returnType: __Type, value: T, node: Execution.Node): JsonNode =
+    private fun <T> createSimpleValueNode(returnType: Type, value: T, node: Execution.Node): JsonNode =
         when (val unwrapped = returnType.unwrapped()) {
             is Type.Scalar<*> -> {
                 serializeScalar(jsonNodeFactory, unwrapped, value, node)
@@ -193,7 +191,7 @@ class ParallelRequestExecutor(val schema: DefaultSchema) : RequestExecutor {
             else -> throw ExecutionException("Invalid Type: ${unwrapped.name}", node)
         }
 
-    private fun createNullNode(node: Execution.Node, returnType: __Type): NullNode {
+    private fun createNullNode(node: Execution.Node, returnType: Type): NullNode {
         if (returnType.kind != TypeKind.NON_NULL) {
             return jsonNodeFactory.nullNode()
         } else {
@@ -205,7 +203,7 @@ class ParallelRequestExecutor(val schema: DefaultSchema) : RequestExecutor {
         ctx: ExecutionContext,
         value: T,
         node: Execution.Node,
-        type: __Type
+        type: Type
     ): ObjectNode {
         val objectNode = jsonNodeFactory.objectNode()
         for (child in node.children) {
@@ -224,7 +222,7 @@ class ParallelRequestExecutor(val schema: DefaultSchema) : RequestExecutor {
         ctx: ExecutionContext,
         value: T,
         child: Execution,
-        type: __Type
+        type: Type
     ): Pair<String, JsonNode?>? {
         when (child) {
             // Union is subclass of Node so check it first
@@ -290,7 +288,7 @@ class ParallelRequestExecutor(val schema: DefaultSchema) : RequestExecutor {
         ctx: ExecutionContext,
         parentValue: T,
         node: Execution.Node,
-        field: __Field
+        field: Field
     ): JsonNode? {
         val include = shouldInclude(ctx, node)
         node.field.checkAccess(parentValue, ctx.requestContext)

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/introspection/__Type.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/introspection/__Type.kt
@@ -27,27 +27,9 @@ interface __Type {
     // NON_NULL and LIST only
     val ofType: __Type?
 
-    operator fun get(name: String): __Field? = null
-
-    fun isList(): Boolean = when {
-        kind == TypeKind.LIST -> true
-        ofType == null -> false
-        else -> (ofType as __Type).isList()
-    }
-
     fun typeReference(): String = when (kind) {
         TypeKind.NON_NULL -> "${ofType?.typeReference()}!"
         TypeKind.LIST -> "[${ofType?.typeReference()}]"
         else -> name ?: ""
-    }
-
-    fun unwrapped(): __Type = when (kind) {
-        TypeKind.NON_NULL, TypeKind.LIST -> ofType!!.unwrapped()
-        else -> this
-    }
-
-    fun unwrapList(): __Type = when (kind) {
-        TypeKind.LIST -> ofType as __Type
-        else -> ofType?.unwrapList() ?: throw NoSuchElementException("this type does not wrap list element")
     }
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/Field.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/Field.kt
@@ -20,7 +20,7 @@ sealed class Field : __Field {
     override val args: List<__InputValue>
         get() = arguments.filterNot { it.type.kClass?.findAnnotation<NotIntrospected>() != null }
 
-    abstract val returnType: __Type
+    abstract val returnType: Type
 
     override val type: __Type
         get() = returnType

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/LookupSchema.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/LookupSchema.kt
@@ -3,7 +3,6 @@ package com.apurebase.kgraphql.schema.structure
 import com.apurebase.kgraphql.isIterable
 import com.apurebase.kgraphql.request.TypeReference
 import com.apurebase.kgraphql.schema.Schema
-import com.apurebase.kgraphql.schema.introspection.__Type
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.jvm.jvmErasure
@@ -36,5 +35,5 @@ interface LookupSchema : Schema {
         }
     }
 
-    fun findTypeByName(name: String): __Type?
+    fun findTypeByName(name: String): Type?
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/SchemaModel.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/SchemaModel.kt
@@ -3,14 +3,13 @@ package com.apurebase.kgraphql.schema.structure
 import com.apurebase.kgraphql.schema.directive.Directive
 import com.apurebase.kgraphql.schema.introspection.NotIntrospected
 import com.apurebase.kgraphql.schema.introspection.__Schema
-import com.apurebase.kgraphql.schema.introspection.__Type
 import kotlin.reflect.KClass
 import kotlin.reflect.full.findAnnotation
 
 data class SchemaModel(
-    val query: Type,
-    val mutation: Type?,
-    val subscription: Type?,
+    private val query: Type,
+    private val mutation: Type?,
+    private val subscription: Type?,
     val allTypes: List<Type>,
     val queryTypes: Map<KClass<*>, Type>,
     val inputTypes: Map<KClass<*>, Type>,
@@ -21,9 +20,9 @@ data class SchemaModel(
 
     val queryTypesByName = queryTypes.values.associateBy { it.name }
 
-    override val types: List<__Type> = toTypeList()
+    override val types: List<Type> = toTypeList()
 
-    private fun toTypeList(): List<__Type> {
+    private fun toTypeList(): List<Type> {
         val list = allTypes
             // workaround on the fact that Double and Float are treated as GraphQL Float
             .filterNot { it is Type.Scalar<*> && it.kClass == Float::class }
@@ -40,10 +39,10 @@ data class SchemaModel(
         return list.toList()
     }
 
-    override val queryType: __Type = query
+    override val queryType: Type = query
 
-    override val mutationType: __Type? = mutation
+    override val mutationType: Type? = mutation
 
-    override val subscriptionType: __Type? = subscription
+    override val subscriptionType: Type? = subscription
 }
 

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/TypeProxy.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/TypeProxy.kt
@@ -23,13 +23,13 @@ open class TypeProxy(var proxied: Type) : Type {
     override val description: String?
         get() = proxied.description
 
-    override val fields: List<__Field>?
+    override val fields: List<Field>?
         get() = proxied.fields
 
-    override val interfaces: List<__Type>?
+    override val interfaces: List<Type>?
         get() = proxied.interfaces
 
-    override val possibleTypes: List<__Type>?
+    override val possibleTypes: List<Type>?
         get() = proxied.possibleTypes
 
     override val enumValues: List<__EnumValue>?
@@ -38,7 +38,7 @@ open class TypeProxy(var proxied: Type) : Type {
     override val inputFields: List<__InputValue>?
         get() = proxied.inputFields
 
-    override val ofType: __Type?
+    override val ofType: Type?
         get() = proxied.ofType
 
     override fun get(name: String) = proxied[name]

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/Validation.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/Validation.kt
@@ -3,14 +3,12 @@ package com.apurebase.kgraphql.schema.structure
 import com.apurebase.kgraphql.ValidationException
 import com.apurebase.kgraphql.schema.SchemaException
 import com.apurebase.kgraphql.schema.introspection.TypeKind
-import com.apurebase.kgraphql.schema.introspection.__Field
-import com.apurebase.kgraphql.schema.introspection.__Type
 import com.apurebase.kgraphql.schema.model.ast.ArgumentNode
 import com.apurebase.kgraphql.schema.model.ast.SelectionNode.FieldNode
 import kotlin.reflect.KClass
 import kotlin.reflect.full.isSubclassOf
 
-fun validatePropertyArguments(parentType: __Type, field: __Field, requestNode: FieldNode) {
+fun validatePropertyArguments(parentType: Type, field: Field, requestNode: FieldNode) {
     val argumentValidationExceptions = field.validateArguments(requestNode.arguments, parentType.name)
 
     if (argumentValidationExceptions.isNotEmpty()) {
@@ -20,7 +18,7 @@ fun validatePropertyArguments(parentType: __Type, field: __Field, requestNode: F
     }
 }
 
-fun __Field.validateArguments(selectionArgs: List<ArgumentNode>?, parentTypeName: String?): List<ValidationException> {
+fun Field.validateArguments(selectionArgs: List<ArgumentNode>?, parentTypeName: String?): List<ValidationException> {
     if (!(args.isNotEmpty() || selectionArgs?.isNotEmpty() != true)) {
         return listOf(
             ValidationException(


### PR DESCRIPTION
This partly reverts #119, mainly for the following reasons:

- I think I now have a bit more understanding of how KGraphQL works and/or was intended, and the `__` types seem to represent definition types, i.e. do not (and should not) have any execution details; similarly, the classes without `__` represent types that are used during execution to hold execution-specific extensions
- Further implementation for schema stitching shows that it is anyway necessary to create dedicated types for execution

To make that distinction more explicit, I even started to convert `__` types to execution types.