### PR TITLE
fix!: Fix validation on root types

### DIFF
--- a/kgraphql-ktor/src/test/kotlin/com/apurebase/kgraphql/KtorConfigurationTest.kt
+++ b/kgraphql-ktor/src/test/kotlin/com/apurebase/kgraphql/KtorConfigurationTest.kt
@@ -9,11 +9,17 @@ import org.junit.jupiter.api.Test
 class KtorConfigurationTest : KtorTest() {
 
     @Test
-    fun `default configuration should`() {
+    fun `default configuration should use Parallel executor`() {
         var checked = false
         testApplication {
             application {
-                val config = install(GraphQL) {}
+                val config = install(GraphQL) {
+                    schema {
+                        query("dummy") {
+                            resolver { -> "dummy" }
+                        }
+                    }
+                }
                 checked = true
                 config.schema.configuration.executor shouldBeEqualTo Executor.Parallel
             }
@@ -28,6 +34,11 @@ class KtorConfigurationTest : KtorTest() {
             application {
                 val config = install(GraphQL) {
                     executor = Executor.DataLoaderPrepared
+                    schema {
+                        query("dummy") {
+                            resolver { -> "dummy" }
+                        }
+                    }
                 }
                 checked = true
                 config.schema.configuration.executor shouldBeEqualTo Executor.DataLoaderPrepared

--- a/kgraphql-ktor/src/test/kotlin/com/apurebase/kgraphql/KtorFeatureTest.kt
+++ b/kgraphql-ktor/src/test/kotlin/com/apurebase/kgraphql/KtorFeatureTest.kt
@@ -37,6 +37,9 @@ class KtorFeatureTest : KtorTest() {
     @Test
     fun `Simple mutation test`() {
         val server = withServer {
+            query("dummy") {
+                resolver { -> "dummy" }
+            }
             mutation("hello") {
                 resolver { -> "World! mutation" }
             }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/SchemaPrinter.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/SchemaPrinter.kt
@@ -99,7 +99,7 @@ class SchemaPrinter(private val config: SchemaPrinterConfig = SchemaPrinterConfi
         // Objects (includes Query, Mutation, and Subscription) with non-empty fields
         //  https://spec.graphql.org/draft/#sec-Objects
         val objects = buildString {
-            schemaTypes[TypeKind.OBJECT]?.filter { !it.fields.isNullOrEmpty() }?.forEachIndexed { index, type ->
+            schemaTypes[TypeKind.OBJECT]?.forEachIndexed { index, type ->
                 if (index > 0) {
                     appendLine()
                 }
@@ -215,9 +215,9 @@ class SchemaPrinter(private val config: SchemaPrinterConfig = SchemaPrinterConfi
         (subscriptionType != null && subscriptionType?.name != "Subscription")
 
     private fun __Schema.hasRegularTypeWithDefaultRootTypeName() = types.any {
-        (it != queryType && it.name == "Query") ||
-            (it != mutationType && it.name == "Mutation") ||
-            (it != subscriptionType && it.name == "Subscription")
+        (it.name != queryType.name && it.name == "Query") ||
+            (it.name != mutationType?.name && it.name == "Mutation") ||
+            (it.name != subscriptionType?.name && it.name == "Subscription")
     }
 
     private fun Depreciable.deprecationInfo(): String = if (isDeprecated) {

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/request/ParserTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/request/ParserTest.kt
@@ -28,12 +28,7 @@ import org.junit.jupiter.api.Test
 
 class ParserTest {
 
-    private fun parse(source: String, options: Parser.Options? = null) = try {
-        Parser(source, options).parseDocument()
-    } catch (e: GraphQLError) {
-        println(e.prettyPrint())
-        throw e
-    }
+    private fun parse(source: String, options: Parser.Options? = null) = Parser(source, options).parseDocument()
 
     private fun parse(source: Source) = Parser(source).parseDocument()
 

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaPrinterTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaPrinterTest.kt
@@ -54,6 +54,9 @@ class SchemaPrinterTest {
     @Test
     fun `schema with types should be printed as expected`() {
         val schema = KGraphQL.schema {
+            query("dummy") {
+                resolver { -> "dummy" }
+            }
             type<Book>()
             type<Author>()
         }
@@ -68,6 +71,10 @@ class SchemaPrinterTest {
               author: Author!
               title: String
             }
+            
+            type Query {
+              dummy: String!
+            }
 
         """.trimIndent()
     }
@@ -75,6 +82,9 @@ class SchemaPrinterTest {
     @Test
     fun `schema with nested lists should be printed as expected`() {
         val schema = KGraphQL.schema {
+            query("dummy") {
+                resolver { -> "dummy" }
+            }
             type<NestedLists>()
         }
 
@@ -83,6 +93,10 @@ class SchemaPrinterTest {
               nested1: [[String]!]!
               nested2: [[[[[String!]]!]]!]!
               nested3: [[[[[[[String]!]]!]!]!]!]
+            }
+            
+            type Query {
+              dummy: String!
             }
 
         """.trimIndent()
@@ -189,6 +203,9 @@ class SchemaPrinterTest {
     @Test
     fun `schema with interfaces should be printed as expected`() {
         val schema = KGraphQL.schema {
+            query("dummy") {
+                resolver { -> "dummy" }
+            }
             type<Simple>()
             type<Complex>()
             type<BaseInterface>()
@@ -202,6 +219,10 @@ class SchemaPrinterTest {
               extra: Int!
               other1: String
               other2: [String]
+            }
+            
+            type Query {
+              dummy: String!
             }
             
             type Simple implements BaseInterface & SimpleInterface {
@@ -230,6 +251,9 @@ class SchemaPrinterTest {
     @Test
     fun `schema with input types should be printed as expected`() {
         val schema = KGraphQL.schema {
+            query("dummy") {
+                resolver { -> "dummy" }
+            }
             inputType<TestObject> {
                 name = "TestObjectInput"
             }
@@ -241,6 +265,10 @@ class SchemaPrinterTest {
         SchemaPrinter().print(schema) shouldBeEqualTo """
             type Mutation {
               add(input: TestObjectInput!): TestObject!
+            }
+            
+            type Query {
+              dummy: String!
             }
             
             type TestObject {
@@ -257,6 +285,9 @@ class SchemaPrinterTest {
     @Test
     fun `schema with custom scalars should be printed as expected`() {
         val schema = KGraphQL.schema {
+            query("dummy") {
+                resolver { -> "dummy" }
+            }
             stringScalar<UUID> {
                 deserialize = UUID::fromString
                 serialize = UUID::toString
@@ -272,12 +303,19 @@ class SchemaPrinterTest {
             
             scalar UUID
             
+            type Query {
+              dummy: String!
+            }
+            
         """.trimIndent()
     }
 
     @Test
     fun `schema with custom type extensions should be printed as expected`() {
         val schema = KGraphQL.schema {
+            query("dummy") {
+                resolver { -> "dummy" }
+            }
             type<TestObject> {
                 property("addedProperty") {
                     resolver { _ -> "added" }
@@ -286,6 +324,10 @@ class SchemaPrinterTest {
         }
 
         SchemaPrinter().print(schema) shouldBeEqualTo """
+            type Query {
+              dummy: String!
+            }
+            
             type TestObject {
               addedProperty: String!
               name: String!
@@ -339,6 +381,9 @@ class SchemaPrinterTest {
     @Test
     fun `schema with mutations should be printed as expected`() {
         val schema = KGraphQL.schema {
+            query("dummy") {
+                resolver { -> "dummy" }
+            }
             mutation("addString") {
                 resolver { string: String -> string }
             }
@@ -354,16 +399,27 @@ class SchemaPrinterTest {
               addString(string: String!): String!
             }
             
+            type Query {
+              dummy: String!
+            }
+            
         """.trimIndent()
     }
 
     @Test
     fun `schema with enums should be printed as expected`() {
         val schema = KGraphQL.schema {
+            query("dummy") {
+                resolver { -> "dummy" }
+            }
             enum<TestEnum>()
         }
 
         SchemaPrinter().print(schema) shouldBeEqualTo """
+            type Query {
+              dummy: String!
+            }
+            
             enum TestEnum {
               TYPE1
               TYPE2
@@ -630,10 +686,17 @@ class SchemaPrinterTest {
     @Test
     fun `schema built-in directives should be printed as expected if built-in directives are included`() {
         val schema = KGraphQL.schema {
+            query("dummy") {
+                resolver { -> "dummy" }
+            }
             type<TestObject>()
         }
 
         SchemaPrinter(SchemaPrinterConfig(includeBuiltInDirectives = true)).print(schema) shouldBeEqualTo """
+            type Query {
+              dummy: String!
+            }
+            
             type TestObject {
               name: String!
             }
@@ -650,12 +713,19 @@ class SchemaPrinterTest {
     @Test
     fun `schema itself should be included if enforced`() {
         val schema = KGraphQL.schema {
+            query("dummy") {
+                resolver { -> "dummy" }
+            }
             type<TestObject>()
         }
 
         SchemaPrinter(SchemaPrinterConfig(includeSchemaDefinition = true)).print(schema) shouldBeEqualTo """
             schema {
               query: Query
+            }
+            
+            type Query {
+              dummy: String!
             }
             
             type TestObject {
@@ -668,6 +738,9 @@ class SchemaPrinterTest {
     @Test
     fun `schema itself should by default be included if required - other type named Mutation`() {
         val schema = KGraphQL.schema {
+            query("dummy") {
+                resolver { -> "dummy" }
+            }
             type<TestObject> {
                 name = "Mutation"
             }
@@ -682,12 +755,19 @@ class SchemaPrinterTest {
               name: String!
             }
             
+            type Query {
+              dummy: String!
+            }
+            
         """.trimIndent()
     }
 
     @Test
     fun `schema itself should by default be included if required - other type named Subscription`() {
         val schema = KGraphQL.schema {
+            query("dummy") {
+                resolver { -> "dummy" }
+            }
             type<TestObject> {
                 name = "Subscription"
             }
@@ -696,6 +776,10 @@ class SchemaPrinterTest {
         SchemaPrinter().print(schema) shouldBeEqualTo """
             schema {
               query: Query
+            }
+            
+            type Query {
+              dummy: String!
             }
             
             type Subscription {

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/dsl/DataLoaderPropertyDSLTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/dsl/DataLoaderPropertyDSLTest.kt
@@ -70,6 +70,9 @@ class DataLoaderPropertyDSLTest {
             configure {
                 executor = Executor.DataLoaderPrepared
             }
+            query("scenario") {
+                resolver { -> "dummy" }
+            }
             type<Scenario> {
                 createGenericDataProperty(typeOf<SchemaBuilderTest.InputOne>()) { SchemaBuilderTest.InputOne("generic") }
             }
@@ -88,6 +91,9 @@ class DataLoaderPropertyDSLTest {
         val schema = defaultSchema {
             configure {
                 executor = Executor.DataLoaderPrepared
+            }
+            query("scenario") {
+                resolver { -> "dummy" }
             }
             type<Scenario> {
                 props.forEach { prop ->

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/introspection/ContextSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/introspection/ContextSpecificationTest.kt
@@ -20,7 +20,6 @@ class ContextSpecificationTest {
         }
 
         val response = deserialize(schema.executeBlocking("{__schema{queryType{fields{args{name}}}}}"))
-        println("response: $response")
         MatcherAssert.assertThat(
             response.extract("data/__schema/queryType/fields[0]/args[0]/name"),
             CoreMatchers.equalTo("limit")
@@ -31,13 +30,15 @@ class ContextSpecificationTest {
     @Suppress("UNUSED_ANONYMOUS_PARAMETER")
     fun `mutation resolver should not return context param`() {
         val schema = defaultSchema {
+            query("sample") {
+                resolver { -> "dummy" }
+            }
             mutation("sample") {
                 resolver { ctx: Context, input: String -> "SAMPLE" }
             }
         }
 
         val response = deserialize(schema.executeBlocking("{__schema{mutationType{fields{args{name}}}}}"))
-        println("response: $response")
         MatcherAssert.assertThat(
             response.extract("data/__schema/mutationType/fields[0]/args[0]/name"),
             CoreMatchers.equalTo("input")

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/introspection/DeprecationSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/introspection/DeprecationSpecificationTest.kt
@@ -32,6 +32,9 @@ class DeprecationSpecificationTest {
     fun `mutations may be deprecated`() {
         val expected = "sample mutation"
         val schema = defaultSchema {
+            query("dummy") {
+                resolver { -> "dummy" }
+            }
             mutation("sample") {
                 deprecate(expected)
                 resolver<String> { "SAMPLE" }
@@ -120,6 +123,9 @@ class DeprecationSpecificationTest {
 
         val expected = "deprecated input value"
         val schema = defaultSchema {
+            query("dummy") {
+                resolver { -> "dummy" }
+            }
             inputType<InputType> {
                 InputType::oldOptional.configure {
                     deprecate(expected)
@@ -158,6 +164,9 @@ class DeprecationSpecificationTest {
 
         val expected = "deprecated input value"
         val schema = defaultSchema {
+            query("dummy") {
+                resolver { -> "dummy" }
+            }
             inputType<InputType> {
                 InputType::oldOptional.configure {
                     deprecate(expected)

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/introspection/DocumentationSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/introspection/DocumentationSpecificationTest.kt
@@ -27,6 +27,9 @@ class DocumentationSpecificationTest {
     fun `mutations may be documented`() {
         val expected = "sample mutation"
         val schema = defaultSchema {
+            query("dummy") {
+                resolver { -> "dummy" }
+            }
             mutation("sample") {
                 description = expected
                 resolver<String> { "SAMPLE" }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/introspection/IntrospectionSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/introspection/IntrospectionSpecificationTest.kt
@@ -50,7 +50,11 @@ class IntrospectionSpecificationTest {
 
     @Test
     fun `__typename field can be used to obtain type of query`() {
-        val schema = defaultSchema {}
+        val schema = defaultSchema {
+            query("dummy") {
+                resolver { -> "dummy" }
+            }
+        }
 
         val response = deserialize(schema.executeBlocking("{__typename}"))
         assertThat(response.extract("data/__typename"), equalTo("Query"))
@@ -59,6 +63,9 @@ class IntrospectionSpecificationTest {
     @Test
     fun `__typename field can be used to obtain type of mutation`() {
         val schema = defaultSchema {
+            query("dummy") {
+                resolver { -> "dummy" }
+            }
             mutation("sample") {
                 resolver { -> Data("Ronaldingo") }
             }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/ListsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/ListsSpecificationTest.kt
@@ -163,6 +163,9 @@ class ListsSpecificationTest {
         )
 
         val schema = KGraphQL.schema {
+            query("dummy") {
+                resolver { -> "dummy" }
+            }
             mutation("createNestedLists") {
                 resolver { nested1: List<List<String?>>,
                            nested2: List<List<List<List<List<String>?>>?>>,

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/ScalarsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/ScalarsSpecificationTest.kt
@@ -59,6 +59,9 @@ class ScalarsSpecificationTest {
     @Test
     fun `integer value represents a value grater than 2^-31 and less or equal to 2^31`() {
         val schema = KGraphQL.schema {
+            query("dummy") {
+                resolver { -> "dummy" }
+            }
             mutation("Int") {
                 resolver { int: Int -> int }
             }
@@ -74,6 +77,9 @@ class ScalarsSpecificationTest {
     @Test
     fun `when float is expected as an input type, both integer and float input values are accepted`() {
         val schema = KGraphQL.schema {
+            query("dummy") {
+                resolver { -> "dummy" }
+            }
             mutation("float") {
                 resolver { float: Float -> float }
             }
@@ -106,6 +112,9 @@ class ScalarsSpecificationTest {
     @Test
     fun `For numeric scalars, input string with numeric content must raise a query error indicating an incorrect type`() {
         val schema = KGraphQL.schema {
+            query("dummy") {
+                resolver { -> "dummy" }
+            }
             mutation("Int") {
                 resolver { int: Int -> int }
             }
@@ -276,6 +285,9 @@ class ScalarsSpecificationTest {
     @Test
     fun `Schema may declare LocalDate custom scalar`() {
         val schema = KGraphQL.schema {
+            query("dummy") {
+                resolver { -> "dummy" }
+            }
             stringScalar<LocalDate> {
                 serialize = { date -> date.toString() }
                 deserialize = { dateString -> LocalDate.parse(dateString) }


### PR DESCRIPTION
According to the spec, root operation types must be of type `Object`, and `Object` types must have at least one defined field. This was already validated for regular types but not for `Query`.

Effectively, this also means that every valid schema needs to define at least one query.

Resolves #156

BREAKING CHANGE: Schemas without Queries no longer work