### PR TITLE
fix!: Limit built-in scalars to the ones defined by the spec

### DIFF
--- a/docs/content/Reference/Type System/scalars.md
+++ b/docs/content/Reference/Type System/scalars.md
@@ -31,3 +31,6 @@ stringScalar<UUID> {
   }
 }
 ```
+
+In addition to the built-in types, KGraphQL provides support for `Long` and `Short` which can be added to a schema
+using `extendedScalars()`.

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/SchemaPrinter.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/SchemaPrinter.kt
@@ -1,7 +1,6 @@
 package com.apurebase.kgraphql.schema
 
 import com.apurebase.kgraphql.request.isIntrospectionType
-import com.apurebase.kgraphql.schema.builtin.BuiltInScalars
 import com.apurebase.kgraphql.schema.directive.Directive
 import com.apurebase.kgraphql.schema.introspection.TypeKind
 import com.apurebase.kgraphql.schema.introspection.__Described
@@ -30,6 +29,8 @@ data class SchemaPrinterConfig(
 )
 
 class SchemaPrinter(private val config: SchemaPrinterConfig = SchemaPrinterConfig()) {
+    private val builtInScalarNames = setOf("Int", "Float", "String", "Boolean", "ID")
+
     /**
      * Returns the given [schema] in schema definition language (SDL). Types and fields are sorted
      * ascending by their name and appear in order of their corresponding spec section, i.e.
@@ -229,7 +230,7 @@ class SchemaPrinter(private val config: SchemaPrinterConfig = SchemaPrinterConfi
     private fun __Directive.isBuiltIn(): Boolean =
         name in setOf(Directive.DEPRECATED.name, Directive.INCLUDE.name, Directive.SKIP.name)
 
-    private fun __Type.isBuiltInScalar(): Boolean = name in BuiltInScalars.entries.map { it.typeDef.name }
+    private fun __Type.isBuiltInScalar(): Boolean = name in builtInScalarNames
 
     private fun __Type.implements(): String =
         interfaces

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/builtin/BuiltInScalars.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/builtin/BuiltInScalars.kt
@@ -31,19 +31,20 @@ private const val BOOLEAN_DESCRIPTION =
     "The Boolean scalar type represents true or false"
 
 /**
- * These scalars are created only for sake of documentation in introspection, not during execution
- *
  * https://spec.graphql.org/October2021/#sec-Scalars.Built-in-Scalars
  */
 enum class BuiltInScalars(val typeDef: TypeDef.Scalar<*>) {
     STRING(TypeDef.Scalar(String::class.defaultKQLTypeName(), String::class, STRING_COERCION, STRING_DESCRIPTION)),
-    SHORT(TypeDef.Scalar(Short::class.defaultKQLTypeName(), Short::class, SHORT_COERCION, SHORT_DESCRIPTION)),
     INT(TypeDef.Scalar(Int::class.defaultKQLTypeName(), Int::class, INT_COERCION, INT_DESCRIPTION)),
 
     // GraphQL does not differentiate between float and double, treat double like float
     DOUBLE(TypeDef.Scalar(Float::class.defaultKQLTypeName(), Double::class, DOUBLE_COERCION, FLOAT_DESCRIPTION)),
     FLOAT(TypeDef.Scalar(Float::class.defaultKQLTypeName(), Float::class, FLOAT_COERCION, FLOAT_DESCRIPTION)),
     BOOLEAN(TypeDef.Scalar(Boolean::class.defaultKQLTypeName(), Boolean::class, BOOLEAN_COERCION, BOOLEAN_DESCRIPTION)),
+}
+
+enum class ExtendedBuiltInScalars(val typeDef: TypeDef.Scalar<*>) {
+    SHORT(TypeDef.Scalar(Short::class.defaultKQLTypeName(), Short::class, SHORT_COERCION, SHORT_DESCRIPTION)),
     LONG(TypeDef.Scalar(Long::class.defaultKQLTypeName(), Long::class, LONG_COERCION, LONG_DESCRIPTION))
 }
 

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/SchemaBuilder.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/SchemaBuilder.kt
@@ -3,6 +3,7 @@ package com.apurebase.kgraphql.schema.dsl
 import com.apurebase.kgraphql.schema.Publisher
 import com.apurebase.kgraphql.schema.Schema
 import com.apurebase.kgraphql.schema.SchemaException
+import com.apurebase.kgraphql.schema.builtin.ExtendedBuiltInScalars
 import com.apurebase.kgraphql.schema.dsl.operations.MutationDSL
 import com.apurebase.kgraphql.schema.dsl.operations.QueryDSL
 import com.apurebase.kgraphql.schema.dsl.operations.SubscriptionDSL
@@ -138,6 +139,12 @@ class SchemaBuilder internal constructor() {
 
     inline fun <reified T : Any> booleanScalar(noinline block: ScalarDSL<T, Boolean>.() -> Unit) {
         booleanScalar(T::class, block)
+    }
+
+    fun extendedScalars() {
+        ExtendedBuiltInScalars.values().forEach {
+            model.addScalar(it.typeDef)
+        }
     }
 
     //================================================================================

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/DataLoaderPreparedRequestExecutor.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/DataLoaderPreparedRequestExecutor.kt
@@ -144,6 +144,7 @@ class DataLoaderPreparedRequestExecutor(val schema: DefaultSchema) : RequestExec
             value is Double -> node.aliasOrKey toValue JsonPrimitive(value)
             value is Boolean -> node.aliasOrKey toValue JsonPrimitive(value)
             value is Long -> node.aliasOrKey toValue JsonPrimitive(value)
+            value is Short -> node.aliasOrKey toValue JsonPrimitive(value)
             value is Deferred<*> -> {
                 deferredLaunch {
                     applyKeyToElement(ctx, value.await(), node, returnType, parentCount)

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/ParallelRequestExecutor.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/ParallelRequestExecutor.kt
@@ -164,7 +164,7 @@ class ParallelRequestExecutor(val schema: DefaultSchema) : RequestExecutor {
             value is Double -> jsonNodeFactory.numberNode(value)
             value is Boolean -> jsonNodeFactory.booleanNode(value)
             value is Long -> jsonNodeFactory.numberNode(value)
-            //big decimal etc?
+            value is Short -> jsonNodeFactory.numberNode(value)
 
             node.children.isNotEmpty() -> {
                 createObjectNode(ctx, value, node, returnType)

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/LongScalarTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/LongScalarTest.kt
@@ -13,12 +13,13 @@ class LongScalarTest {
     @Test
     fun testLongField() {
         val schema = defaultSchema {
+            extendedScalars()
             query("long") {
                 resolver { -> Long.MAX_VALUE }
             }
         }
 
-        val response = schema.executeBlocking("{long}")
+        val response = schema.executeBlocking("{ long }")
         val long = deserialize(response).extract<Long>("data/long")
         assertThat(long, equalTo(Long.MAX_VALUE))
     }
@@ -26,13 +27,21 @@ class LongScalarTest {
     @Test
     fun testLongArgument() {
         val schema = defaultSchema {
+            extendedScalars()
             query("isLong") {
-                resolver { long: Long -> if (long > Int.MAX_VALUE) "YES" else "NO" }
+                resolver { long: Long ->
+                    if (long > Int.MAX_VALUE) {
+                        "YES"
+                    } else {
+                        "NO"
+                    }
+                }
             }
         }
 
-        val isLong =
-            deserialize(schema.executeBlocking("{isLong(long: ${Int.MAX_VALUE.toLong() + 1})}")).extract<String>("data/isLong")
+        val isLong = deserialize(
+            schema.executeBlocking("{ isLong(long: ${Int.MAX_VALUE.toLong() + 1}) }")
+        ).extract<String>("data/isLong")
         assertThat(isLong, equalTo("YES"))
     }
 
@@ -52,7 +61,7 @@ class LongScalarTest {
         }
 
         val value = Int.MAX_VALUE.toLong() + 2
-        val response = deserialize(schema.executeBlocking("{number(number: $value)}"))
+        val response = deserialize(schema.executeBlocking("{ number(number: $value) }"))
         assertThat(response.extract<Long>("data/number"), equalTo(value))
     }
 

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/github/GitHubIssue75.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/github/GitHubIssue75.kt
@@ -47,6 +47,8 @@ class GitHubIssue75 {
                 useDefaultPrettyPrinter = true
             }
 
+            extendedScalars()
+
             query("findTrace") {
                 resolver { traceID: String ->
                     Trace(
@@ -132,6 +134,6 @@ class GitHubIssue75 {
               }
             }
         """, "{\"traceID\": \"646851f15cb2dad1\"}"
-        ).let(::println)
+        )
     }
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaBuilderTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaBuilderTest.kt
@@ -750,11 +750,11 @@ class SchemaBuilderTest {
     @Test
     fun `Short int types are mapped to Short Scalar`() {
         val schema = defaultSchema {
+            extendedScalars()
             query("shortQuery") {
                 resolver { -> 1.toShort() }
             }
         }
-
 
         val typesIntrospection = deserialize(schema.executeBlocking("{__schema{types{name}}}"))
         val types = typesIntrospection.extract<List<Map<String, String>>>("data/__schema/types")

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaPrinterTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaPrinterTest.kt
@@ -537,6 +537,7 @@ class SchemaPrinterTest {
     @Test
     fun `schema with descriptions should be printed as expected if descriptions are included`() {
         val schema = KGraphQL.schema {
+            extendedScalars()
             type<TestObject> {
                 property(TestObject::name) {
                     description = "This is the name"
@@ -581,6 +582,12 @@ class SchemaPrinterTest {
               "Subscription object"
               subscription: Subscription
             }
+            
+            "The Long scalar type represents a signed 64-bit numeric non-fractional value"
+            scalar Long
+
+            "The Short scalar type represents a signed 16-bit numeric non-fractional value"
+            scalar Short
             
             "Mutation object"
             type Mutation {


### PR DESCRIPTION
Partially resolves #83 by splitting up the current `BuiltInScalars` into two:

- The actual built-in scalars as defined by the spec
- Some extended scalars supported by KGraphQL

BREAKING CHANGE: Those extended scalars are no longer automatically added to a schema but must be manually included using `extendedScalars()` if needed.

BREAKING CHANGE: Shorts are returned as numeric value, no longer as string.