### PR TITLE
build: use v2 of the official dokka gradle plugin

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -10,6 +10,6 @@ plugins {
 
 dependencies {
     implementation(libs.kotlin.gradle)
-    implementation(libs.dokkatoo.gradle)
+    implementation(libs.dokka.gradle)
     implementation(libs.mavenPublish.gradle)
 }

--- a/buildSrc/src/main/kotlin/library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/library-conventions.gradle.kts
@@ -5,7 +5,7 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
 plugins {
     id("kotlin-conventions")
-    id("dev.adamko.dokkatoo-html")
+    id("org.jetbrains.dokka")
     id("com.vanniktech.maven.publish")
 }
 
@@ -20,16 +20,13 @@ kotlin {
     }
 }
 
-dokkatoo {
-    dokkaGeneratorIsolation.set(
-        ProcessIsolation {
-            maxHeapSize.set("4g")
-        }
-    )
+dokka {
+    dokkaGeneratorIsolation = ProcessIsolation {
+        maxHeapSize = "4g"
+    }
 }
 
 mavenPublishing {
-    configure(KotlinJvm(JavadocJar.Dokka("dokkatooGeneratePublicationHtml")))
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
     signAllPublications()
     pom {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,4 @@
 org.gradle.parallel=true
 org.gradle.caching=true
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
+org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref 
 
 [libraries]
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
-dokkatoo-gradle = { module = "dev.adamko.dokkatoo:dokkatoo-plugin", version = "2.4.0" }
+dokka-gradle = { module = "org.jetbrains.dokka:org.jetbrains.dokka.gradle.plugin", version = "2.0.0" }
 mavenPublish-gradle = { module = "com.vanniktech.maven.publish:com.vanniktech.maven.publish.gradle.plugin", version = "0.30.0" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-jdk8 = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8", version.ref = "kotlinx-coroutines" }


### PR DESCRIPTION
The official (but yet experimental) v2 of the dokka gradle plugin has integrated the benefits of the community maintained dokkatoo plugin.