### PR TITLE
refactor: Back to actual types (2)

### DIFF
--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/DataLoaderPreparedRequestExecutor.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/DataLoaderPreparedRequestExecutor.kt
@@ -198,10 +198,7 @@ class DataLoaderPreparedRequestExecutor(val schema: DefaultSchema) : RequestExec
             return
         }
 
-        val expectedType = checkNotNull(schema.findTypeByName(container.condition.onType)) {
-            "Unable to find type ${container.condition.onType}"
-        }
-
+        val expectedType = container.condition.onType
         if (expectedType.kind == TypeKind.OBJECT || expectedType.kind == TypeKind.INTERFACE) {
             if (expectedType.isInstance(value)) {
                 container.elements.map { child ->

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/ParallelRequestExecutor.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/ParallelRequestExecutor.kt
@@ -255,9 +255,7 @@ class ParallelRequestExecutor(val schema: DefaultSchema) : RequestExecutor {
         value: T,
         container: Execution.Fragment
     ): Map<String, JsonNode?> {
-        val expectedType = checkNotNull(schema.findTypeByName(container.condition.onType)) {
-            "Unable to find type ${container.condition.onType}"
-        }
+        val expectedType = container.condition.onType
         val include = shouldInclude(ctx, container)
 
         if (include) {

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/TypeCondition.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/TypeCondition.kt
@@ -1,6 +1,8 @@
 package com.apurebase.kgraphql.schema.execution
 
+import com.apurebase.kgraphql.schema.structure.Type
+
 /**
  * type conditions can be declared on fragments
  */
-class TypeCondition(val onType: String)
+class TypeCondition(val onType: Type)

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/RequestInterpreter.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/RequestInterpreter.kt
@@ -41,7 +41,7 @@ class RequestInterpreter(private val schemaModel: SchemaModel) {
             }
 
             val (conditionType, selectionSet) = fragments[node.name.value] ?: return null
-            val condition = TypeCondition(conditionType.name!!)
+            val condition = TypeCondition(conditionType)
 
             fragmentsStack.push(node.name.value)
             val elements = selectionSet.selections.map { conditionType.handleSelectionFieldOrFragment(it, this) }
@@ -137,7 +137,7 @@ class RequestInterpreter(private val schemaModel: SchemaModel) {
             }
             Execution.Fragment(
                 selectionNode = fragment,
-                condition = TypeCondition(type.name!!),
+                condition = TypeCondition(type),
                 directives = fragment.directives?.lookup(),
                 elements = fragment.selectionSet.selections.map { type.handleSelectionFieldOrFragment(it, ctx) }
             )


### PR DESCRIPTION
Similar to #152 this reverts the refactoring done to fragment conditions in #119 as it is no longer needed and causes unnecessary runtime overhead.