### PR TITLE
fix: Improve handling of input types

### DIFF
--- a/docs/content/Reference/Type System/input-objects.md
+++ b/docs/content/Reference/Type System/input-objects.md
@@ -7,6 +7,68 @@ An GraphQL Input Object defines a set of input fields; the input fields are eith
 objects. Like Object and Interface types, Input Object types are inferred from defined operations, but can be explicitly
 declared as well.
 
+## Schema
+
+Input Objects take their fields from the primary constructor, supporting property and non-property parameters.
+
+*Example Definition*
+
+```kotlin
+// Non-data class with a constructor parameter that is not a property
+class NonDataClass(param1: String = "Hello", val param3: Boolean?) {
+    var param2: Int = param1.length
+}
+
+val schema = KGraphQL.schema {
+    inputType<NonDataClass> {
+        name = "NonDataClassInput"
+    }
+    query("test") {
+        resolver { input: NonDataClass -> input }
+    }
+}
+```
+
+*Resulting SDL*
+
+```graphql
+type NonDataClass {
+  param2: Int!
+  param3: Boolean
+}
+
+type Query {
+  test(input: NonDataClassInput!): NonDataClass!
+}
+
+input NonDataClassInput {
+  param1: String!
+  param3: Boolean
+}
+```
+
+## Runtime
+
+Input Objects are instantiated via their primary constructor. Kotlin default values are used unless a different value
+is provided explicitly. Due to a limitation in Kotlin, default values are not visible in the generated schema, though.
+
 ## inputType {}
 
-`inputType` method can be used only to set description property and explicitly define type.
+Input types can be configured via the `inputType` DSL.
+
+*Example*
+
+```kotlin
+inputType<InputObject> {
+    name = "MyInputObject"
+    description = "Description for input object"
+    
+    InputObject::foo.configure {
+        deprecate("Deprecated old input value")
+    }
+}
+```
+
+## Limitations
+
+Although non-property constructor parameters are supported, it is not possible to add a description or deprecate them.

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/SchemaCompilation.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/SchemaCompilation.kt
@@ -26,6 +26,7 @@ import com.apurebase.kgraphql.schema.model.SchemaDefinition
 import com.apurebase.kgraphql.schema.model.Transformation
 import com.apurebase.kgraphql.schema.model.TypeDef
 import kotlin.reflect.KClass
+import kotlin.reflect.KParameter
 import kotlin.reflect.KProperty1
 import kotlin.reflect.KType
 import kotlin.reflect.KVisibility
@@ -351,9 +352,8 @@ class SchemaCompilation(
     private suspend fun handleInputType(kClass: KClass<*>): Type {
         assertValidObjectType(kClass)
 
-        if (kClass.primaryConstructor == null) {
-            throw SchemaException("Java class '${kClass.simpleName}' as inputType is not supported")
-        }
+        val primaryConstructor = kClass.primaryConstructor
+            ?: throw SchemaException("Java class '${kClass.simpleName}' as inputType is not supported")
 
         val inputObjectDef =
             definition.inputObjects.find { it.kClass == kClass } ?: TypeDef.Input(kClass.defaultKQLTypeName(), kClass)
@@ -361,11 +361,20 @@ class SchemaCompilation(
         val typeProxy = TypeProxy(objectType)
         inputTypeProxies[kClass] = typeProxy
 
+        val memberPropertiesByName = kClass.memberProperties.associateBy { it.name }
         val fields = if (kClass.findAnnotation<NotIntrospected>() == null) {
-            kClass.memberProperties.map { property ->
+            // Input types are created using their primary constructor. Therefore, it makes sense to (only) use the
+            // parameters of this constructor for the fields (cf. https://github.com/stuebingerb/KGraphQL/issues/235).
+            // Member properties are sorted by name (https://youtrack.jetbrains.com/issue/KT-41042), and SDL is
+            // sorting by name, so we'll also sort constructor parameters to be consistent.
+            primaryConstructor.parameters.sortedBy { it.name }.map { parameter ->
+                // kProperty is used to configure deprecation and description in the DSL, so we use it
+                // if available
+                val kProperty = memberPropertiesByName[parameter.name]
                 handleKotlinInputProperty(
-                    kProperty = property,
-                    kqlProperty = inputObjectDef.kotlinProperties[property]
+                    parameter = parameter,
+                    kProperty = kProperty,
+                    kqlProperty = kProperty?.let { inputObjectDef.kotlinProperties[it] }
                 )
             }
         } else {
@@ -420,21 +429,22 @@ class SchemaCompilation(
     }
 
     private suspend fun <T : Any, R> handleKotlinInputProperty(
-        kProperty: KProperty1<T, R>,
+        parameter: KParameter,
+        kProperty: KProperty1<T, R>?,
         kqlProperty: PropertyDef.Kotlin<*, *>?
     ): InputValue<*> {
-        val type = handlePossiblyWrappedType(kProperty.returnType, TypeCategory.INPUT)
-        val actualKqlProperty = kqlProperty ?: PropertyDef.Kotlin(kProperty)
-        if (actualKqlProperty.isDeprecated && !type.isNullable()) {
+        val type = handlePossiblyWrappedType(parameter.type, TypeCategory.INPUT)
+        val actualKqlProperty = kqlProperty ?: kProperty?.let { PropertyDef.Kotlin(it) }
+        if (actualKqlProperty?.isDeprecated == true && !type.isNullable()) {
             throw SchemaException("Required fields cannot be marked as deprecated")
         }
         return InputValue(
             InputValueDef(
-                kProperty.returnType.jvmErasure,
-                kProperty.name,
-                description = actualKqlProperty.description,
-                isDeprecated = actualKqlProperty.isDeprecated,
-                deprecationReason = actualKqlProperty.deprecationReason
+                parameter.type.jvmErasure,
+                parameter.name ?: throw SchemaException("No name available for parameter $parameter"),
+                description = actualKqlProperty?.description,
+                isDeprecated = actualKqlProperty?.isDeprecated ?: false,
+                deprecationReason = actualKqlProperty?.deprecationReason
             ), type
         )
     }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaPrinterTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaPrinterTest.kt
@@ -540,12 +540,14 @@ class SchemaPrinterTest {
         val schema = KGraphQL.schema {
             extendedScalars()
             type<TestObject> {
+                description = "Description for query object"
                 property(TestObject::name) {
                     description = "This is the name"
                 }
             }
             inputType<TestObject> {
                 name = "TestObjectInput"
+                description = "Description for input object"
             }
             enum<TestEnum> {
                 value(TestEnum.TYPE1) {
@@ -616,6 +618,7 @@ class SchemaPrinterTest {
               subscribeObject: TestObject!
             }
             
+            "Description for query object"
             type TestObject {
               "This is the name"
               name: String!
@@ -627,6 +630,7 @@ class SchemaPrinterTest {
               TYPE2
             }
             
+            "Description for input object"
             input TestObjectInput {
               name: String!
             }


### PR DESCRIPTION
Input types are instantiated using their primary constructor. However, during schema compilation they were treated like regular objects, where fields are taken from the member properties (which may differ from the constructor parameters).

Schema compilation now takes properties of input types from the primary constructor (only), while also supporting non-property parameters. This also resolves the problem that execution could complain about "missing non-optional input fields" when those fields were actually marked as optional in the schema by enhancing how the `valueMap` for the constructor call is processed.

Limitation: non-property parameters cannot be deprecated or described

Resolves #235