### PR TITLE
feature: Allow arbitrary error extensions

### DIFF
--- a/kgraphql/api/kgraphql.api
+++ b/kgraphql/api/kgraphql.api
@@ -42,8 +42,8 @@ public final class com/apurebase/kgraphql/ExtensionsKt {
 }
 
 public class com/apurebase/kgraphql/GraphQLError : java/lang/Exception {
-	public fun <init> (Ljava/lang/String;Ljava/util/List;Lcom/apurebase/kgraphql/schema/model/ast/Source;Ljava/util/List;Ljava/lang/Throwable;Ljava/lang/String;Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lcom/apurebase/kgraphql/schema/model/ast/Source;Ljava/util/List;Ljava/lang/Throwable;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Lcom/apurebase/kgraphql/schema/model/ast/Source;Ljava/util/List;Ljava/lang/Throwable;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lcom/apurebase/kgraphql/schema/model/ast/Source;Ljava/util/List;Ljava/lang/Throwable;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getExtensions ()Ljava/util/Map;
 	public final fun getExtensionsErrorDetail ()Ljava/util/Map;
 	public final fun getExtensionsErrorType ()Ljava/lang/String;

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/GraphQLErrorTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/GraphQLErrorTest.kt
@@ -1,5 +1,6 @@
 package com.apurebase.kgraphql
 
+import kotlinx.serialization.json.add
 import kotlinx.serialization.json.addJsonObject
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
@@ -57,6 +58,52 @@ class GraphQLErrorTest {
                                 put("age", "Limited to 150")
                             })
                             put("multiCheck", "The 'from' number must not exceed the 'to' number")
+                        })
+                    })
+                }
+            })
+        }.toString()
+
+        graphqlError.serialize() shouldBeEqualTo expectedJson
+    }
+
+    @Test
+    fun `test graphql error with custom extensions, type and detail`() {
+        val graphqlError = GraphQLError(
+            message = "test",
+            extensions = mapOf(
+                "type" to "VALIDATION_ERROR",
+                "listProperty" to listOf("value1", "value2", 3),
+                "detail" to mapOf<String, Any?>(
+                    "singleCheck" to mapOf("email" to "not an email", "age" to "Limited to 150"),
+                    "multiCheck" to "The 'from' number must not exceed the 'to' number"
+                )
+            ),
+            extensionsErrorType = "this is overwritten by extensions[type]",
+            extensionsErrorDetail = mapOf<String, Any?>(
+                "ignoredCheck" to "this is overwritten by extensions[detail]"
+            )
+        )
+
+        val expectedJson = buildJsonObject {
+            put("errors", buildJsonArray {
+                addJsonObject {
+                    put("message", "test")
+                    put("locations", buildJsonArray {})
+                    put("path", buildJsonArray {})
+                    put("extensions", buildJsonObject {
+                        put("type", "VALIDATION_ERROR")
+                        put("detail", buildJsonObject {
+                            put("singleCheck", buildJsonObject {
+                                put("email", "not an email")
+                                put("age", "Limited to 150")
+                            })
+                            put("multiCheck", "The 'from' number must not exceed the 'to' number")
+                        })
+                        put("listProperty", buildJsonArray {
+                            add("value1")
+                            add("value2")
+                            add(3)
                         })
                     })
                 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/QueryTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/QueryTest.kt
@@ -72,8 +72,9 @@ class QueryTest : BaseSchemaTest() {
             execute("{film{title, director{name, favDish}}}")
         } shouldThrow GraphQLError::class with {
             message shouldBeEqualTo "Property favDish on Director does not exist"
-            extensionsErrorType shouldBeEqualTo "GRAPHQL_VALIDATION_FAILED"
-            extensionsErrorDetail shouldBeEqualTo null
+            extensions shouldBeEqualTo mapOf(
+                "type" to "GRAPHQL_VALIDATION_FAILED"
+            )
         }
     }
 
@@ -119,8 +120,9 @@ class QueryTest : BaseSchemaTest() {
             execute("{scenario{author, content}}")
         } shouldThrow GraphQLError::class with {
             message shouldBeEqualTo "Property author on Scenario does not exist"
-            extensionsErrorType shouldBeEqualTo "GRAPHQL_VALIDATION_FAILED"
-            extensionsErrorDetail shouldBeEqualTo null
+            extensions shouldBeEqualTo mapOf(
+                "type" to "GRAPHQL_VALIDATION_FAILED"
+            )
         }
     }
 
@@ -229,8 +231,9 @@ class QueryTest : BaseSchemaTest() {
             execute("{scenario{id(uppercase: true), content}}")
         } shouldThrow GraphQLError::class with {
             message shouldBeEqualTo "Property id on type Scenario has no arguments, found: [uppercase]"
-            extensionsErrorType shouldBeEqualTo "GRAPHQL_VALIDATION_FAILED"
-            extensionsErrorDetail shouldBeEqualTo null
+            extensions shouldBeEqualTo mapOf(
+                "type" to "GRAPHQL_VALIDATION_FAILED"
+            )
         }
     }
 
@@ -403,8 +406,9 @@ class QueryTest : BaseSchemaTest() {
             """.trimIndent())
         } shouldThrow GraphQLError::class with {
             message shouldBeEqualTo "Unknown type MissingType in type condition on fragment"
-            extensionsErrorType shouldBeEqualTo "GRAPHQL_VALIDATION_FAILED"
-            extensionsErrorDetail shouldBeEqualTo null
+            extensions shouldBeEqualTo mapOf(
+                "type" to "GRAPHQL_VALIDATION_FAILED"
+            )
         }
     }
 
@@ -421,8 +425,9 @@ class QueryTest : BaseSchemaTest() {
             """.trimIndent())
         } shouldThrow GraphQLError::class with {
             message shouldBeEqualTo "Fragment film_title not found"
-            extensionsErrorType shouldBeEqualTo "GRAPHQL_VALIDATION_FAILED"
-            extensionsErrorDetail shouldBeEqualTo null
+            extensions shouldBeEqualTo mapOf(
+                "type" to "GRAPHQL_VALIDATION_FAILED"
+            )
         }
     }
 
@@ -432,8 +437,9 @@ class QueryTest : BaseSchemaTest() {
             execute("{film}")
         } shouldThrow GraphQLError::class with {
             message shouldBeEqualTo "Missing selection set on property film of type Film"
-            extensionsErrorType shouldBeEqualTo "GRAPHQL_VALIDATION_FAILED"
-            extensionsErrorDetail shouldBeEqualTo null
+            extensions shouldBeEqualTo mapOf(
+                "type" to "GRAPHQL_VALIDATION_FAILED"
+            )
         }
     }
 
@@ -474,7 +480,7 @@ class QueryTest : BaseSchemaTest() {
                 name
             }
         """.trimIndent()
-        ).also(::println).deserialize()
+        ).deserialize()
 
         result.extract<List<String>>("data/root/fields") shouldBeEqualTo listOf("fields")
         result.extract<Int>("data/root/kids[0]/id") shouldBeEqualTo 1

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/request/LexerTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/request/LexerTest.kt
@@ -202,8 +202,9 @@ internal class LexerTest {
             source shouldBeEqualTo testSource
             locations shouldNotBeEqualTo null
             locations!!.shouldHaveSize(1)
-            extensionsErrorType shouldBeEqualTo "GRAPHQL_PARSE_FAILED"
-            extensionsErrorDetail shouldBeEqualTo null
+            extensions shouldBeEqualTo mapOf(
+                "type" to "GRAPHQL_PARSE_FAILED"
+            )
             prettyPrint() shouldBeEqualTo """
                 Syntax Error: Cannot parse the unexpected character "?".
                 

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/InputValuesSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/InputValuesSpecificationTest.kt
@@ -105,7 +105,9 @@ class InputValuesSpecificationTest {
             deserialize(schema.executeBlocking("{ Boolean(value: $value) }"))
         } shouldThrow GraphQLError::class with {
             message shouldBeEqualTo "argument '$value' is not valid value of type Boolean"
-            extensionsErrorType shouldBeEqualTo "BAD_USER_INPUT"
+            extensions shouldBeEqualTo mapOf(
+                "type" to "BAD_USER_INPUT"
+            )
         }
     }
 
@@ -135,7 +137,9 @@ class InputValuesSpecificationTest {
             deserialize(schema.executeBlocking("{ String(value: $value) }"))
         } shouldThrow GraphQLError::class with {
             message shouldBeEqualTo "argument '$value' is not valid value of type String"
-            extensionsErrorType shouldBeEqualTo "BAD_USER_INPUT"
+            extensions shouldBeEqualTo mapOf(
+                "type" to "BAD_USER_INPUT"
+            )
         }
     }
 
@@ -161,7 +165,9 @@ class InputValuesSpecificationTest {
             deserialize(schema.executeBlocking("{ Enum(value: $value) }"))
         } shouldThrow GraphQLError::class with {
             message shouldBeEqualTo "Invalid enum ${FakeEnum::class.simpleName} value. Expected one of [ENUM1, ENUM2]"
-            extensionsErrorType shouldBeEqualTo "BAD_USER_INPUT"
+            extensions shouldBeEqualTo mapOf(
+                "type" to "BAD_USER_INPUT"
+            )
         }
     }
 
@@ -180,7 +186,9 @@ class InputValuesSpecificationTest {
             deserialize(schema.executeBlocking("{ List(value: $value) }"))
         } shouldThrow GraphQLError::class with {
             message shouldBeEqualTo "Cannot coerce $value to numeric constant"
-            extensionsErrorType shouldBeEqualTo "BAD_USER_INPUT"
+            extensions shouldBeEqualTo mapOf(
+                "type" to "BAD_USER_INPUT"
+            )
         }
     }
 
@@ -201,7 +209,9 @@ class InputValuesSpecificationTest {
             schema.executeBlocking("{ Object(value: { number: 232, description: \"little number\", list: $value }) }")
         } shouldThrow GraphQLError::class with {
             message shouldBeEqualTo "argument '$value' is not valid value of type String"
-            extensionsErrorType shouldBeEqualTo "BAD_USER_INPUT"
+            extensions shouldBeEqualTo mapOf(
+                "type" to "BAD_USER_INPUT"
+            )
         }
     }
 
@@ -212,7 +222,9 @@ class InputValuesSpecificationTest {
             schema.executeBlocking("{ Object(value: null) }")
         } shouldThrow GraphQLError::class with {
             message shouldBeEqualTo "argument 'null' is not valid value of type FakeData"
-            extensionsErrorType shouldBeEqualTo "BAD_USER_INPUT"
+            extensions shouldBeEqualTo mapOf(
+                "type" to "BAD_USER_INPUT"
+            )
         }
     }
 
@@ -295,7 +307,9 @@ class InputValuesSpecificationTest {
             schema.executeBlocking("query(\$object: FakeDate) { Object(value: \$object) }")
         } shouldThrow GraphQLError::class with {
             message shouldBeEqualTo "Invalid variable \$object argument type FakeDate, expected FakeData!"
-            extensionsErrorType shouldBeEqualTo "BAD_USER_INPUT"
+            extensions shouldBeEqualTo mapOf(
+                "type" to "BAD_USER_INPUT"
+            )
         }
     }
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/InputObjectsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/InputObjectsSpecificationTest.kt
@@ -89,7 +89,9 @@ class InputObjectsSpecificationTest {
             )
         } shouldThrow GraphQLError::class with {
             message shouldBeEqualTo "Property 'valu1' on 'MyInput' does not exist"
-            extensionsErrorType shouldBeEqualTo "BAD_USER_INPUT"
+            extensions shouldBeEqualTo mapOf(
+                "type" to "BAD_USER_INPUT"
+            )
         }
     }
 


### PR DESCRIPTION
Current error extensions are enforcing a fixed structure with a `type` key and a `detail` key. This allows to provide a custom map that will translate 1:1 to the response json. Keys in the `extensions` map will take precedence over the previous `extensionsErrorType` and `extensionsErrorDetail`.