### PR TITLE
fix: Prevent illegal names with stitching

### DIFF
--- a/kgraphql-ktor-stitched/src/main/kotlin/com/apurebase/kgraphql/stitched/schema/model/StitchedMutableSchemaDefinition.kt
+++ b/kgraphql-ktor-stitched/src/main/kotlin/com/apurebase/kgraphql/stitched/schema/model/StitchedMutableSchemaDefinition.kt
@@ -42,7 +42,7 @@ class StitchedMutableSchemaDefinition : MutableSchemaDefinition() {
 
     fun addStitchedProperty(stitchedProperty: StitchedProperty) {
         if (stitchedProperties.any { it.typeName == stitchedProperty.typeName && it.fieldName == stitchedProperty.fieldName }) {
-            throw SchemaException("Cannot add stitched field with duplicated field ${stitchedProperty.fieldName} for type ${stitchedProperty.typeName}")
+            throw SchemaException("Cannot add stitched field with duplicated name '${stitchedProperty.fieldName}' for type '${stitchedProperty.typeName}'")
         }
         stitchedProperties.add(stitchedProperty)
     }

--- a/kgraphql-ktor-stitched/src/main/kotlin/com/apurebase/kgraphql/stitched/schema/structure/StitchedSchemaCompilation.kt
+++ b/kgraphql-ktor-stitched/src/main/kotlin/com/apurebase/kgraphql/stitched/schema/structure/StitchedSchemaCompilation.kt
@@ -53,8 +53,11 @@ class StitchedSchemaCompilation(
             val originalType: TypeProxy = (typesByName[typeName] as? TypeProxy)
                 ?: throw SchemaException("Stitched type $typeName does not exist")
             val stitchedFields = stitchedProperties.map { property ->
+                if (property.fieldName.startsWith("__")) {
+                    throw SchemaException("Illegal name '${property.fieldName}'. Names starting with '__' are reserved for introspection system")
+                }
                 if (originalType.fields?.any { it.name == property.fieldName } == true) {
-                    throw SchemaException("Cannot add stitched field ${property.fieldName} with duplicate name")
+                    throw SchemaException("Cannot add stitched field with duplicated name '${property.fieldName}'")
                 }
                 val remoteQuery = queryType.fields?.firstOrNull { it.name == property.remoteQueryName }
                     ?: error("Stitched remote query ${property.remoteQueryName} does not exist")


### PR DESCRIPTION
Stitched fields also must not start with `__`.