### PR TITLE
refactor: Make variables work with ValueNodes

### DIFF
--- a/kgraphql-ktor-stitched/api/kgraphql-ktor-stitched.api
+++ b/kgraphql-ktor-stitched/api/kgraphql-ktor-stitched.api
@@ -321,6 +321,7 @@ public final class com/apurebase/kgraphql/stitched/schema/structure/Introspected
 	public fun setFields (Ljava/util/List;)V
 	public fun toString ()Ljava/lang/String;
 	public fun typeReference ()Ljava/lang/String;
+	public fun unwrapped ()Lcom/apurebase/kgraphql/schema/introspection/__Type;
 }
 
 public synthetic class com/apurebase/kgraphql/stitched/schema/structure/IntrospectedRootOperation$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
@@ -405,6 +406,7 @@ public final class com/apurebase/kgraphql/stitched/schema/structure/Introspected
 	public fun setFields (Ljava/util/List;)V
 	public fun toString ()Ljava/lang/String;
 	public fun typeReference ()Ljava/lang/String;
+	public fun unwrapped ()Lcom/apurebase/kgraphql/schema/introspection/__Type;
 }
 
 public synthetic class com/apurebase/kgraphql/stitched/schema/structure/IntrospectedType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {

--- a/kgraphql/api/kgraphql.api
+++ b/kgraphql/api/kgraphql.api
@@ -105,6 +105,7 @@ public final class com/apurebase/kgraphql/helpers/KGraphQLExtensionsKt {
 	public static final fun getFields (Lcom/apurebase/kgraphql/schema/execution/Execution;)Ljava/util/List;
 	public static final fun toJsonElement (Ljava/util/Collection;)Lkotlinx/serialization/json/JsonElement;
 	public static final fun toJsonElement (Ljava/util/Map;)Lkotlinx/serialization/json/JsonElement;
+	public static final fun toValueNode (Lcom/fasterxml/jackson/databind/JsonNode;Lcom/apurebase/kgraphql/schema/introspection/__Type;)Lcom/apurebase/kgraphql/schema/model/ast/ValueNode;
 }
 
 public final class com/apurebase/kgraphql/request/CachingDocumentParser {
@@ -230,41 +231,32 @@ public final class com/apurebase/kgraphql/request/TypeReference {
 }
 
 public final class com/apurebase/kgraphql/request/Variables {
-	public fun <init> (Lcom/apurebase/kgraphql/schema/structure/LookupSchema;Lcom/apurebase/kgraphql/request/VariablesJson;Ljava/util/List;)V
-	public final fun copy (Lcom/apurebase/kgraphql/schema/structure/LookupSchema;Lcom/apurebase/kgraphql/request/VariablesJson;Ljava/util/List;)Lcom/apurebase/kgraphql/request/Variables;
-	public static synthetic fun copy$default (Lcom/apurebase/kgraphql/request/Variables;Lcom/apurebase/kgraphql/schema/structure/LookupSchema;Lcom/apurebase/kgraphql/request/VariablesJson;Ljava/util/List;ILjava/lang/Object;)Lcom/apurebase/kgraphql/request/Variables;
+	public fun <init> (Lcom/apurebase/kgraphql/request/VariablesJson;Ljava/util/List;)V
+	public final fun copy (Lcom/apurebase/kgraphql/request/VariablesJson;Ljava/util/List;)Lcom/apurebase/kgraphql/request/Variables;
+	public static synthetic fun copy$default (Lcom/apurebase/kgraphql/request/Variables;Lcom/apurebase/kgraphql/request/VariablesJson;Ljava/util/List;ILjava/lang/Object;)Lcom/apurebase/kgraphql/request/Variables;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun get (Lkotlin/reflect/KClass;Lkotlin/reflect/KType;Ljava/lang/String;Lcom/apurebase/kgraphql/schema/model/ast/ValueNode$VariableNode;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public final fun get (Lcom/apurebase/kgraphql/schema/structure/Type;Lcom/apurebase/kgraphql/schema/model/ast/ValueNode$VariableNode;)Lcom/apurebase/kgraphql/schema/model/ast/ValueNode;
 	public final fun getRaw ()Lcom/fasterxml/jackson/databind/JsonNode;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class com/apurebase/kgraphql/request/VariablesJson {
-	public abstract fun get (Lkotlin/reflect/KClass;Lkotlin/reflect/KType;Lcom/apurebase/kgraphql/schema/model/ast/NameNode;)Ljava/lang/Object;
+	public abstract fun get (Lcom/apurebase/kgraphql/schema/structure/Type;Lcom/apurebase/kgraphql/schema/model/ast/NameNode;)Lcom/apurebase/kgraphql/schema/model/ast/ValueNode;
 	public abstract fun getRaw ()Lcom/fasterxml/jackson/databind/JsonNode;
-	public abstract fun toTypeReference (Lkotlin/reflect/KType;)Lcom/fasterxml/jackson/databind/JavaType;
-}
-
-public final class com/apurebase/kgraphql/request/VariablesJson$DefaultImpls {
-	public static fun toTypeReference (Lcom/apurebase/kgraphql/request/VariablesJson;Lkotlin/reflect/KType;)Lcom/fasterxml/jackson/databind/JavaType;
 }
 
 public final class com/apurebase/kgraphql/request/VariablesJson$Defined : com/apurebase/kgraphql/request/VariablesJson {
-	public fun <init> (Lcom/fasterxml/jackson/databind/ObjectMapper;Lcom/fasterxml/jackson/databind/JsonNode;)V
-	public fun <init> (Lcom/fasterxml/jackson/databind/ObjectMapper;Ljava/lang/String;)V
-	public fun get (Lkotlin/reflect/KClass;Lkotlin/reflect/KType;Lcom/apurebase/kgraphql/schema/model/ast/NameNode;)Ljava/lang/Object;
+	public fun <init> (Lcom/fasterxml/jackson/databind/JsonNode;)V
+	public fun get (Lcom/apurebase/kgraphql/schema/structure/Type;Lcom/apurebase/kgraphql/schema/model/ast/NameNode;)Lcom/apurebase/kgraphql/schema/model/ast/ValueNode;
 	public final fun getJson ()Lcom/fasterxml/jackson/databind/JsonNode;
-	public final fun getObjectMapper ()Lcom/fasterxml/jackson/databind/ObjectMapper;
 	public fun getRaw ()Lcom/fasterxml/jackson/databind/JsonNode;
-	public fun toTypeReference (Lkotlin/reflect/KType;)Lcom/fasterxml/jackson/databind/JavaType;
 }
 
 public final class com/apurebase/kgraphql/request/VariablesJson$Empty : com/apurebase/kgraphql/request/VariablesJson {
 	public fun <init> ()V
-	public fun get (Lkotlin/reflect/KClass;Lkotlin/reflect/KType;Lcom/apurebase/kgraphql/schema/model/ast/NameNode;)Ljava/lang/Object;
+	public fun get (Lcom/apurebase/kgraphql/schema/structure/Type;Lcom/apurebase/kgraphql/schema/model/ast/NameNode;)Lcom/apurebase/kgraphql/schema/model/ast/ValueNode;
 	public fun getRaw ()Lcom/fasterxml/jackson/databind/JsonNode;
-	public fun toTypeReference (Lkotlin/reflect/KType;)Lcom/fasterxml/jackson/databind/JavaType;
 }
 
 public final class com/apurebase/kgraphql/schema/DefaultSchema : com/apurebase/kgraphql/schema/Schema, com/apurebase/kgraphql/schema/introspection/__Schema, com/apurebase/kgraphql/schema/structure/LookupSchema {
@@ -1106,10 +1098,12 @@ public abstract interface class com/apurebase/kgraphql/schema/introspection/__Ty
 	public abstract fun getOfType ()Lcom/apurebase/kgraphql/schema/introspection/__Type;
 	public abstract fun getPossibleTypes ()Ljava/util/List;
 	public abstract fun typeReference ()Ljava/lang/String;
+	public abstract fun unwrapped ()Lcom/apurebase/kgraphql/schema/introspection/__Type;
 }
 
 public final class com/apurebase/kgraphql/schema/introspection/__Type$DefaultImpls {
 	public static fun typeReference (Lcom/apurebase/kgraphql/schema/introspection/__Type;)Ljava/lang/String;
+	public static fun unwrapped (Lcom/apurebase/kgraphql/schema/introspection/__Type;)Lcom/apurebase/kgraphql/schema/introspection/__Type;
 }
 
 public final class com/apurebase/kgraphql/schema/model/Add : com/apurebase/kgraphql/schema/model/DataActor {
@@ -2359,7 +2353,6 @@ public abstract interface class com/apurebase/kgraphql/schema/structure/Type : c
 	public abstract fun isNotNullable ()Z
 	public abstract fun isNullable ()Z
 	public abstract fun listType ()Lcom/apurebase/kgraphql/schema/structure/Type$AList;
-	public abstract fun toKType ()Lkotlin/reflect/KType;
 	public abstract fun unwrapList ()Lcom/apurebase/kgraphql/schema/structure/Type;
 	public abstract fun unwrapNonNull ()Lcom/apurebase/kgraphql/schema/structure/Type;
 	public abstract fun unwrapped ()Lcom/apurebase/kgraphql/schema/structure/Type;
@@ -2386,10 +2379,10 @@ public final class com/apurebase/kgraphql/schema/structure/Type$AList : com/apur
 	public fun isNotNullable ()Z
 	public fun isNullable ()Z
 	public fun listType ()Lcom/apurebase/kgraphql/schema/structure/Type$AList;
-	public fun toKType ()Lkotlin/reflect/KType;
 	public fun typeReference ()Ljava/lang/String;
 	public fun unwrapList ()Lcom/apurebase/kgraphql/schema/structure/Type;
 	public fun unwrapNonNull ()Lcom/apurebase/kgraphql/schema/structure/Type;
+	public synthetic fun unwrapped ()Lcom/apurebase/kgraphql/schema/introspection/__Type;
 	public fun unwrapped ()Lcom/apurebase/kgraphql/schema/structure/Type;
 }
 
@@ -2405,10 +2398,10 @@ public abstract class com/apurebase/kgraphql/schema/structure/Type$ComplexType :
 	public fun isNotNullable ()Z
 	public fun isNullable ()Z
 	public fun listType ()Lcom/apurebase/kgraphql/schema/structure/Type$AList;
-	public fun toKType ()Lkotlin/reflect/KType;
 	public fun typeReference ()Ljava/lang/String;
 	public fun unwrapList ()Lcom/apurebase/kgraphql/schema/structure/Type;
 	public fun unwrapNonNull ()Lcom/apurebase/kgraphql/schema/structure/Type;
+	public synthetic fun unwrapped ()Lcom/apurebase/kgraphql/schema/introspection/__Type;
 	public fun unwrapped ()Lcom/apurebase/kgraphql/schema/structure/Type;
 }
 
@@ -2421,7 +2414,6 @@ public final class com/apurebase/kgraphql/schema/structure/Type$DefaultImpls {
 	public static fun isNotNullable (Lcom/apurebase/kgraphql/schema/structure/Type;)Z
 	public static fun isNullable (Lcom/apurebase/kgraphql/schema/structure/Type;)Z
 	public static fun listType (Lcom/apurebase/kgraphql/schema/structure/Type;)Lcom/apurebase/kgraphql/schema/structure/Type$AList;
-	public static fun toKType (Lcom/apurebase/kgraphql/schema/structure/Type;)Lkotlin/reflect/KType;
 	public static fun typeReference (Lcom/apurebase/kgraphql/schema/structure/Type;)Ljava/lang/String;
 	public static fun unwrapList (Lcom/apurebase/kgraphql/schema/structure/Type;)Lcom/apurebase/kgraphql/schema/structure/Type;
 	public static fun unwrapNonNull (Lcom/apurebase/kgraphql/schema/structure/Type;)Lcom/apurebase/kgraphql/schema/structure/Type;
@@ -2450,10 +2442,10 @@ public final class com/apurebase/kgraphql/schema/structure/Type$Enum : com/apure
 	public fun isNotNullable ()Z
 	public fun isNullable ()Z
 	public fun listType ()Lcom/apurebase/kgraphql/schema/structure/Type$AList;
-	public fun toKType ()Lkotlin/reflect/KType;
 	public fun typeReference ()Ljava/lang/String;
 	public fun unwrapList ()Lcom/apurebase/kgraphql/schema/structure/Type;
 	public fun unwrapNonNull ()Lcom/apurebase/kgraphql/schema/structure/Type;
+	public synthetic fun unwrapped ()Lcom/apurebase/kgraphql/schema/introspection/__Type;
 	public fun unwrapped ()Lcom/apurebase/kgraphql/schema/structure/Type;
 }
 
@@ -2479,10 +2471,10 @@ public final class com/apurebase/kgraphql/schema/structure/Type$Input : com/apur
 	public fun isNotNullable ()Z
 	public fun isNullable ()Z
 	public fun listType ()Lcom/apurebase/kgraphql/schema/structure/Type$AList;
-	public fun toKType ()Lkotlin/reflect/KType;
 	public fun typeReference ()Ljava/lang/String;
 	public fun unwrapList ()Lcom/apurebase/kgraphql/schema/structure/Type;
 	public fun unwrapNonNull ()Lcom/apurebase/kgraphql/schema/structure/Type;
+	public synthetic fun unwrapped ()Lcom/apurebase/kgraphql/schema/introspection/__Type;
 	public fun unwrapped ()Lcom/apurebase/kgraphql/schema/structure/Type;
 }
 
@@ -2524,10 +2516,10 @@ public final class com/apurebase/kgraphql/schema/structure/Type$NonNull : com/ap
 	public fun isNotNullable ()Z
 	public fun isNullable ()Z
 	public fun listType ()Lcom/apurebase/kgraphql/schema/structure/Type$AList;
-	public fun toKType ()Lkotlin/reflect/KType;
 	public fun typeReference ()Ljava/lang/String;
 	public fun unwrapList ()Lcom/apurebase/kgraphql/schema/structure/Type;
 	public fun unwrapNonNull ()Lcom/apurebase/kgraphql/schema/structure/Type;
+	public synthetic fun unwrapped ()Lcom/apurebase/kgraphql/schema/introspection/__Type;
 	public fun unwrapped ()Lcom/apurebase/kgraphql/schema/structure/Type;
 }
 
@@ -2584,10 +2576,10 @@ public final class com/apurebase/kgraphql/schema/structure/Type$RemoteEnum : com
 	public fun isNotNullable ()Z
 	public fun isNullable ()Z
 	public fun listType ()Lcom/apurebase/kgraphql/schema/structure/Type$AList;
-	public fun toKType ()Lkotlin/reflect/KType;
 	public fun typeReference ()Ljava/lang/String;
 	public fun unwrapList ()Lcom/apurebase/kgraphql/schema/structure/Type;
 	public fun unwrapNonNull ()Lcom/apurebase/kgraphql/schema/structure/Type;
+	public synthetic fun unwrapped ()Lcom/apurebase/kgraphql/schema/introspection/__Type;
 	public fun unwrapped ()Lcom/apurebase/kgraphql/schema/structure/Type;
 }
 
@@ -2614,10 +2606,10 @@ public final class com/apurebase/kgraphql/schema/structure/Type$RemoteInputObjec
 	public fun isNotNullable ()Z
 	public fun isNullable ()Z
 	public fun listType ()Lcom/apurebase/kgraphql/schema/structure/Type$AList;
-	public fun toKType ()Lkotlin/reflect/KType;
 	public fun typeReference ()Ljava/lang/String;
 	public fun unwrapList ()Lcom/apurebase/kgraphql/schema/structure/Type;
 	public fun unwrapNonNull ()Lcom/apurebase/kgraphql/schema/structure/Type;
+	public synthetic fun unwrapped ()Lcom/apurebase/kgraphql/schema/introspection/__Type;
 	public fun unwrapped ()Lcom/apurebase/kgraphql/schema/structure/Type;
 }
 
@@ -2676,10 +2668,10 @@ public final class com/apurebase/kgraphql/schema/structure/Type$RemoteScalar : c
 	public fun isNotNullable ()Z
 	public fun isNullable ()Z
 	public fun listType ()Lcom/apurebase/kgraphql/schema/structure/Type$AList;
-	public fun toKType ()Lkotlin/reflect/KType;
 	public fun typeReference ()Ljava/lang/String;
 	public fun unwrapList ()Lcom/apurebase/kgraphql/schema/structure/Type;
 	public fun unwrapNonNull ()Lcom/apurebase/kgraphql/schema/structure/Type;
+	public synthetic fun unwrapped ()Lcom/apurebase/kgraphql/schema/introspection/__Type;
 	public fun unwrapped ()Lcom/apurebase/kgraphql/schema/structure/Type;
 }
 
@@ -2705,10 +2697,10 @@ public final class com/apurebase/kgraphql/schema/structure/Type$Scalar : com/apu
 	public fun isNotNullable ()Z
 	public fun isNullable ()Z
 	public fun listType ()Lcom/apurebase/kgraphql/schema/structure/Type$AList;
-	public fun toKType ()Lkotlin/reflect/KType;
 	public fun typeReference ()Ljava/lang/String;
 	public fun unwrapList ()Lcom/apurebase/kgraphql/schema/structure/Type;
 	public fun unwrapNonNull ()Lcom/apurebase/kgraphql/schema/structure/Type;
+	public synthetic fun unwrapped ()Lcom/apurebase/kgraphql/schema/introspection/__Type;
 	public fun unwrapped ()Lcom/apurebase/kgraphql/schema/structure/Type;
 }
 
@@ -2749,10 +2741,10 @@ public final class com/apurebase/kgraphql/schema/structure/Type$_Context : com/a
 	public fun isNotNullable ()Z
 	public fun isNullable ()Z
 	public fun listType ()Lcom/apurebase/kgraphql/schema/structure/Type$AList;
-	public fun toKType ()Lkotlin/reflect/KType;
 	public fun typeReference ()Ljava/lang/String;
 	public fun unwrapList ()Lcom/apurebase/kgraphql/schema/structure/Type;
 	public fun unwrapNonNull ()Lcom/apurebase/kgraphql/schema/structure/Type;
+	public synthetic fun unwrapped ()Lcom/apurebase/kgraphql/schema/introspection/__Type;
 	public fun unwrapped ()Lcom/apurebase/kgraphql/schema/structure/Type;
 }
 
@@ -2777,10 +2769,10 @@ public final class com/apurebase/kgraphql/schema/structure/Type$_ExecutionNode :
 	public fun isNotNullable ()Z
 	public fun isNullable ()Z
 	public fun listType ()Lcom/apurebase/kgraphql/schema/structure/Type$AList;
-	public fun toKType ()Lkotlin/reflect/KType;
 	public fun typeReference ()Ljava/lang/String;
 	public fun unwrapList ()Lcom/apurebase/kgraphql/schema/structure/Type;
 	public fun unwrapNonNull ()Lcom/apurebase/kgraphql/schema/structure/Type;
+	public synthetic fun unwrapped ()Lcom/apurebase/kgraphql/schema/introspection/__Type;
 	public fun unwrapped ()Lcom/apurebase/kgraphql/schema/structure/Type;
 }
 
@@ -2807,10 +2799,10 @@ public class com/apurebase/kgraphql/schema/structure/TypeProxy : com/apurebase/k
 	public fun isNullable ()Z
 	public fun listType ()Lcom/apurebase/kgraphql/schema/structure/Type$AList;
 	public final fun setProxied (Lcom/apurebase/kgraphql/schema/structure/Type;)V
-	public fun toKType ()Lkotlin/reflect/KType;
 	public fun typeReference ()Ljava/lang/String;
 	public fun unwrapList ()Lcom/apurebase/kgraphql/schema/structure/Type;
 	public fun unwrapNonNull ()Lcom/apurebase/kgraphql/schema/structure/Type;
+	public synthetic fun unwrapped ()Lcom/apurebase/kgraphql/schema/introspection/__Type;
 	public fun unwrapped ()Lcom/apurebase/kgraphql/schema/structure/Type;
 }
 

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/helpers/KGraphQLExtensions.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/helpers/KGraphQLExtensions.kt
@@ -1,6 +1,21 @@
 package com.apurebase.kgraphql.helpers
 
+import com.apurebase.kgraphql.schema.builtin.BuiltInScalars
 import com.apurebase.kgraphql.schema.execution.Execution
+import com.apurebase.kgraphql.schema.introspection.TypeKind
+import com.apurebase.kgraphql.schema.introspection.__Type
+import com.apurebase.kgraphql.schema.model.ast.NameNode
+import com.apurebase.kgraphql.schema.model.ast.ValueNode
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.BooleanNode
+import com.fasterxml.jackson.databind.node.DoubleNode
+import com.fasterxml.jackson.databind.node.FloatNode
+import com.fasterxml.jackson.databind.node.IntNode
+import com.fasterxml.jackson.databind.node.LongNode
+import com.fasterxml.jackson.databind.node.NullNode
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.databind.node.TextNode
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -62,3 +77,57 @@ fun Map<*, *>.toJsonElement(): JsonElement {
     }
     return JsonObject(map)
 }
+
+/**
+ * Converts this [JsonNode] to a [ValueNode], applying special treatment for doubles and floats:
+ *
+ * Json does not differentiate between "1" and "1.0" (cf. https://json-schema.org/understanding-json-schema/reference/numeric),
+ * and while it is allowed to pass "1" for a Double, it is not allowed to pass "1.0" for an Int.
+ * So when the [expectedType] is INT *and* the value is a whole number, we convert a Json "1.0"
+ * to [ValueNode.NumberValueNode] instead of [ValueNode.DoubleValueNode].
+ */
+fun JsonNode?.toValueNode(expectedType: __Type): ValueNode = when (this) {
+    is BooleanNode -> ValueNode.BooleanValueNode(booleanValue(), null)
+    is IntNode -> ValueNode.NumberValueNode(longValue(), null)
+    is LongNode -> ValueNode.NumberValueNode(longValue(), null)
+
+    is DoubleNode -> if (expectedType.isInt() && doubleValue() % 1.0 == 0.0) {
+        ValueNode.NumberValueNode(longValue(), null)
+    } else {
+        ValueNode.DoubleValueNode(doubleValue(), null)
+    }
+
+    is FloatNode -> if (expectedType.isInt() && doubleValue() % 1.0 == 0.0) {
+        ValueNode.NumberValueNode(longValue(), null)
+    } else {
+        ValueNode.DoubleValueNode(doubleValue(), null)
+    }
+
+    is TextNode -> if (expectedType.unwrapped().kind == TypeKind.ENUM) {
+        ValueNode.EnumValueNode(textValue(), null)
+    } else {
+        // TODO: what about multiline strings?
+        ValueNode.StringValueNode(textValue(), false, null)
+    }
+
+    is ArrayNode -> ValueNode.ListValueNode(map { it.toValueNode(expectedType) }, null)
+    is ObjectNode -> ValueNode.ObjectValueNode(
+        properties().filterNot { it.key.startsWith("__") }.map { prop ->
+            val inputFields = checkNotNull(expectedType.unwrapped().inputFields) {
+                "Expected INPUT_OBJECT for ${expectedType.unwrapped().name} but got ${expectedType.kind}"
+            }
+            val expectedPropType = inputFields.first { it.name == prop.key }.type
+            ValueNode.ObjectValueNode.ObjectFieldNode(
+                null,
+                NameNode(prop.key, null),
+                prop.value.toValueNode(expectedPropType)
+            )
+        },
+        null
+    )
+
+    is NullNode, null -> ValueNode.NullValueNode(null)
+    else -> error("Unexpected value: $this")
+}
+
+private fun __Type.isInt() = unwrapped().name == BuiltInScalars.INT.typeDef.name

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/request/Variables.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/request/Variables.kt
@@ -1,100 +1,44 @@
 package com.apurebase.kgraphql.request
 
-import com.apurebase.kgraphql.ExecutionException
 import com.apurebase.kgraphql.InvalidInputValueException
 import com.apurebase.kgraphql.ValidationException
-import com.apurebase.kgraphql.getIterableElementType
-import com.apurebase.kgraphql.isIterable
 import com.apurebase.kgraphql.schema.model.ast.TypeNode
 import com.apurebase.kgraphql.schema.model.ast.ValueNode
 import com.apurebase.kgraphql.schema.model.ast.VariableDefinitionNode
-import com.apurebase.kgraphql.schema.structure.LookupSchema
+import com.apurebase.kgraphql.schema.structure.Type
 import com.fasterxml.jackson.databind.JsonNode
-import kotlin.reflect.KClass
-import kotlin.reflect.KType
 
-@Suppress("UNCHECKED_CAST")
-data class Variables(
-    private val typeDefinitionProvider: LookupSchema,
-    private val variablesJson: VariablesJson,
-    private val variables: List<VariableDefinitionNode>?
-) {
-
-    /**
-     * map and return object of requested class
-     */
-    fun <T : Any> get(
-        kClass: KClass<T>,
-        kType: KType,
-        typeName: String?,
-        keyNode: ValueNode.VariableNode,
-        transform: (value: ValueNode) -> Any?
-    ): T? {
+data class Variables(private val variablesJson: VariablesJson, private val variables: List<VariableDefinitionNode>?) {
+    fun get(type: Type, keyNode: ValueNode.VariableNode): ValueNode? {
         val variable = variables?.firstOrNull { keyNode.name.value == it.variable.name.value }
         if (variable == null) {
-            throw ValidationException("Variable '$${keyNode.name.value}' was not declared for this operation", listOf(keyNode))
+            throw ValidationException(
+                "Variable '$${keyNode.name.value}' was not declared for this operation",
+                listOf(keyNode)
+            )
         }
 
-        val isIterable = kClass.isIterable()
+        validateVariable(type, variable)
 
-        validateVariable(typeDefinitionProvider.typeReference(kType), typeName, variable)
-
-        var value = variablesJson.get(kClass, kType, keyNode.name)
-        if (value == null && variable.defaultValue != null) {
-            value = transformDefaultValue(transform, variable.defaultValue, kClass)
-        }
-
-        value?.let {
-            if (isIterable && !kType.getIterableElementType().isMarkedNullable) {
-                for (element in value as Iterable<*>) {
-                    if (element == null) {
-                        throw InvalidInputValueException(
-                            "Invalid argument value $value from variable $${keyNode.name.value}, expected list with non-null arguments",
-                            keyNode
-                        )
-                    }
-                }
-            }
-        }
-
-        return value
+        return variablesJson.get(type, keyNode.name) ?: variable.defaultValue
     }
 
     fun getRaw(): JsonNode? = variablesJson.getRaw()
 
-    private fun <T : Any> transformDefaultValue(
-        transform: (value: ValueNode) -> Any?,
-        defaultValue: ValueNode,
-        kClass: KClass<T>
-    ): T? {
-        val transformedDefaultValue = transform.invoke(defaultValue)
-        return when {
-            transformedDefaultValue == null -> null
-            kClass.isInstance(transformedDefaultValue) -> transformedDefaultValue as T?
-            else -> throw ExecutionException("Invalid transform function returned")
-        }
-    }
-
-    private fun validateVariable(
-        expectedType: TypeReference,
-        expectedTypeName: String?,
-        variable: VariableDefinitionNode
-    ) {
+    private fun validateVariable(expectedType: Type, variable: VariableDefinitionNode) {
         val variableType = variable.type
-
-        val invalidName = (expectedTypeName ?: expectedType.name) != variable.type.nameNode.value
-        val invalidIsList = expectedType.isList != variableType.isList
+        val invalidName = expectedType.unwrapped().name != variable.type.nameNode.value
+        val invalidIsList = expectedType.isList() != variableType.isList
         val invalidNullability =
-            !expectedType.isNullable && variableType.isNullable && variable.defaultValue == null
-
-        val invalidElementNullability = !expectedType.isElementNullable && when (variableType) {
+            !expectedType.isNullable() && variableType.isNullable && variable.defaultValue == null
+        val invalidElementNullability = !expectedType.isElementNullable() && when (variableType) {
             is TypeNode.ListTypeNode -> variableType.isElementNullable
             else -> false
         }
 
         if (invalidName || invalidIsList || invalidNullability || invalidElementNullability) {
             throw InvalidInputValueException(
-                "Invalid variable $${variable.variable.name.value} argument type ${variableType.nameNode.value}, expected $expectedType",
+                "Invalid variable $${variable.variable.name.value} argument type ${variableType.nameNode.value}, expected ${expectedType.typeReference()}",
                 variable
             )
         }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/request/VariablesJson.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/request/VariablesJson.kt
@@ -1,67 +1,35 @@
 package com.apurebase.kgraphql.request
 
-import com.apurebase.kgraphql.ExecutionException
-import com.apurebase.kgraphql.GraphQLError
-import com.apurebase.kgraphql.getIterableElementType
-import com.apurebase.kgraphql.isIterable
+import com.apurebase.kgraphql.helpers.toValueNode
 import com.apurebase.kgraphql.schema.model.ast.NameNode
-import com.fasterxml.jackson.databind.JavaType
+import com.apurebase.kgraphql.schema.model.ast.ValueNode
+import com.apurebase.kgraphql.schema.structure.Type
 import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.NullNode
-import com.fasterxml.jackson.databind.type.TypeFactory
-import kotlin.reflect.KClass
-import kotlin.reflect.KType
-import kotlin.reflect.jvm.jvmErasure
 
 /**
  * Represents already parsed variables json
  */
 interface VariablesJson {
 
-    fun <T : Any> get(kClass: KClass<T>, kType: KType, key: NameNode): T?
+    fun get(type: Type, key: NameNode): ValueNode?
 
     fun getRaw(): JsonNode?
 
     class Empty : VariablesJson {
-        override fun <T : Any> get(kClass: KClass<T>, kType: KType, key: NameNode): T? = null
+        override fun get(type: Type, key: NameNode): ValueNode? = null
 
         override fun getRaw(): JsonNode? = null
     }
 
-    class Defined(val objectMapper: ObjectMapper, val json: JsonNode) : VariablesJson {
-
-        constructor(objectMapper: ObjectMapper, json: String) : this(objectMapper, objectMapper.readTree(json))
-
-        /**
-         * Maps and returns object of requested [key] as [kClass]
-         */
-        override fun <T : Any> get(kClass: KClass<T>, kType: KType, key: NameNode): T? {
-            require(kClass == kType.jvmErasure) { "kClass and KType must represent same class" }
-            return json.let { node -> node[key.value] }?.let { tree ->
-                try {
-                    // TODO: Move away from jackson and only depend on kotlinx.serialization
-                    objectMapper.treeToValue<T>(tree, kType.toTypeReference())
-                } catch (e: GraphQLError) {
-                    throw e
-                } catch (e: Exception) {
-                    throw ExecutionException("Failed to coerce $tree as $kType", key, e)
-                }
-            }
+    class Defined(val json: JsonNode) : VariablesJson {
+        override fun get(type: Type, key: NameNode): ValueNode? {
+            return json.let { node -> node[key.value] }?.toValueNode(type)
         }
 
         /**
          * Returns the raw [json] unless it is a [NullNode]
          */
         override fun getRaw(): JsonNode? = json.takeUnless { it is NullNode }
-    }
-
-    fun KType.toTypeReference(): JavaType {
-        return if (jvmErasure.isIterable()) {
-            val elementType = getIterableElementType()
-            TypeFactory.defaultInstance().constructCollectionType(List::class.java, elementType.jvmErasure.java)
-        } else {
-            TypeFactory.defaultInstance().constructSimpleType(jvmErasure.java, emptyArray())
-        }
     }
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/DefaultSchema.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/DefaultSchema.kt
@@ -52,7 +52,7 @@ class DefaultSchema(
         }
 
         val parsedVariables = variables
-            ?.let { VariablesJson.Defined(configuration.objectMapper, variables) }
+            ?.let { VariablesJson.Defined(configuration.objectMapper.readTree(variables)) }
             ?: VariablesJson.Empty()
 
         val document = Parser(request).parseDocument()

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/ArgumentTransformer.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/ArgumentTransformer.kt
@@ -13,7 +13,6 @@ import com.apurebase.kgraphql.schema.structure.InputValue
 import com.apurebase.kgraphql.schema.structure.Type
 import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.full.primaryConstructor
-import kotlin.reflect.jvm.jvmErasure
 
 open class ArgumentTransformer {
 
@@ -76,14 +75,9 @@ open class ArgumentTransformer {
         // This parameter is used to track if we have seen a ListValueNode in the recursive call chain.
         coerceSingleValueAsList: Boolean
     ): Any? {
-        val kType = type.toKType()
-        val typeName = type.unwrapped().name
-
         return when {
             value is ValueNode.VariableNode -> {
-                variables.get(kType.jvmErasure, kType, typeName, value) { subValue ->
-                    transformValue(type, subValue, variables, coerceSingleValueAsList)
-                }
+                variables.get(type, value)?.let { transformValue(type, it, variables, coerceSingleValueAsList) }
             }
 
             // https://spec.graphql.org/October2021/#sec-List.Input-Coercion

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/DataLoaderPreparedRequestExecutor.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/DataLoaderPreparedRequestExecutor.kt
@@ -376,9 +376,9 @@ class DataLoaderPreparedRequestExecutor(val schema: DefaultSchema) : RequestExec
         coroutineScope {
             val result = deferredJsonBuilder(timeout = plan.options.timeout ?: schema.configuration.timeout) {
                 val ctx = ExecutionContext(
-                    Variables(schema, variables, plan.firstOrNull { it.variables != null }?.variables),
+                    Variables(variables, plan.firstOrNull { it.variables != null }?.variables),
                     context,
-                    plan.constructLoaders(),
+                    plan.constructLoaders()
                 )
 
                 "data" toDeferredObj {

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/ParallelRequestExecutor.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/ParallelRequestExecutor.kt
@@ -51,7 +51,7 @@ class ParallelRequestExecutor(val schema: DefaultSchema) : RequestExecutor {
             val data = root.putObject("data")
 
             val resultMap = plan.toMapAsync(dispatcher) {
-                val ctx = ExecutionContext(Variables(schema, variables, it.variables), context)
+                val ctx = ExecutionContext(Variables(variables, it.variables), context)
                 if (shouldInclude(ctx, it)) {
                     writeOperation(
                         isSubscription = plan.isSubscription,

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/introspection/__Type.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/introspection/__Type.kt
@@ -32,4 +32,9 @@ interface __Type {
         TypeKind.LIST -> "[${ofType?.typeReference()}]"
         else -> name ?: ""
     }
+
+    fun unwrapped(): __Type = when (kind) {
+        TypeKind.NON_NULL, TypeKind.LIST -> (ofType as __Type).unwrapped()
+        else -> this
+    }
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/RequestInterpreter.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/RequestInterpreter.kt
@@ -3,6 +3,7 @@ package com.apurebase.kgraphql.schema.structure
 import com.apurebase.kgraphql.ValidationException
 import com.apurebase.kgraphql.request.VariablesJson
 import com.apurebase.kgraphql.schema.DefaultSchema.Companion.OPERATION_NAME_PARAM
+import com.apurebase.kgraphql.schema.builtin.BuiltInScalars
 import com.apurebase.kgraphql.schema.directive.Directive
 import com.apurebase.kgraphql.schema.execution.Execution
 import com.apurebase.kgraphql.schema.execution.ExecutionOptions
@@ -21,10 +22,10 @@ import com.apurebase.kgraphql.schema.model.ast.SelectionNode.FragmentNode
 import com.apurebase.kgraphql.schema.model.ast.SelectionNode.FragmentNode.FragmentSpreadNode
 import com.apurebase.kgraphql.schema.model.ast.SelectionNode.FragmentNode.InlineFragmentNode
 import com.apurebase.kgraphql.schema.model.ast.SelectionSetNode
+import com.apurebase.kgraphql.schema.model.ast.ValueNode
 import com.apurebase.kgraphql.schema.model.ast.VariableDefinitionNode
 import com.apurebase.kgraphql.schema.model.ast.toArguments
 import java.util.Stack
-import kotlin.reflect.full.starProjectedType
 
 class RequestInterpreter(private val schemaModel: SchemaModel) {
 
@@ -317,10 +318,10 @@ class RequestInterpreter(private val schemaModel: SchemaModel) {
                     }
                 }.joinToString(prefix = "[", postfix = "]")
 
-                val operationName = requestedOperationName ?: (
-                    variables.get(String::class, String::class.starProjectedType, OPERATION_NAME_PARAM)
-                        ?: throw ValidationException("Must provide an operation name from: $operationNamesFound")
-                    )
+                val operationName = requestedOperationName ?: variables.get(
+                    BuiltInScalars.STRING.typeDef.toScalarType(),
+                    OPERATION_NAME_PARAM
+                )?.let { it as? ValueNode.StringValueNode }?.value
 
                 operations.firstOrNull { it.name?.value == operationName }
                     ?: throw ValidationException("Must provide an operation name from: $operationNamesFound, found $operationName")

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/Type.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/Type.kt
@@ -8,9 +8,6 @@ import com.apurebase.kgraphql.schema.introspection.__InputValue
 import com.apurebase.kgraphql.schema.introspection.__Type
 import com.apurebase.kgraphql.schema.model.TypeDef
 import kotlin.reflect.KClass
-import kotlin.reflect.KType
-import kotlin.reflect.KTypeProjection
-import kotlin.reflect.full.createType
 
 interface Type : __Type {
 
@@ -24,7 +21,7 @@ interface Type : __Type {
 
     operator fun get(name: String): Field? = null
 
-    fun unwrapped(): Type = when (kind) {
+    override fun unwrapped(): Type = when (kind) {
         TypeKind.NON_NULL, TypeKind.LIST -> (ofType as Type).unwrapped()
         else -> this
     }
@@ -59,21 +56,6 @@ interface Type : __Type {
     fun isElementNullable() = isList() && unwrapList().kind != TypeKind.NON_NULL
 
     fun isInstance(value: Any?): Boolean = kClass?.isInstance(value) ?: false
-
-    fun toKType(): KType {
-        val unwrappedKClass: KClass<*> = requireNotNull(unwrapped().kClass) {
-            "This type cannot be represented as KType"
-        }
-
-        return if (isList()) {
-            listType().kClass.createType(
-                arguments = listOf(KTypeProjection.covariant(unwrappedKClass.createType(nullable = isElementNullable()))),
-                nullable = isNullable()
-            )
-        } else {
-            unwrappedKClass.createType(nullable = isNullable())
-        }
-    }
 
     val kClass: KClass<*>?
 

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/BaseSchemaTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/BaseSchemaTest.kt
@@ -30,6 +30,10 @@ abstract class BaseSchemaTest {
     val davidFincher = Director("David Fincher", 43, listOf(bradPitt, morganFreeman, kevinSpacey))
     val se7en = Film(Id("Se7en", 1995), 1995, "Se7en", davidFincher)
 
+    // test film 3
+    val martinScorsese = Director("Martin Scorsese", 82, listOf())
+    val theBigShave = Film(Id("The Big Shave", 1967), 1967, "The Big Shave", martinScorsese, FilmType.SHORT_LENGTH)
+
     val rickyGervais = Actor("Ricky Gervais", 58)
 
     // new actors created via mutations in schema
@@ -43,6 +47,10 @@ abstract class BaseSchemaTest {
         query("number") {
             description = "returns little of big number"
             resolver { big: Boolean -> if (big) 10000 else 0 }
+        }
+        query("float") {
+            description = "returns the given float"
+            resolver { float: Float -> float }
         }
         query("film") {
             description = "mock film"
@@ -84,17 +92,18 @@ abstract class BaseSchemaTest {
                 when (rank) {
                     1 -> prestige
                     2 -> se7en
+                    3 -> theBigShave
                     else -> null
                 }
             }
         }
         query("filmsByType") {
             description = "film categorized by type"
-            resolver { type: FilmType -> listOf(prestige, se7en) }
+            resolver { type: FilmType -> listOf(prestige, se7en, theBigShave).filter { it.type == type } }
         }
         query("people") {
             description = "List of all people"
-            resolver { -> listOf(davidFincher, bradPitt, morganFreeman, christianBale, christopherNolan) }
+            resolver { -> listOf(davidFincher, bradPitt, morganFreeman, christianBale, christopherNolan, martinScorsese) }
         }
         query("randomPerson") {
             description = "not really random person"

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/InputValuesSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/InputValuesSpecificationTest.kt
@@ -50,6 +50,20 @@ class InputValuesSpecificationTest {
         assertThat(response.extract<Int>("data/Int"), equalTo(input))
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = ["42.0", "\"foo\"", "bar"])
+    @Specification("2.9.1 Int Value")
+    fun `Invalid Int input value`(value: String) {
+        invoking {
+            deserialize(schema.executeBlocking("{ Int(value: $value) }"))
+        } shouldThrow GraphQLError::class with {
+            message shouldBeEqualTo "Cannot coerce $value to numeric constant"
+            extensions shouldBeEqualTo mapOf(
+                "type" to "BAD_USER_INPUT"
+            )
+        }
+    }
+
     @Test
     @Specification("2.9.2 Float Value")
     fun `Float input value`() {

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/QueryDocumentSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/QueryDocumentSpecificationTest.kt
@@ -38,7 +38,7 @@ class QueryDocumentSpecificationTest {
     fun `must provide operation name when multiple named operations`() {
         invoking {
             deserialize(schema.executeBlocking("query FIZZ {fizz} mutation BUZZ {createActor(name : \"Kurt Russel\"){name}}"))
-        } shouldThrow GraphQLError::class withMessage "Must provide an operation name from: [FIZZ, BUZZ]"
+        } shouldThrow GraphQLError::class withMessage "Must provide an operation name from: [FIZZ, BUZZ], found null"
     }
 
     @Test

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/ListsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/ListsSpecificationTest.kt
@@ -69,7 +69,7 @@ class ListsSpecificationTest {
         invoking {
             schema.executeBlocking("query(\$list: [String!]!) { list(list: \$list) }", variables)
         } shouldThrow GraphQLError::class withMessage
-            "Invalid argument value [GAGA, null, DADA, PADA] from variable \$list, expected list with non-null arguments"
+            "argument 'null' is not valid value of type String"
     }
 
     @Test
@@ -206,7 +206,7 @@ class ListsSpecificationTest {
         )
         assertThat(
             mutationResponse.toString(),
-            equalTo("{data={addObject={list=[foo, bar, foo, bar], set=[bar, foo]}}}")
+            equalTo("{data={addObject={list=[foo, bar, foo, bar], set=[foo, bar]}}}")
         )
     }
 


### PR DESCRIPTION
Previously, KGraphQL had two different ways of instantiating objects:

1. When providing objects directly in the request, they were created in the `ArgumentTransformer` by calling their primary constructor
2. When providing objects via variables, they were created via Jackson

This aligns both implementations to use the `ArgumentTransformer`, consolidating functionality and allowing us to get rid of Jackson in the variables completely.

Caveat: As previously Jackson was also doing input coercion (by e.g. silently handling "1.0" as Int), this may unintentionally alter runtime behavior in case of missing test coverage.