### PR TITLE
feat: Allow property renaming

### DIFF
--- a/docs/content/Reference/Type System/objects-and-interfaces.md
+++ b/docs/content/Reference/Type System/objects-and-interfaces.md
@@ -59,12 +59,12 @@ KGraphQL.schema {
 ## Kotlin Properties
 
 Kotlin properties are automatically inspected during schema creation. Schema DSL allows ignoring
-and [deprecation](../deprecation.md) of kotlin properties
+and [deprecation](../deprecation.md) of kotlin properties as well as renaming.
 
 *Example*
 
 ```kotlin
-data class Person(val name: String, val age: Int)
+data class Person(val firstName: String, val lastName: String, val name: String, val age: Int)
 
 KGraphQL.schema {
     type<Person>{
@@ -72,9 +72,20 @@ KGraphQL.schema {
             ignore = true
         }
         property(Person::name){
-            deprecate("Person need no name")
+            name = "fullName"
+            deprecate("Use firstName and lastName")
         }
     }
+}
+```
+
+*Resulting SDL*
+
+```graphql
+type Person {
+  firstName: String!
+  fullName: String! @deprecated(reason: "Use firstName and lastName")
+  lastName: String!
 }
 ```
 
@@ -254,5 +265,5 @@ This feature can be used in production but does currently have some issues:
 1. The `useDefaultPrettyPrint` doesn't work
 1. Order of fields are not guaranteed to match the order that was requested
 1. Custom generic type resolvers are not supported
-1. Other than that it should work as expected
 1. Schema stitching is not supported
+1. Other than that it should work as expected

--- a/kgraphql/api/kgraphql.api
+++ b/kgraphql/api/kgraphql.api
@@ -564,7 +564,9 @@ public final class com/apurebase/kgraphql/schema/dsl/KotlinPropertyDSL : com/apu
 	public fun <init> (Lkotlin/reflect/KProperty1;Lkotlin/jvm/functions/Function1;)V
 	public final fun accessRule (Lkotlin/jvm/functions/Function2;)V
 	public final fun getIgnore ()Z
+	public final fun getName ()Ljava/lang/String;
 	public final fun setIgnore (Z)V
+	public final fun setName (Ljava/lang/String;)V
 	public final fun toKQLProperty ()Lcom/apurebase/kgraphql/schema/model/PropertyDef$Kotlin;
 }
 
@@ -1373,14 +1375,15 @@ public final class com/apurebase/kgraphql/schema/model/Increment : com/apurebase
 }
 
 public final class com/apurebase/kgraphql/schema/model/InputValueDef : com/apurebase/kgraphql/schema/model/Depreciable, com/apurebase/kgraphql/schema/model/DescribedDef {
-	public fun <init> (Lkotlin/reflect/KClass;Ljava/lang/String;Ljava/lang/Object;ZLjava/lang/String;Ljava/lang/String;Lkotlin/reflect/KType;)V
-	public synthetic fun <init> (Lkotlin/reflect/KClass;Ljava/lang/String;Ljava/lang/Object;ZLjava/lang/String;Ljava/lang/String;Lkotlin/reflect/KType;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lkotlin/reflect/KClass;Ljava/lang/String;Ljava/lang/Object;ZLjava/lang/String;Ljava/lang/String;Lkotlin/reflect/KType;Ljava/lang/String;)V
+	public synthetic fun <init> (Lkotlin/reflect/KClass;Ljava/lang/String;Ljava/lang/Object;ZLjava/lang/String;Ljava/lang/String;Lkotlin/reflect/KType;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getDefaultValue ()Ljava/lang/Object;
 	public fun getDeprecationReason ()Ljava/lang/String;
 	public fun getDescription ()Ljava/lang/String;
 	public final fun getKClass ()Lkotlin/reflect/KClass;
 	public final fun getKType ()Lkotlin/reflect/KType;
 	public final fun getName ()Ljava/lang/String;
+	public final fun getParameterName ()Ljava/lang/String;
 	public fun isDeprecated ()Z
 }
 
@@ -1454,8 +1457,8 @@ public class com/apurebase/kgraphql/schema/model/PropertyDef$Function : com/apur
 }
 
 public class com/apurebase/kgraphql/schema/model/PropertyDef$Kotlin : com/apurebase/kgraphql/schema/model/Definition, com/apurebase/kgraphql/schema/model/PropertyDef {
-	public fun <init> (Lkotlin/reflect/KProperty1;Ljava/lang/String;ZLjava/lang/String;Lkotlin/jvm/functions/Function2;Z)V
-	public synthetic fun <init> (Lkotlin/reflect/KProperty1;Ljava/lang/String;ZLjava/lang/String;Lkotlin/jvm/functions/Function2;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lkotlin/reflect/KProperty1;Ljava/lang/String;ZLjava/lang/String;Lkotlin/jvm/functions/Function2;ZLjava/lang/String;)V
+	public synthetic fun <init> (Lkotlin/reflect/KProperty1;Ljava/lang/String;ZLjava/lang/String;Lkotlin/jvm/functions/Function2;ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getAccessRule ()Lkotlin/jvm/functions/Function2;
 	public fun getDeprecationReason ()Ljava/lang/String;
 	public fun getDescription ()Ljava/lang/String;
@@ -2259,6 +2262,7 @@ public final class com/apurebase/kgraphql/schema/structure/InputValue : com/apur
 	public fun getDeprecationReason ()Ljava/lang/String;
 	public fun getDescription ()Ljava/lang/String;
 	public fun getName ()Ljava/lang/String;
+	public final fun getParameterName ()Ljava/lang/String;
 	public synthetic fun getType ()Lcom/apurebase/kgraphql/schema/introspection/__Type;
 	public fun getType ()Lcom/apurebase/kgraphql/schema/structure/Type;
 	public fun isDeprecated ()Z

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/KotlinPropertyDSL.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/KotlinPropertyDSL.kt
@@ -9,14 +9,17 @@ class KotlinPropertyDSL<T : Any, R>(
     block: KotlinPropertyDSL<T, R>.() -> Unit
 ) : LimitedAccessItemDSL<T>() {
 
+    // Whether this property should be ignored, i.e. hidden from GraphQL
     var ignore = false
+
+    // Custom name for this property, otherwise taken from the [kProperty]
+    var name: String? = null
 
     init {
         block()
     }
 
     fun accessRule(rule: (T, Context) -> Exception?) {
-
         val accessRuleAdapter: (T?, Context) -> Exception? = { parent, ctx ->
             if (parent != null) rule(
                 parent,
@@ -25,7 +28,6 @@ class KotlinPropertyDSL<T : Any, R>(
                 IllegalArgumentException("Unexpected null parent of kotlin property")
             }
         }
-
         accessRuleBlock = accessRuleAdapter
     }
 
@@ -35,6 +37,7 @@ class KotlinPropertyDSL<T : Any, R>(
         isDeprecated = isDeprecated,
         deprecationReason = deprecationReason,
         isIgnored = ignore,
-        accessRule = accessRuleBlock
+        accessRule = accessRuleBlock,
+        customName = name
     )
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/ArgumentTransformer.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/ArgumentTransformer.kt
@@ -114,7 +114,8 @@ open class ArgumentTransformer {
                             value
                         )
 
-                    constructorParametersByName[fieldName] to transformValue(
+                    val parameterName = (inputField as? InputValue<*>)?.parameterName ?: fieldName
+                    constructorParametersByName[parameterName] to transformValue(
                         paramType,
                         valueField.value,
                         variables,
@@ -136,7 +137,9 @@ open class ArgumentTransformer {
                         parameter to null
                     } else {
                         // Value was not provided and parameter is required: error
-                        missingNonOptionalInputs.add(name ?: "Parameter #${parameter.index}")
+                        val inputField =
+                            type.unwrapped().inputFields?.firstOrNull { (it as? InputValue<*>)?.parameterName == name }
+                        missingNonOptionalInputs.add(inputField?.name ?: name ?: "Parameter #${parameter.index}")
                         null
                     }
                 }.toMap()

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/InputValueDef.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/InputValueDef.kt
@@ -1,6 +1,7 @@
 package com.apurebase.kgraphql.schema.model
 
 import kotlin.reflect.KClass
+import kotlin.reflect.KParameter
 import kotlin.reflect.KType
 
 class InputValueDef<T : Any>(
@@ -10,5 +11,6 @@ class InputValueDef<T : Any>(
     override val isDeprecated: Boolean = false,
     override val description: String? = null,
     override val deprecationReason: String? = null,
-    val kType: KType? = null
+    val kType: KType? = null,
+    val parameterName: String = name
 ) : DescribedDef, Depreciable

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/PropertyDef.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/PropertyDef.kt
@@ -43,8 +43,9 @@ interface PropertyDef<T> : Depreciable, DescribedDef {
         override val isDeprecated: Boolean = false,
         override val deprecationReason: String? = null,
         override val accessRule: ((T?, Context) -> Exception?)? = null,
-        val isIgnored: Boolean = false
-    ) : Definition(kProperty.name), PropertyDef<T>
+        val isIgnored: Boolean = false,
+        customName: String? = null
+    ) : Definition(customName ?: kProperty.name), PropertyDef<T>
 
     class Union<T>(
         name: String,

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/InputValue.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/InputValue.kt
@@ -19,4 +19,6 @@ class InputValue<T : Any>(
     override val deprecationReason: String? = valueDef.deprecationReason
 
     val default: T? = valueDef.defaultValue
+
+    val parameterName: String = valueDef.parameterName
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/InputObjectTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/InputObjectTest.kt
@@ -1,0 +1,182 @@
+package com.apurebase.kgraphql.integration
+
+import com.apurebase.kgraphql.KGraphQL
+import com.apurebase.kgraphql.schema.SchemaException
+import org.amshove.kluent.invoking
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldThrow
+import org.amshove.kluent.withMessage
+import org.junit.jupiter.api.Test
+
+class InputObjectTest {
+    data class Person(val name: String, val age: Int)
+
+    @Test
+    fun `property name should default to Kotlin name`() {
+        val schema = KGraphQL.schema {
+            inputType<Person> {
+                name = "PersonInput"
+            }
+
+            query("getPerson") {
+                resolver { name: String -> Person(name = name, age = 42) }
+            }
+
+            mutation("addPerson") {
+                resolver { person: Person -> person }
+            }
+        }
+
+        val sdl = schema.printSchema()
+        sdl shouldBeEqualTo """
+            type Mutation {
+              addPerson(person: PersonInput!): Person!
+            }
+            
+            type Person {
+              age: Int!
+              name: String!
+            }
+            
+            type Query {
+              getPerson(name: String!): Person!
+            }
+            
+            input PersonInput {
+              age: Int!
+              name: String!
+            }
+            
+        """.trimIndent()
+
+        schema.executeBlocking(
+            """
+            query {
+              getPerson(name: "foo") { name age }
+            }
+        """.trimIndent()
+        ) shouldBeEqualTo """
+            {"data":{"getPerson":{"name":"foo","age":42}}}
+        """.trimIndent()
+
+        schema.executeBlocking(
+            """
+            mutation {
+              addPerson(person: { name: "bar", age: 20 }) { name age }
+            }
+        """.trimIndent()
+        ) shouldBeEqualTo """
+            {"data":{"addPerson":{"name":"bar","age":20}}}
+        """.trimIndent()
+
+        val variables = """
+            { "person": { "name": "foobar", "age": 60 } }
+        """.trimIndent()
+        schema.executeBlocking(
+            """
+            mutation(${'$'}person: PersonInput!) {
+              addPerson(person: ${'$'}person) { name age }
+            }
+        """.trimIndent(),
+            variables = variables
+        ) shouldBeEqualTo """
+            {"data":{"addPerson":{"name":"foobar","age":60}}}
+        """.trimIndent()
+    }
+
+    @Test
+    fun `property name should be configurable`() {
+        val schema = KGraphQL.schema {
+            inputType<Person> {
+                name = "PersonInput"
+                property(Person::age) {
+                    name = "inputAge"
+                }
+                property(Person::name) {
+                    name = "inputName"
+                }
+            }
+
+            query("getPerson") {
+                resolver { name: String -> Person(name = name, age = 42) }
+            }
+
+            mutation("addPerson") {
+                resolver { person: Person -> person }
+            }
+        }
+
+        val sdl = schema.printSchema()
+        sdl shouldBeEqualTo """
+            type Mutation {
+              addPerson(person: PersonInput!): Person!
+            }
+            
+            type Person {
+              age: Int!
+              name: String!
+            }
+            
+            type Query {
+              getPerson(name: String!): Person!
+            }
+            
+            input PersonInput {
+              inputAge: Int!
+              inputName: String!
+            }
+            
+        """.trimIndent()
+
+        schema.executeBlocking(
+            """
+            query {
+              getPerson(name: "foo") { name age }
+            }
+        """.trimIndent()
+        ) shouldBeEqualTo """
+            {"data":{"getPerson":{"name":"foo","age":42}}}
+        """.trimIndent()
+
+        schema.executeBlocking(
+            """
+            mutation {
+              addPerson(person: { inputName: "bar", inputAge: 20 }) { name age }
+            }
+        """.trimIndent()
+        ) shouldBeEqualTo """
+            {"data":{"addPerson":{"name":"bar","age":20}}}
+        """.trimIndent()
+
+        val variables = """
+            { "person": { "inputName": "foobar", "inputAge": 60 } }
+        """.trimIndent()
+        schema.executeBlocking(
+            """
+            mutation(${'$'}person: PersonInput!) {
+              addPerson(person: ${'$'}person) { name age }
+            }
+        """.trimIndent(),
+            variables = variables
+        ) shouldBeEqualTo """
+            {"data":{"addPerson":{"name":"foobar","age":60}}}
+        """.trimIndent()
+    }
+
+    @Test
+    fun `property name must not start with __ when configured`() {
+        invoking {
+            KGraphQL.schema {
+                inputType<Person> {
+                    property(Person::name) {
+                        name = "__name"
+                    }
+                }
+
+                query("getPerson") {
+                    resolver { person: Person -> person }
+                }
+            }
+        } shouldThrow SchemaException::class withMessage "Illegal name '__name'. Names starting with '__' are reserved for introspection system"
+    }
+}

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/ObjectTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/ObjectTest.kt
@@ -1,0 +1,103 @@
+package com.apurebase.kgraphql.integration
+
+import com.apurebase.kgraphql.KGraphQL
+import com.apurebase.kgraphql.schema.SchemaException
+import org.amshove.kluent.invoking
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldThrow
+import org.amshove.kluent.withMessage
+import org.junit.jupiter.api.Test
+
+class ObjectTest {
+    data class Person(val name: String, val age: Int)
+
+    @Test
+    fun `property name should default to Kotlin name`() {
+        val schema = KGraphQL.schema {
+            query("getPerson") {
+                resolver { name: String -> Person(name = name, age = 42) }
+            }
+        }
+
+        val sdl = schema.printSchema()
+        sdl shouldBeEqualTo """
+            type Person {
+              age: Int!
+              name: String!
+            }
+            
+            type Query {
+              getPerson(name: String!): Person!
+            }
+            
+        """.trimIndent()
+
+        schema.executeBlocking(
+            """
+            query {
+              getPerson(name: "foo") { name age }
+            }
+        """.trimIndent()
+        ) shouldBeEqualTo """
+            {"data":{"getPerson":{"name":"foo","age":42}}}
+        """.trimIndent()
+    }
+
+    @Test
+    fun `property name should be configurable`() {
+        val schema = KGraphQL.schema {
+            type<Person> {
+                property(Person::age) {
+                    name = "newAge"
+                }
+                property(Person::name) {
+                    name = "newName"
+                }
+            }
+
+            query("getPerson") {
+                resolver { name: String -> Person(name = name, age = 42) }
+            }
+        }
+
+        val sdl = schema.printSchema()
+        sdl shouldBeEqualTo """
+            type Person {
+              newAge: Int!
+              newName: String!
+            }
+            
+            type Query {
+              getPerson(name: String!): Person!
+            }
+            
+        """.trimIndent()
+
+        schema.executeBlocking(
+            """
+            query {
+              getPerson(name: "foo") { newName newAge }
+            }
+        """.trimIndent()
+        ) shouldBeEqualTo """
+            {"data":{"getPerson":{"newName":"foo","newAge":42}}}
+        """.trimIndent()
+    }
+
+    @Test
+    fun `property name must not start with __ when configured`() {
+        invoking {
+            KGraphQL.schema {
+                type<Person> {
+                    property(Person::name) {
+                        name = "__name"
+                    }
+                }
+
+                query("getPerson") {
+                    resolver { name: String -> Person(name = name, age = 42) }
+                }
+            }
+        } shouldThrow SchemaException::class withMessage "Illegal name '__name'. Names starting with '__' are reserved for introspection system"
+    }
+}

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/VariablesSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/VariablesSpecificationTest.kt
@@ -153,7 +153,7 @@ class VariablesSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `Advanced variables`() {
+    fun `advanced variables`() {
         val d = "$"
         val request = """
             mutation MultipleCreate(
@@ -198,7 +198,6 @@ class VariablesSpecificationTest : BaseSchemaTest() {
         """.trimIndent()
 
         val result = execute(request, variables)
-
 
         assertNoErrors(result)
         assertThat(result.extract("data/createFirst/name"), equalTo("Jógvan"))

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/NonNullSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/NonNullSpecificationTest.kt
@@ -134,6 +134,11 @@ class NonNullSpecificationTest {
     @Test
     fun `missing non-nullable values without Kotlin default values should raise an error`() {
         val schema = KGraphQL.schema {
+            inputType<MyInput> {
+                property(MyInput::value1) {
+                    name = "valueOne"
+                }
+            }
             query("main") {
                 resolver { input: MyInput -> "${input.value1} - ${input.value2 ?: "Nada"} - ${input.value3}" }
             }
@@ -148,7 +153,7 @@ class NonNullSpecificationTest {
                 """.trimIndent()
             )
         } shouldThrow GraphQLError::class with {
-            message shouldBeEqualTo "Missing non-optional input fields: value1, value3"
+            message shouldBeEqualTo "Missing non-optional input fields: valueOne, value3"
         }
     }
 


### PR DESCRIPTION
Allows existing (Kotlin) properties of objects and input objects to be renamed via DSL.

Resolves #166