### PR TITLE
feat!: Automatic input type naming

### DIFF
--- a/docs/content/Reference/Type System/input-objects.md
+++ b/docs/content/Reference/Type System/input-objects.md
@@ -20,9 +20,6 @@ class NonDataClass(param1: String = "Hello", val param3: Boolean?) {
 }
 
 val schema = KGraphQL.schema {
-    inputType<NonDataClass> {
-        name = "NonDataClassInput"
-    }
     query("test") {
         resolver { input: NonDataClass -> input }
     }
@@ -47,6 +44,86 @@ input NonDataClassInput {
 }
 ```
 
+## Input Type Name
+
+To avoid equal names between input and query types, input types get an automated `"Input"` suffix unless their name
+already ends with `"Input"` or they have explicit configuration in the DSL via `inputType {}`.
+
+*Example*
+
+```kotlin
+schema {
+    mutation("addType") {
+        resolver { input: Type -> input }
+    }
+    mutation("addFoo") {
+        resolver { input: FooInput -> Foo(input.name) }
+    }
+}
+```
+
+In this case, the input type `Type` will automatically be renamed to `TypeInput` but `FooInput` will not become
+`FooInputInput`:
+
+```graphql
+type Foo {
+  name: String!
+}
+
+type Mutation {
+  addFoo(input: FooInput!): Foo!
+  addType(input: TypeInput!): Type!
+}
+
+type Type {
+  name: String!
+}
+
+input FooInput {
+  name: String!
+}
+
+input TypeInput {
+  name: String!
+}
+```
+
+This behavior applies recursively to nested types as well:
+
+```kotlin
+schema {
+    mutation("addParent") {
+        resolver { input: ParentType -> input }
+    }
+}
+```
+
+The nested `ChildType` will also be renamed to `ChildTypeInput`:
+
+```graphql
+type ChildType {
+  childName: String!
+}
+
+type Mutation {
+  addParent(input: ParentTypeInput!): ParentType!
+}
+
+type ParentType {
+  child: ChildType!
+  parentName: String!
+}
+
+input ChildTypeInput {
+  childName: String!
+}
+
+input ParentTypeInput {
+  child: ChildTypeInput!
+  parentName: String!
+}
+```
+
 ## Runtime
 
 Input Objects are instantiated via their primary constructor. Kotlin default values are used unless a different value
@@ -66,6 +143,52 @@ inputType<InputObject> {
     InputObject::foo.configure {
         deprecate("Deprecated old input value")
     }
+}
+```
+
+Whenever an input type is configured via DSL the automatic suffix will *not* be appended, regardless of the name.
+
+*Example*
+
+```kotlin
+schema {
+    mutation("addType") {
+        resolver { input: InputType -> Type(input.name) }
+    }
+    mutation("addParent") {
+        resolver { input: ParentType -> input }
+    }
+    inputType<InputType>()
+    inputType<ParentType> {
+        name = "MyParentInputType"
+    }
+}
+```
+
+Both, `InputType` and `ParentType` are explicitly configured, and therefore will keep their original name (a custom
+`name` is not required). 
+
+```graphql
+type ChildType {
+  childName: String!
+}
+
+type Mutation {
+  addParent(input: MyParentInputType!): ParentType!
+}
+
+type ParentType {
+  child: ChildType!
+  parentName: String!
+}
+
+input ChildTypeInput {
+  childName: String!
+}
+
+input MyParentInputType {
+  child: ChildTypeInput!
+  parentName: String!
 }
 ```
 

--- a/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/execution/StitchedSchemaExecutionTest.kt
+++ b/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/execution/StitchedSchemaExecutionTest.kt
@@ -127,9 +127,6 @@ class StitchedSchemaExecutionTest {
     }
 
     private fun SchemaBuilder.complexRemoteSchema2WithInputObject() = run {
-        inputType<Child> {
-            name = "ChildInput"
-        }
         query("remote2") {
             resolver { inputObject: Child? -> inputObject?.let { Remote2(inputObject.childFoo, 13) } }
         }
@@ -1001,9 +998,6 @@ class StitchedSchemaExecutionTest {
             query("remote1") {
                 resolver { -> "dummy" }
             }
-            inputType<Remote1> {
-                name = "Remote1Input"
-            }
             enum<RemoteEnum>()
             mutation("objectMutation") {
                 resolver { input: Remote1 -> input.copy(foo1 = "${input.foo1}-processed") }
@@ -1196,9 +1190,6 @@ class StitchedSchemaExecutionTest {
 
         fun SchemaBuilder.remoteSchema1WithVariables() = run {
             enum<RemoteEnum>()
-            inputType<VariableObject> {
-                name = "VariableObjectInput"
-            }
             query("getBoolean") {
                 resolver { toGet: Boolean -> toGet }
             }

--- a/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/structure/IntrospectedSchemaTest.kt
+++ b/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/structure/IntrospectedSchemaTest.kt
@@ -25,9 +25,6 @@ class IntrospectedSchemaTest {
             query("getEnum") {
                 resolver { -> TestEnum.TYPE1 }
             }
-            inputType<TestObject> {
-                name = "TestObjectInput"
-            }
             mutation("add") {
                 resolver { input: TestObject -> input }
             }

--- a/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/structure/StitchedSchemaTest.kt
+++ b/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/structure/StitchedSchemaTest.kt
@@ -367,9 +367,6 @@ class StitchedSchemaTest {
                     query("dummy") {
                         resolver { -> "dummy" }
                     }
-                    inputType<TestObject> {
-                        name = "TestObjectInput"
-                    }
                     mutation("add") {
                         resolver { input: TestObject -> input }
                     }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/SchemaCompilation.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/SchemaCompilation.kt
@@ -353,7 +353,13 @@ open class SchemaCompilation(
             ?: throw SchemaException("Java class '${kClass.simpleName}' as inputType is not supported")
 
         val inputObjectDef =
-            definition.inputObjects.find { it.kClass == kClass } ?: TypeDef.Input(kClass.defaultKQLTypeName(), kClass)
+            definition.inputObjects.find { it.kClass == kClass } ?: TypeDef.Input(kClass.defaultKQLTypeName().let {
+                if (it.endsWith("Input")) {
+                    it
+                } else {
+                    "${it}Input"
+                }
+            }, kClass)
         val objectType = Type.Input(inputObjectDef)
         val typeProxy = TypeProxy(objectType)
         inputTypeProxies[kClass] = typeProxy

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/BaseSchemaTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/BaseSchemaTest.kt
@@ -232,10 +232,6 @@ abstract class BaseSchemaTest {
             }
         }
 
-        inputType<Actor> {
-            name = "ActorInput"
-        }
-
         mutation("createActorWithAliasedInputType") {
             description = "create new actor from full fledged ActorInput as input type"
             resolver { newActor: Actor ->

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/InputObjectTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/InputObjectTest.kt
@@ -14,10 +14,6 @@ class InputObjectTest {
     @Test
     fun `property name should default to Kotlin name`() {
         val schema = KGraphQL.schema {
-            inputType<Person> {
-                name = "PersonInput"
-            }
-
             query("getPerson") {
                 resolver { name: String -> Person(name = name, age = 42) }
             }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/github/GitHubIssue137.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/github/GitHubIssue137.kt
@@ -15,6 +15,7 @@ class GitHubIssue137 {
     fun `testing abc`() {
         KGraphQL.schema {
             configure { wrapErrors = false }
+            inputType<InputType>()
             query("search") {
                 resolver { criteria: Criteria ->
                     criteria.inputs.joinToString { "${it.id}_${it.id2}: ${it.value}" }
@@ -33,8 +34,6 @@ class GitHubIssue137 {
                     ]
                 }
             """
-        ).also(::println)
-            .deserialize()
-            .extract<String>("data/search") shouldBeEqualTo "1_2: Search"
+        ).deserialize().extract<String>("data/search") shouldBeEqualTo "1_2: Search"
     }
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaPrinterTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaPrinterTest.kt
@@ -254,9 +254,6 @@ class SchemaPrinterTest {
             query("dummy") {
                 resolver { -> "dummy" }
             }
-            inputType<TestObject> {
-                name = "TestObjectInput"
-            }
             mutation("add") {
                 resolver { input: TestObject -> input }
             }
@@ -645,9 +642,6 @@ class SchemaPrinterTest {
                 property(TestObject::name) {
                     description = "This is the name"
                 }
-            }
-            inputType<TestObject> {
-                name = "TestObjectInput"
             }
             enum<TestEnum> {
                 value(TestEnum.TYPE1) {

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/InputObjectsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/InputObjectsSpecificationTest.kt
@@ -103,9 +103,6 @@ class InputObjectsSpecificationTest {
     @Test
     fun `input objects should take fields from primary constructor`() {
         val schema = KGraphQL.schema {
-            inputType<NonDataClass> {
-                name = "NonDataClassInput"
-            }
             query("test") {
                 resolver { input: NonDataClass -> input }
             }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/ListsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/ListsSpecificationTest.kt
@@ -150,9 +150,6 @@ class ListsSpecificationTest {
             mutation("addObject") {
                 resolver { input: TestObject -> input }
             }
-            inputType<TestObject> {
-                name = "TestObjectInput"
-            }
         }
         val queryResponse = deserialize(schema.executeBlocking("{ getObject { list set } }"))
         assertThat(queryResponse.toString(), equalTo("{data={getObject={list=[foo, bar, foo, bar], set=[foo, bar]}}}"))
@@ -183,9 +180,6 @@ class ListsSpecificationTest {
             }
             mutation("addObject") {
                 resolver { input: TestObject -> input }
-            }
-            inputType<TestObject> {
-                name = "TestObjectInput"
             }
         }
         val variables = """

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/ScalarsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/ScalarsSpecificationTest.kt
@@ -364,7 +364,7 @@ class ScalarsSpecificationTest {
                 }
             }
 
-            inputType<NewPart> {}
+            inputType<NewPart>()
         }
 
         val manufacturer = """Joe Bloggs"""

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/TypeSystemSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/TypeSystemSpecificationTest.kt
@@ -4,30 +4,231 @@ import com.apurebase.kgraphql.KGraphQL.Companion.schema
 import com.apurebase.kgraphql.Specification
 import com.apurebase.kgraphql.expect
 import com.apurebase.kgraphql.schema.SchemaException
+import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
 @Specification("3 Type System")
 class TypeSystemSpecificationTest {
 
     class String
-
+    class Type(val name: kotlin.String)
+    class TypeInput(val name: kotlin.String)
+    class InputType(val name: kotlin.String)
+    class ParentType(val parentName: kotlin.String, val child: ChildType)
+    class ChildType(val childName: kotlin.String)
     class __Type
 
     @Test
-    fun `All types within a GraphQL schema must have unique names`() {
+    fun `all types within a GraphQL schema must have unique names`() {
         expect<SchemaException>("Cannot add Object type with duplicated name String") {
             schema {
-                type<TypeSystemSpecificationTest.String>()
+                type<String>()
+            }
+        }
+        expect<SchemaException>("Cannot add Object type with duplicated name String") {
+            schema {
+                type<Type> {
+                    name = "String"
+                }
+            }
+        }
+        expect<SchemaException>("Cannot add Input type with duplicated name String") {
+            schema {
+                inputType<Type> {
+                    name = "String"
+                }
+            }
+        }
+        expect<SchemaException>("Cannot add Input type with duplicated name Type") {
+            schema {
+                type<Type>()
+                inputType<Type>()
             }
         }
     }
 
     @Test
-    fun `All types and directives defined within a schema must not have a name which begins with __`() {
+    fun `all types and directives defined within a schema must not have a name which begins with __`() {
         expect<SchemaException>("Type name starting with \"__\" are excluded for introspection system") {
             schema {
                 type<__Type>()
             }
         }
+        expect<SchemaException>("Type name starting with \"__\" are excluded for introspection system") {
+            schema {
+                type<Type> {
+                    name = "__Type"
+                }
+            }
+        }
+        expect<SchemaException>("Type name starting with \"__\" are excluded for introspection system") {
+            schema {
+                inputType<__Type>()
+            }
+        }
+        expect<SchemaException>("Type name starting with \"__\" are excluded for introspection system") {
+            schema {
+                inputType<Type> {
+                    name = "__Type"
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `input types should automatically get Input suffix if needed`() {
+        val schema = schema {
+            query("queryType") {
+                resolver { -> Type("type") }
+            }
+            query("queryParent") {
+                resolver { -> ParentType("parent", ChildType("child")) }
+            }
+            mutation("addType") {
+                resolver { input: Type -> input }
+            }
+            mutation("addParent") {
+                resolver { input: ParentType -> input }
+            }
+        }
+
+        val sdl = schema.printSchema()
+        sdl shouldBeEqualTo """
+            type ChildType {
+              childName: String!
+            }
+            
+            type Mutation {
+              addParent(input: ParentTypeInput!): ParentType!
+              addType(input: TypeInput!): Type!
+            }
+            
+            type ParentType {
+              child: ChildType!
+              parentName: String!
+            }
+            
+            type Query {
+              queryParent: ParentType!
+              queryType: Type!
+            }
+            
+            type Type {
+              name: String!
+            }
+            
+            input ChildTypeInput {
+              childName: String!
+            }
+            
+            input ParentTypeInput {
+              child: ChildTypeInput!
+              parentName: String!
+            }
+            
+            input TypeInput {
+              name: String!
+            }
+            
+        """.trimIndent()
+    }
+
+    @Test
+    fun `input types should not get an additional Input suffix if already present`() {
+        val schema = schema {
+            query("queryType") {
+                resolver { -> Type("type") }
+            }
+            mutation("addType") {
+                // input type already ends with "Input" and should not become "TypeInputInput"
+                resolver { input: TypeInput -> Type(input.name) }
+            }
+        }
+
+        val sdl = schema.printSchema()
+        sdl shouldBeEqualTo """
+            type Mutation {
+              addType(input: TypeInput!): Type!
+            }
+            
+            type Query {
+              queryType: Type!
+            }
+            
+            type Type {
+              name: String!
+            }
+            
+            input TypeInput {
+              name: String!
+            }
+            
+        """.trimIndent()
+    }
+
+    @Test
+    fun `input types should not get an Input suffix when they are explicitly configured`() {
+        val schema = schema {
+            query("queryType") {
+                resolver { -> Type("type") }
+            }
+            query("queryParent") {
+                resolver { -> ParentType("parent", ChildType("child")) }
+            }
+            mutation("addType") {
+                resolver { input: InputType -> Type(input.name) }
+            }
+            mutation("addParent") {
+                resolver { input: ParentType -> input }
+            }
+            // Input type does not even have to specify a custom name; being configured is enough
+            // to keep its original name ("InputType" in this case)
+            inputType<InputType>()
+            inputType<ParentType> {
+                // Name does not end with "Input" but is explicitly configured and should stay as-is
+                // Child name inside ParentType should still get the "Input" suffix
+                name = "MyParentInputType"
+            }
+        }
+
+        val sdl = schema.printSchema()
+        sdl shouldBeEqualTo """
+            type ChildType {
+              childName: String!
+            }
+            
+            type Mutation {
+              addParent(input: MyParentInputType!): ParentType!
+              addType(input: InputType!): Type!
+            }
+            
+            type ParentType {
+              child: ChildType!
+              parentName: String!
+            }
+            
+            type Query {
+              queryParent: ParentType!
+              queryType: Type!
+            }
+            
+            type Type {
+              name: String!
+            }
+            
+            input ChildTypeInput {
+              childName: String!
+            }
+            
+            input InputType {
+              name: String!
+            }
+            
+            input MyParentInputType {
+              child: ChildTypeInput!
+              parentName: String!
+            }
+            
+        """.trimIndent()
     }
 }


### PR DESCRIPTION
To avoid equal names between input and query types, input types now get an automated `"Input"` suffix unless their name already ends with `"Input"` or they have explicit configuration in the DSL via `inputType {}`. This avoids in a lot of cases an otherwise unnecessary manual configuration step.

BREAKING CHANGE: This may change existing schemas when a certain type was only used as input type and is not configured explicitly (technically also when a type was used as input _and_ query type but that resulted in an invalid schema anyway).