### PR TITLE
refactor: Replace hamcrest+kluent with kotest

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ kotlinx-benchmark = "0.4.14"
 jackson = "2.19.0"
 ktor = "3.1.3"
 junit-jupiter = "5.12.2"
+kotest = "5.9.1"
 
 [plugins]
 serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
@@ -29,8 +30,7 @@ ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
 ktor-server-auth = { module = "io.ktor:ktor-server-auth", version.ref = "ktor" }
 ktor-server-test-host = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor" }
-hamcrest = { module = "org.hamcrest:hamcrest", version = "3.0" }
-kluent = { module = "org.amshove.kluent:kluent", version = "1.73" }
+kotest = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit-jupiter" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit-jupiter" }
 kotlinx-benchmark-runtime = { module = "org.jetbrains.kotlinx:kotlinx-benchmark-runtime", version.ref = "kotlinx-benchmark" }

--- a/kgraphql-ktor-stitched/build.gradle.kts
+++ b/kgraphql-ktor-stitched/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
 
     testImplementation(libs.junit.jupiter.api)
-    testImplementation(libs.kluent)
+    testImplementation(libs.kotest)
     testImplementation(libs.ktor.server.test.host)
+    testImplementation(testFixtures(project(":kgraphql")))
 }

--- a/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/execution/StitchedSchemaExecutionTest.kt
+++ b/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/execution/StitchedSchemaExecutionTest.kt
@@ -11,6 +11,7 @@ import com.apurebase.kgraphql.stitched.getRemoteSchema
 import com.apurebase.kgraphql.stitched.schema.structure.StitchedSchemaTest.Face
 import com.apurebase.kgraphql.stitched.schema.structure.StitchedSchemaTest.Inter
 import com.apurebase.kgraphql.stitched.schema.structure.StitchedSchemaTest.InterInter
+import io.kotest.matchers.shouldBe
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.post
@@ -22,7 +23,6 @@ import io.ktor.server.testing.testApplication
 import kotlinx.serialization.json.Json.Default.decodeFromString
 import kotlinx.serialization.json.Json.Default.encodeToString
 import kotlinx.serialization.json.JsonObject
-import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
 @OptIn(ExperimentalAPI::class)
@@ -174,7 +174,7 @@ class StitchedSchemaExecutionTest {
         client.post("local") {
             header(HttpHeaders.ContentType, ContentType.Application.Json)
             setBody(graphqlRequest("{ remote1 }"))
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"remote1":"remote1"}}
         """.trimIndent()
 
@@ -182,7 +182,7 @@ class StitchedSchemaExecutionTest {
         client.post("local") {
             header(HttpHeaders.ContentType, ContentType.Application.Json)
             setBody(graphqlRequest("{ remote2 }"))
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"remote2":"remote2"}}
         """.trimIndent()
     }
@@ -229,7 +229,7 @@ class StitchedSchemaExecutionTest {
         client.post("local") {
             header(HttpHeaders.ContentType, ContentType.Application.Json)
             setBody(graphqlRequest("{ local remote1 remote2 }"))
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"local":"local","remote1":"remote1","remote2":"remote2"}}
         """.trimIndent()
     }
@@ -262,7 +262,7 @@ class StitchedSchemaExecutionTest {
         }
 
         val sdl = client.get("local?schema").bodyAsText()
-        sdl shouldBeEqualTo """
+        sdl shouldBe """
             type Query {
               local: String!
               remote1: Remote1!
@@ -278,7 +278,7 @@ class StitchedSchemaExecutionTest {
         client.post("local") {
             header(HttpHeaders.ContentType, ContentType.Application.Json)
             setBody(graphqlRequest("{ remote1 { __typename foo1 } }"))
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"remote1":{"__typename":"Remote1","foo1":"remote1.foo1"}}}
         """.trimIndent()
     }
@@ -317,7 +317,7 @@ class StitchedSchemaExecutionTest {
         }
 
         val sdl = client.get("local?schema").bodyAsText()
-        sdl shouldBeEqualTo """
+        sdl shouldBe """
             type Query {
               local: String!
               remote: RemoteParent!
@@ -338,7 +338,7 @@ class StitchedSchemaExecutionTest {
         client.post("local") {
             header(HttpHeaders.ContentType, ContentType.Application.Json)
             setBody(graphqlRequest("{ remote { __typename foo child { __typename childFoo childChild { __typename childFoo childChild { __typename } } } } }"))
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"remote":{"__typename":"RemoteParent","foo":"parent","child":{"__typename":"RemoteChild","childFoo":"child","childChild":{"__typename":"RemoteChild","childFoo":"childChild","childChild":null}}}}}
         """.trimIndent()
     }
@@ -399,7 +399,7 @@ class StitchedSchemaExecutionTest {
             }
 
             val sdl = client.get("local?schema").bodyAsText()
-            sdl shouldBeEqualTo """
+            sdl shouldBe """
                 type Query {
                   local: String!
                   remote1: RemoteParent!
@@ -426,7 +426,7 @@ class StitchedSchemaExecutionTest {
             client.post("local") {
                 header(HttpHeaders.ContentType, ContentType.Application.Json)
                 setBody(graphqlRequest("{ remote1 { __typename foo child { __typename childFoo childChild { __typename childChildFoo stitchedField } } } }"))
-            }.bodyAsText() shouldBeEqualTo """
+            }.bodyAsText() shouldBe """
             {"data":{"remote1":{"__typename":"RemoteParent","foo":"parent","child":{"__typename":"RemoteChild","childFoo":"child","childChild":{"__typename":"RemoteChildChild","childChildFoo":"childChild","stitchedField":"fromRemote2"}}}}}
         """.trimIndent()
         }
@@ -471,7 +471,7 @@ class StitchedSchemaExecutionTest {
         }
 
         val sdl = client.get("local?schema").bodyAsText()
-        sdl shouldBeEqualTo """
+        sdl shouldBe """
             type Query {
               local: String!
               remote(type: String!): RemoteUnion
@@ -505,7 +505,7 @@ class StitchedSchemaExecutionTest {
                     """.trimIndent()
                 )
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"remote":{"__typename":"RemoteB","foo2":"remote.union.B","bar2":42}}}
         """.trimIndent()
 
@@ -524,7 +524,7 @@ class StitchedSchemaExecutionTest {
                     """.trimIndent()
                 )
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"remote":{"__typename":"RemoteA","foo1":"remote.union.A"}}}
         """.trimIndent()
 
@@ -543,7 +543,7 @@ class StitchedSchemaExecutionTest {
                     """.trimIndent()
                 )
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"remote":null}}
         """.trimIndent()
     }
@@ -605,7 +605,7 @@ class StitchedSchemaExecutionTest {
         }
 
         val sdl = client.get("local?schema").bodyAsText()
-        sdl shouldBeEqualTo """
+        sdl shouldBe """
             type Local {
               localFoo: String!
             }
@@ -676,7 +676,7 @@ class StitchedSchemaExecutionTest {
                     """.trimIndent()
                 )
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"local":{"localFoo":"local"},"remote1":{"__typename":"Remote1","foo1":"remote1.foo1"},"remote2":{"__typename":"RemoteB","foo2":"remote.union","bar2":42}}}
         """.trimIndent()
 
@@ -715,7 +715,7 @@ class StitchedSchemaExecutionTest {
                     """.trimIndent()
                 )
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"remote2WithChild":{"__typename":"RemoteWithUnionChild","foo":"foo","child":{"__typename":"RemoteB","foo2":"foo2","bar2":1337},"localChild":{"__typename":"Local","localFoo":"fromRemote2WithChild"}}}}
         """.trimIndent()
 
@@ -742,7 +742,7 @@ class StitchedSchemaExecutionTest {
                     """.trimIndent()
                 )
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"remote2WithChild":{"__typename":"RemoteWithUnionChild","foo":"foo","child":{"__typename":"RemoteB","foo2":"foo2","bar2":1337}}}}
         """.trimIndent()
     }
@@ -802,7 +802,7 @@ class StitchedSchemaExecutionTest {
         }
 
         val sdl = client.get("local?schema").bodyAsText()
-        sdl shouldBeEqualTo """
+        sdl shouldBe """
             type Local {
               localFoo: String!
             }
@@ -857,7 +857,7 @@ class StitchedSchemaExecutionTest {
                     """.trimIndent()
                 )
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"remote1":{"__typename":"Remote1","foo1":"remote1.foo1","stitchedRemote":{"__typename":"Remote2","foo2":"remote2Foo","bar2":42},"stitchedLocal":{"__typename":"Local","localFoo":"local"}}}}
         """.trimIndent()
     }
@@ -890,7 +890,7 @@ class StitchedSchemaExecutionTest {
         }
 
         val sdl = client.get("local?schema").bodyAsText()
-        sdl shouldBeEqualTo """
+        sdl shouldBe """
             type Query {
               local: String!
               remote1: RemoteEnum!
@@ -914,7 +914,7 @@ class StitchedSchemaExecutionTest {
                     """.trimIndent()
                 )
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"remote1":"REMOTE1"}}
         """.trimIndent()
     }
@@ -958,7 +958,7 @@ class StitchedSchemaExecutionTest {
         }
 
         val sdl = client.get("local?schema").bodyAsText()
-        sdl shouldBeEqualTo """
+        sdl shouldBe """
             type Mutation {
               remote1Mutation: Remote1!
             }
@@ -979,7 +979,7 @@ class StitchedSchemaExecutionTest {
         client.post("local") {
             header(HttpHeaders.ContentType, ContentType.Application.Json)
             setBody(graphqlRequest("mutation { remote1Mutation { foo1 } }"))
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"remote1Mutation":{"foo1":"remote1.mutationFoo1"}}}
         """.trimIndent()
 
@@ -987,7 +987,7 @@ class StitchedSchemaExecutionTest {
         client.post("local") {
             header(HttpHeaders.ContentType, ContentType.Application.Json)
             setBody(graphqlRequest("{ remote2 }"))
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"remote2":"remote2"}}
         """.trimIndent()
     }
@@ -1059,7 +1059,7 @@ class StitchedSchemaExecutionTest {
         }
 
         val sdl = client.get("local?schema").bodyAsText()
-        sdl shouldBeEqualTo """
+        sdl shouldBe """
             type Local {
               foo1: String!
             }
@@ -1108,7 +1108,7 @@ class StitchedSchemaExecutionTest {
                     """.trimIndent()
                 )
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"localMutation":null}}
         """.trimIndent()
 
@@ -1123,7 +1123,7 @@ class StitchedSchemaExecutionTest {
                     """.trimIndent()
                 )
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"optionalIntMutation":null}}
         """.trimIndent()
 
@@ -1141,7 +1141,7 @@ class StitchedSchemaExecutionTest {
                     """.trimIndent()
                 )
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"booleanMutation":{"foo1":"true"},"enumMutation":{"foo1":"REMOTE1"},"enumListMutation":[{"foo1":"REMOTE2"},{"foo1":"REMOTE1"}],"stringMutation":{"foo1":"bar1"}}}
         """.trimIndent()
 
@@ -1158,7 +1158,7 @@ class StitchedSchemaExecutionTest {
                     """.trimIndent()
                 )
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"defaultIntMutation":{"foo1":"42"},"intMutation":{"foo1":"1337"},"optionalIntMutation":null}}
         """.trimIndent()
 
@@ -1173,7 +1173,7 @@ class StitchedSchemaExecutionTest {
                     """.trimIndent()
                 )
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"objectMutation":{"foo1":"complexMutationFoo-processed"}}}
         """.trimIndent()
     }
@@ -1227,7 +1227,7 @@ class StitchedSchemaExecutionTest {
         }
 
         val sdl = client.get("local?schema").bodyAsText()
-        sdl shouldBeEqualTo """
+        sdl shouldBe """
             type Mutation {
               invertBoolean(toInvert: Boolean!): Boolean!
             }
@@ -1275,7 +1275,7 @@ class StitchedSchemaExecutionTest {
                     """.trimIndent()
                 )
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"getBoolean":true,"getInt":7}}
         """.trimIndent()
 
@@ -1304,7 +1304,7 @@ class StitchedSchemaExecutionTest {
                     variables
                 )
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"getBoolean":true,"getInt":7,"getFloat":13.37,"getObject":{"foo":"foo\nbar","bar":8,"foobar":3.51,"enum":"REMOTE1","list":[true,false,true]}}}
         """.trimIndent()
 
@@ -1320,7 +1320,7 @@ class StitchedSchemaExecutionTest {
                     variables
                 )
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"invertBoolean":false}}
         """.trimIndent()
     }
@@ -1369,7 +1369,7 @@ class StitchedSchemaExecutionTest {
         }
 
         val sdl = client.get("local?schema").bodyAsText()
-        sdl shouldBeEqualTo """
+        sdl shouldBe """
             type Query {
               getRemoteChild(bar: String!): RemoteChild!
               getRemoteObject(foo: String!): RemoteObject!
@@ -1403,7 +1403,7 @@ class StitchedSchemaExecutionTest {
                     """.trimIndent()
                 )
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"getRemoteObject":{"foo":"foo1","stitchedChild":{"bar":"bar1"}}}}
         """.trimIndent()
 
@@ -1432,7 +1432,7 @@ class StitchedSchemaExecutionTest {
                     variables
                 )
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"getRemoteObject":{"foo":"fooVar","stitchedChild":{"bar":"barVar"}}}}
         """.trimIndent()
 
@@ -1458,7 +1458,7 @@ class StitchedSchemaExecutionTest {
                     variables
                 )
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"getRemoteObject":{"foo":"fooVar","__typename":"RemoteObject","stitchedChild":{"bar":"barVar"}}}}
         """.trimIndent()
     }
@@ -1512,7 +1512,7 @@ class StitchedSchemaExecutionTest {
         }
 
         val sdl = client.get("local?schema").bodyAsText()
-        sdl shouldBeEqualTo """
+        sdl shouldBe """
             type Query {
               getRemoteChild(bar: String!): RemoteChild!
               getRemoteObject(foo: String!): RemoteObject!
@@ -1546,7 +1546,7 @@ class StitchedSchemaExecutionTest {
                     """.trimIndent()
                 )
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"getRemoteObject":{"notFoo":"foo1","stitchedChild":{"bar":"bar1"}}}}
         """.trimIndent()
 
@@ -1575,7 +1575,7 @@ class StitchedSchemaExecutionTest {
                     variables
                 )
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"getRemoteObject":{"notFoo":"fooVar","stitchedChild":{"bar":"barVar"}}}}
         """.trimIndent()
 
@@ -1601,7 +1601,7 @@ class StitchedSchemaExecutionTest {
                     variables
                 )
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"getRemoteObject":{"notFoo":"fooVar","__typename":"RemoteObject","stitchedChild":{"bar":"barVar"}}}}
         """.trimIndent()
     }
@@ -1629,7 +1629,7 @@ class StitchedSchemaExecutionTest {
         }
 
         val sdl = client.get("local?schema").bodyAsText()
-        sdl shouldBeEqualTo """
+        sdl shouldBe """
             type Mutation {
               createRemote1(foo1: String!): Remote1!
             }
@@ -1660,7 +1660,7 @@ class StitchedSchemaExecutionTest {
                     """.trimIndent()
                 )
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"createRemote1":{"foo1":"a very very long foo","truncatedFoo1":"a very ver...","veryTruncatedFoo1":"a ..."}}}
         """.trimIndent()
     }
@@ -1708,7 +1708,7 @@ class StitchedSchemaExecutionTest {
         }
 
         val sdl = client.get("local?schema").bodyAsText()
-        sdl shouldBeEqualTo """
+        sdl shouldBe """
             type Query {
               remote1: Remote1!
               remote2: String!
@@ -1733,7 +1733,7 @@ class StitchedSchemaExecutionTest {
                     """.trimIndent()
                 )
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"remote1":{"foo1":"remote1.foo1"}}}
         """.trimIndent()
 
@@ -1748,7 +1748,7 @@ class StitchedSchemaExecutionTest {
                     """.trimIndent()
                 )
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"remote1":{"foo1":"remote1.foo1","stitchedRemote2":"remote2"}}}
         """.trimIndent()
     }
@@ -1792,7 +1792,7 @@ class StitchedSchemaExecutionTest {
         }
 
         val sdl = client.get("local?schema").bodyAsText()
-        sdl shouldBeEqualTo """
+        sdl shouldBe """
             type Query {
               remote1: RemoteEnum!
               remote2: Remote2!
@@ -1823,7 +1823,7 @@ class StitchedSchemaExecutionTest {
                     """.trimIndent()
                 )
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"remote2":{"bar2":42,"stitchedEnum":"REMOTE1"}}}
         """.trimIndent()
 
@@ -1839,7 +1839,7 @@ class StitchedSchemaExecutionTest {
                     """.trimIndent()
                 )
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"remote2":{"s1":"REMOTE1","s2":"REMOTE1"}}}
         """.trimIndent()
 
@@ -1855,7 +1855,7 @@ class StitchedSchemaExecutionTest {
                     """.trimIndent()
                 )
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"errors":[{"message":"Property nonexisting on Remote2 does not exist","locations":[{"line":2,"column":13}],"path":[],"extensions":{"type":"GRAPHQL_VALIDATION_FAILED"}}]}
         """.trimIndent()
     }
@@ -1893,7 +1893,7 @@ class StitchedSchemaExecutionTest {
         }
 
         val sdl = client.get("local?schema").bodyAsText()
-        sdl shouldBeEqualTo """
+        sdl shouldBe """
             type Local {
               isLocal: Boolean!
               remoteFoo: String!
@@ -1919,7 +1919,7 @@ class StitchedSchemaExecutionTest {
                     """.trimIndent()
                 )
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"local":{"remoteFoo":"local","stitched":"remote1"}}}
         """.trimIndent()
     }
@@ -1980,7 +1980,7 @@ class StitchedSchemaExecutionTest {
         }
 
         val sdl = client.get("local?schema").bodyAsText()
-        sdl shouldBeEqualTo """
+        sdl shouldBe """
             type Query {
               remote1(enum: RemoteEnum!): RemoteEnum!
               remote2(enum: RemoteEnum!): Remote2TypeWithEnum!
@@ -2010,7 +2010,7 @@ class StitchedSchemaExecutionTest {
                     """.trimIndent()
                 )
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"one":{"localEnum":"REMOTE1","stitchedEnum":"REMOTE1"},"two":{"localEnum":"REMOTE2","stitchedEnum":"REMOTE2"}}}
         """.trimIndent()
     }
@@ -2067,7 +2067,7 @@ class StitchedSchemaExecutionTest {
         }
 
         val sdl = client.get("local?schema").bodyAsText()
-        sdl shouldBeEqualTo """
+        sdl shouldBe """
             type Local {
               isLocal: Boolean!
               remoteFoo: String!
@@ -2103,7 +2103,7 @@ class StitchedSchemaExecutionTest {
                     """.trimIndent()
                 )
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"remote1":{"foo1":"remote1.foo1","stitchedRemote2":{"foo2":"remote2Foo","bar2":42}}}}
         """.trimIndent()
 
@@ -2118,7 +2118,7 @@ class StitchedSchemaExecutionTest {
                     """.trimIndent()
                 )
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"remote1":{"foo1":"remote1.foo1","stitchedRemote2":{"foo2":"remote2Foo"},"stitchedLocal":{"remoteFoo":"remote1.foo1","isLocal":true}}}}
         """.trimIndent()
     }
@@ -2170,7 +2170,7 @@ class StitchedSchemaExecutionTest {
             }
 
             val sdl = client.get("local?schema").bodyAsText()
-            sdl shouldBeEqualTo """
+            sdl shouldBe """
                 type Query {
                   local(fooInput: String!): String!
                   remoteFoo: Remote!
@@ -2195,7 +2195,7 @@ class StitchedSchemaExecutionTest {
                     """.trimIndent()
                     )
                 )
-            }.bodyAsText() shouldBeEqualTo """
+            }.bodyAsText() shouldBe """
                 {"data":{"remoteFoo":{"foo":"foo","stitchedLocal":"foo"}}}
             """.trimIndent()
 
@@ -2210,7 +2210,7 @@ class StitchedSchemaExecutionTest {
                     """.trimIndent()
                     )
                 )
-            }.bodyAsText() shouldBeEqualTo """
+            }.bodyAsText() shouldBe """
                 {"data":{"remoteNull":{"foo":null,"stitchedLocal":null}}}
             """.trimIndent()
         }
@@ -2262,7 +2262,7 @@ class StitchedSchemaExecutionTest {
             }
 
             val sdl = client.get("local?schema").bodyAsText()
-            sdl shouldBeEqualTo """
+            sdl shouldBe """
                 type Query {
                   local(optionalFooInput: String): String!
                   remoteFoo: Remote!
@@ -2287,7 +2287,7 @@ class StitchedSchemaExecutionTest {
                         """.trimIndent()
                     )
                 )
-            }.bodyAsText() shouldBeEqualTo """
+            }.bodyAsText() shouldBe """
                 {"data":{"remoteFoo":{"foo":"foo","stitchedLocal":"foo"}}}
             """.trimIndent()
 
@@ -2302,7 +2302,7 @@ class StitchedSchemaExecutionTest {
                         """.trimIndent()
                     )
                 )
-            }.bodyAsText() shouldBeEqualTo """
+            }.bodyAsText() shouldBe """
                 {"data":{"remoteNull":{"foo":null,"stitchedLocal":"called with null"}}}
             """.trimIndent()
         }
@@ -2350,7 +2350,7 @@ class StitchedSchemaExecutionTest {
         }
 
         val sdl = client.get("local?schema").bodyAsText()
-        sdl shouldBeEqualTo """
+        sdl shouldBe """
             type Query {
               local(fooInput: String!): String!
               remoteFoo(input: String!): Remote!
@@ -2374,7 +2374,7 @@ class StitchedSchemaExecutionTest {
                     """.trimIndent()
                 )
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"remoteFoo":{"foo":"foo","stitchedLocal":"foo"}}}
         """.trimIndent()
 
@@ -2389,7 +2389,7 @@ class StitchedSchemaExecutionTest {
                     """.trimIndent()
                 )
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"local":"a very \"special\" kind\t\r\bf\n\n of \\t foo"}}
         """.trimIndent()
 
@@ -2404,7 +2404,7 @@ class StitchedSchemaExecutionTest {
                     """.trimIndent()
                 )
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"remoteFoo":{"foo":"a very \"special\" kind\t\r\bf\n\n of \\t foo","stitchedLocal":"a very \"special\" kind\t\r\bf\n\n of \\t foo"}}}
         """.trimIndent()
     }
@@ -2459,7 +2459,7 @@ class StitchedSchemaExecutionTest {
         }
 
         val sdl = client.get("local?schema").bodyAsText()
-        sdl shouldBeEqualTo """
+        sdl shouldBe """
             type Query {
               remote1: Remote1!
               remote2(barValue: Int, fooValue: String!): Remote2!
@@ -2490,7 +2490,7 @@ class StitchedSchemaExecutionTest {
                     """.trimIndent()
                 )
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"remote1":{"foo1":"remote1.foo1","stitchedRemote2":{"foo2":"remote1.foo1","bar2":42}}}}
         """.trimIndent()
 
@@ -2505,7 +2505,7 @@ class StitchedSchemaExecutionTest {
                     """.trimIndent()
                 )
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"remote1":{"foo1":"remote1.foo1","stitchedRequiredRemote2":{"foo2":"foo","bar2":13}}}}
         """.trimIndent()
 
@@ -2520,7 +2520,7 @@ class StitchedSchemaExecutionTest {
                     """.trimIndent()
                 )
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"remote1":{"foo1":"remote1.foo1","stitchedRemote2":{"foo2":"remote1.foo1","bar2":43}}}}
         """.trimIndent()
     }
@@ -2567,7 +2567,7 @@ class StitchedSchemaExecutionTest {
         }
 
         val sdl = client.get("local?schema").bodyAsText()
-        sdl shouldBeEqualTo """
+        sdl shouldBe """
             type Child {
               childFoo: String!
             }
@@ -2605,7 +2605,7 @@ class StitchedSchemaExecutionTest {
                     """.trimIndent()
                 )
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"remote1":{"__typename":"Remote1WithChild","foo1":"remote1","stitchedRemote2":{"__typename":"Remote2","foo2":"childFoo","bar2":13},"child":{"__typename":"Child","childFoo":"childFoo"}}}}
         """.trimIndent()
     }
@@ -2660,7 +2660,7 @@ class StitchedSchemaExecutionTest {
         }
 
         val sdl = client.get("local?schema").bodyAsText()
-        sdl shouldBeEqualTo """
+        sdl shouldBe """
             type Query {
               remote1(foos: [String!]!): [Remote1!]!
               remote2WithList: RemoteWithList!
@@ -2689,7 +2689,7 @@ class StitchedSchemaExecutionTest {
                     """.trimIndent()
                 )
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"remote2WithList":{"foo":"remoteWithList","bars":["bar1","bar3","bar2"],"barObjects":[{"foo1":"bar1"},{"foo1":"bar3"},{"foo1":"bar2"}]}}}
         """.trimIndent()
     }
@@ -2717,7 +2717,7 @@ class StitchedSchemaExecutionTest {
         }
 
         val sdl = client.get("local?schema").bodyAsText()
-        sdl shouldBeEqualTo """
+        sdl shouldBe """
             type Face implements Inter & InterInter {
               value: String!
               value2: Boolean!
@@ -2743,7 +2743,7 @@ class StitchedSchemaExecutionTest {
             setBody(
                 graphqlRequest("{interface{value, __typename ... on Face{value2}}}")
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"interface":{"value":"~~MOCK~~","__typename":"Face","value2":false}}}
         """.trimIndent()
     }
@@ -2798,7 +2798,7 @@ class StitchedSchemaExecutionTest {
         }
 
         val sdl = client.get("local?schema").bodyAsText()
-        sdl shouldBeEqualTo """
+        sdl shouldBe """
             type CommonType {
               fromSchema: String!
             }
@@ -2850,7 +2850,7 @@ class StitchedSchemaExecutionTest {
                     """.trimIndent()
                 )
             )
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"data":{"remote1":{"__typename":"Remote1Type","foo":"remote1Foo","common":{"__typename":"CommonType","fromSchema":"remote1"}},"remote2":{"__typename":"Remote2Type","foo":"remote2Foo","common":{"__typename":"CommonType","fromSchema":"remote2"}}}}
         """.trimIndent()
     }
@@ -2913,7 +2913,7 @@ class StitchedSchemaExecutionTest {
         client.post("local") {
             header(HttpHeaders.ContentType, ContentType.Application.Json)
             setBody(graphqlRequest("{ failSyntax }"))
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"errors":[{"message":"Property failSyntax on Query does not exist","locations":[{"line":1,"column":3}],"path":[],"extensions":{"type":"GRAPHQL_VALIDATION_FAILED"}}]}
         """.trimIndent()
 
@@ -2922,21 +2922,21 @@ class StitchedSchemaExecutionTest {
         client.post("local") {
             header(HttpHeaders.ContentType, ContentType.Application.Json)
             setBody(graphqlRequest("{ failLocal }"))
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"errors":[{"message":"don't call me local!","locations":[],"path":[],"extensions":{"type":"INTERNAL_SERVER_ERROR","detail":{"localErrorKey":"localErrorValue"}}}]}
         """.trimIndent()
 
         client.post("local") {
             header(HttpHeaders.ContentType, ContentType.Application.Json)
             setBody(graphqlRequest("{ failRemote }"))
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"errors":[{"message":"don't call me remote!","locations":[{"line":1,"column":3}],"path":[],"extensions":{"type":"BAD_USER_INPUT","remoteUrl":"remote","remoteOperation":"failRemote","remoteErrorKey":["remoteErrorValue1","remoteErrorValue2"]}}]}
         """.trimIndent()
 
         client.post("local") {
             header(HttpHeaders.ContentType, ContentType.Application.Json)
             setBody(graphqlRequest("{ failRemote2 }"))
-        }.bodyAsText() shouldBeEqualTo """
+        }.bodyAsText() shouldBe """
             {"errors":[{"message":"Error(s) during remote execution","locations":[{"line":1,"column":3}],"path":[],"extensions":{"type":"INTERNAL_SERVER_ERROR","remoteUrl":"remote","remoteOperation":"failRemote2"}}]}
         """.trimIndent()
     }

--- a/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/structure/IntrospectedSchemaTest.kt
+++ b/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/structure/IntrospectedSchemaTest.kt
@@ -3,7 +3,7 @@ package com.apurebase.kgraphql.stitched.schema.structure
 import com.apurebase.kgraphql.KGraphQL
 import com.apurebase.kgraphql.request.Introspection
 import com.apurebase.kgraphql.schema.SchemaPrinter
-import org.amshove.kluent.shouldBeEqualTo
+import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 
 class IntrospectedSchemaTest {
@@ -35,6 +35,6 @@ class IntrospectedSchemaTest {
             schema.executeBlocking(Introspection.query())
         )
 
-        SchemaPrinter().print(schemaFromIntrospection) shouldBeEqualTo SchemaPrinter().print(schema)
+        SchemaPrinter().print(schemaFromIntrospection) shouldBe SchemaPrinter().print(schema)
     }
 }

--- a/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/structure/StitchedSchemaTest.kt
+++ b/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/structure/StitchedSchemaTest.kt
@@ -2,23 +2,20 @@ package com.apurebase.kgraphql.stitched.schema.structure
 
 import com.apurebase.kgraphql.Context
 import com.apurebase.kgraphql.ExperimentalAPI
+import com.apurebase.kgraphql.expect
 import com.apurebase.kgraphql.request.Introspection
 import com.apurebase.kgraphql.schema.Schema
 import com.apurebase.kgraphql.schema.SchemaException
 import com.apurebase.kgraphql.schema.SchemaPrinter
 import com.apurebase.kgraphql.schema.SchemaPrinterConfig
 import com.apurebase.kgraphql.schema.execution.Execution
+import com.apurebase.kgraphql.shouldBeInstanceOf
 import com.apurebase.kgraphql.stitched.StitchedKGraphQL
 import com.apurebase.kgraphql.stitched.getRemoteSchema
 import com.apurebase.kgraphql.stitched.schema.configuration.StitchedSchemaConfiguration
 import com.apurebase.kgraphql.stitched.schema.execution.RemoteRequestExecutor
 import com.fasterxml.jackson.databind.JsonNode
-import org.amshove.kluent.invoking
-import org.amshove.kluent.`should be instance of`
-import org.amshove.kluent.shouldBe
-import org.amshove.kluent.shouldBeEqualTo
-import org.amshove.kluent.shouldThrow
-import org.amshove.kluent.withMessage
+import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 import java.util.Locale
 import java.util.UUID
@@ -75,7 +72,7 @@ class StitchedSchemaTest {
             }
         }
 
-        schema.configuration `should be instance of` StitchedSchemaConfiguration::class
+        schema.configuration shouldBeInstanceOf StitchedSchemaConfiguration::class
         (schema.configuration as StitchedSchemaConfiguration).remoteExecutor shouldBe customRemoteRequestExecutor
     }
 
@@ -111,8 +108,8 @@ class StitchedSchemaTest {
             
         """.trimIndent()
 
-        SchemaPrinter().print(schema) shouldBeEqualTo expectedSDL
-        SchemaPrinter().print(schema.introspected()) shouldBeEqualTo expectedSDL
+        SchemaPrinter().print(schema) shouldBe expectedSDL
+        SchemaPrinter().print(schema.introspected()) shouldBe expectedSDL
     }
 
     @Test
@@ -173,8 +170,8 @@ class StitchedSchemaTest {
             
         """.trimIndent()
 
-        SchemaPrinter(SchemaPrinterConfig(includeDescriptions = true)).print(schema) shouldBeEqualTo expectedSDL
-        SchemaPrinter(SchemaPrinterConfig(includeDescriptions = true)).print(schema.introspected()) shouldBeEqualTo expectedSDL
+        SchemaPrinter(SchemaPrinterConfig(includeDescriptions = true)).print(schema) shouldBe expectedSDL
+        SchemaPrinter(SchemaPrinterConfig(includeDescriptions = true)).print(schema.introspected()) shouldBe expectedSDL
     }
 
     @Test
@@ -213,8 +210,8 @@ class StitchedSchemaTest {
 
         """.trimIndent()
 
-        SchemaPrinter().print(schema) shouldBeEqualTo expectedSDL
-        SchemaPrinter().print(schema.introspected()) shouldBeEqualTo expectedSDL
+        SchemaPrinter().print(schema) shouldBe expectedSDL
+        SchemaPrinter().print(schema.introspected()) shouldBe expectedSDL
     }
 
     @Test
@@ -282,8 +279,8 @@ class StitchedSchemaTest {
 
         """.trimIndent()
 
-        SchemaPrinter(SchemaPrinterConfig(includeDescriptions = true)).print(schema) shouldBeEqualTo expectedSDL
-        SchemaPrinter(SchemaPrinterConfig(includeDescriptions = true)).print(schema.introspected()) shouldBeEqualTo expectedSDL
+        SchemaPrinter(SchemaPrinterConfig(includeDescriptions = true)).print(schema) shouldBe expectedSDL
+        SchemaPrinter(SchemaPrinterConfig(includeDescriptions = true)).print(schema.introspected()) shouldBe expectedSDL
     }
 
     @Test
@@ -350,8 +347,8 @@ class StitchedSchemaTest {
 
         """.trimIndent()
 
-        SchemaPrinter(SchemaPrinterConfig(includeDescriptions = true)).print(schema) shouldBeEqualTo expectedSDL
-        SchemaPrinter(SchemaPrinterConfig(includeDescriptions = true)).print(schema.introspected()) shouldBeEqualTo expectedSDL
+        SchemaPrinter(SchemaPrinterConfig(includeDescriptions = true)).print(schema) shouldBe expectedSDL
+        SchemaPrinter(SchemaPrinterConfig(includeDescriptions = true)).print(schema.introspected()) shouldBe expectedSDL
     }
 
     @Test
@@ -393,8 +390,8 @@ class StitchedSchemaTest {
             
         """.trimIndent()
 
-        SchemaPrinter().print(schema) shouldBeEqualTo expectedSDL
-        SchemaPrinter().print(schema.introspected()) shouldBeEqualTo expectedSDL
+        SchemaPrinter().print(schema) shouldBe expectedSDL
+        SchemaPrinter().print(schema.introspected()) shouldBe expectedSDL
     }
 
     @Test
@@ -439,8 +436,8 @@ class StitchedSchemaTest {
             
         """.trimIndent()
 
-        SchemaPrinter().print(schema) shouldBeEqualTo expectedSDL
-        SchemaPrinter().print(schema.introspected()) shouldBeEqualTo expectedSDL
+        SchemaPrinter().print(schema) shouldBe expectedSDL
+        SchemaPrinter().print(schema.introspected()) shouldBe expectedSDL
     }
 
     @Test
@@ -478,8 +475,8 @@ class StitchedSchemaTest {
             
         """.trimIndent()
 
-        SchemaPrinter().print(schema) shouldBeEqualTo expectedSDL
-        SchemaPrinter().print(schema.introspected()) shouldBeEqualTo expectedSDL
+        SchemaPrinter().print(schema) shouldBe expectedSDL
+        SchemaPrinter().print(schema.introspected()) shouldBe expectedSDL
     }
 
     interface InterInter : Inter {
@@ -535,14 +532,14 @@ class StitchedSchemaTest {
             
         """.trimIndent()
 
-        SchemaPrinter().print(schema) shouldBeEqualTo expectedSDL
-        SchemaPrinter().print(schema.introspected()) shouldBeEqualTo expectedSDL
+        SchemaPrinter().print(schema) shouldBe expectedSDL
+        SchemaPrinter().print(schema.introspected()) shouldBe expectedSDL
     }
 
     @Test
     fun `schema should prevent duplicate field names from stitching`() {
         data class SimpleClass(val existing: String)
-        invoking {
+        expect<SchemaException>("Cannot add stitched field with duplicated name 'existing'") {
             StitchedKGraphQL.stitchedSchema {
                 configure {
                     remoteExecutor = DummyRemoteRequestExecutor
@@ -568,9 +565,9 @@ class StitchedSchemaTest {
                     }
                 }
             }
-        } shouldThrow SchemaException::class withMessage "Cannot add stitched field with duplicated name 'existing'"
+        }
 
-        invoking {
+        expect<SchemaException>("Cannot add stitched field with duplicated name 'extension' for type 'SimpleClass'") {
             StitchedKGraphQL.stitchedSchema {
                 configure {
                     remoteExecutor = DummyRemoteRequestExecutor
@@ -601,13 +598,13 @@ class StitchedSchemaTest {
                     }
                 }
             }
-        } shouldThrow SchemaException::class withMessage "Cannot add stitched field with duplicated name 'extension' for type 'SimpleClass'"
+        }
     }
 
     @Test
     fun `schema should prevent invalid field names from stitching`() {
         data class SimpleClass(val existing: String)
-        invoking {
+        expect<SchemaException>("Illegal name '__extension'. Names starting with '__' are reserved for introspection system") {
             StitchedKGraphQL.stitchedSchema {
                 configure {
                     remoteExecutor = DummyRemoteRequestExecutor
@@ -633,12 +630,12 @@ class StitchedSchemaTest {
                     }
                 }
             }
-        } shouldThrow SchemaException::class withMessage "Illegal name '__extension'. Names starting with '__' are reserved for introspection system"
+        }
     }
 
     @Test
     fun `schema should prevent multiple local schema definitions`() {
-        invoking {
+        expect<SchemaException>("Local schema already defined") {
             StitchedKGraphQL.stitchedSchema {
                 configure {
                     remoteExecutor = DummyRemoteRequestExecutor
@@ -654,7 +651,7 @@ class StitchedSchemaTest {
                     }
                 }
             }
-        } shouldThrow SchemaException::class withMessage "Local schema already defined"
+        }
     }
 
     // TODO: make configurable? this doesn't seem like *always* intended
@@ -716,8 +713,8 @@ class StitchedSchemaTest {
             
         """.trimIndent()
 
-        SchemaPrinter().print(schema) shouldBeEqualTo expectedSDL
-        SchemaPrinter().print(schema.introspected()) shouldBeEqualTo expectedSDL
+        SchemaPrinter().print(schema) shouldBe expectedSDL
+        SchemaPrinter().print(schema.introspected()) shouldBe expectedSDL
 
         schema.executeBlocking(
             """
@@ -725,7 +722,7 @@ class StitchedSchemaTest {
               __type(name: "SimpleClass") { name kind fields { name } }
             }
             """.trimIndent()
-        ) shouldBeEqualTo """
+        ) shouldBe """
             {"data":{"__type":{"name":"SimpleClass","kind":"OBJECT","fields":[{"name":"existing"},{"name":"extension"},{"name":"extensionWithDefault"},{"name":"extensionWithOptional"}]}}}
         """.trimIndent()
     }

--- a/kgraphql-ktor/build.gradle.kts
+++ b/kgraphql-ktor/build.gradle.kts
@@ -10,7 +10,7 @@ dependencies {
     implementation(libs.ktor.server.core)
 
     testImplementation(libs.junit.jupiter.api)
-    testImplementation(libs.kluent)
+    testImplementation(libs.kotest)
     testImplementation(libs.ktor.server.test.host)
     testImplementation(libs.ktor.server.auth)
 }

--- a/kgraphql-ktor/src/test/kotlin/com/apurebase/kgraphql/KtorConfigurationTest.kt
+++ b/kgraphql-ktor/src/test/kotlin/com/apurebase/kgraphql/KtorConfigurationTest.kt
@@ -1,9 +1,9 @@
 package com.apurebase.kgraphql
 
 import com.apurebase.kgraphql.schema.execution.Executor
+import io.kotest.matchers.shouldBe
 import io.ktor.server.application.install
 import io.ktor.server.testing.testApplication
-import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
 class KtorConfigurationTest : KtorTest() {
@@ -21,10 +21,10 @@ class KtorConfigurationTest : KtorTest() {
                     }
                 }
                 checked = true
-                config.schema.configuration.executor shouldBeEqualTo Executor.Parallel
+                config.schema.configuration.executor shouldBe Executor.Parallel
             }
         }
-        checked shouldBeEqualTo true
+        checked shouldBe true
     }
 
     @Test
@@ -41,9 +41,9 @@ class KtorConfigurationTest : KtorTest() {
                     }
                 }
                 checked = true
-                config.schema.configuration.executor shouldBeEqualTo Executor.DataLoaderPrepared
+                config.schema.configuration.executor shouldBe Executor.DataLoaderPrepared
             }
         }
-        checked shouldBeEqualTo true
+        checked shouldBe true
     }
 }

--- a/kgraphql-ktor/src/test/kotlin/com/apurebase/kgraphql/KtorFeatureTest.kt
+++ b/kgraphql-ktor/src/test/kotlin/com/apurebase/kgraphql/KtorFeatureTest.kt
@@ -1,5 +1,6 @@
 package com.apurebase.kgraphql
 
+import io.kotest.matchers.shouldBe
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
@@ -10,7 +11,6 @@ import kotlinx.serialization.json.add
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.json.putJsonObject
-import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
 class KtorFeatureTest : KtorTest() {
@@ -29,8 +29,8 @@ class KtorFeatureTest : KtorTest() {
             field("hello")
         }
         runBlocking {
-            response.bodyAsText() shouldBeEqualTo "{\"data\":{\"hello\":\"World!\"}}"
-            response.contentType() shouldBeEqualTo ContentType.Application.Json
+            response.bodyAsText() shouldBe "{\"data\":{\"hello\":\"World!\"}}"
+            response.contentType() shouldBe ContentType.Application.Json
         }
     }
 
@@ -49,8 +49,8 @@ class KtorFeatureTest : KtorTest() {
             field("hello")
         }
         runBlocking {
-            response.bodyAsText() shouldBeEqualTo "{\"data\":{\"hello\":\"World! mutation\"}}"
-            response.contentType() shouldBeEqualTo ContentType.Application.Json
+            response.bodyAsText() shouldBe "{\"data\":{\"hello\":\"World! mutation\"}}"
+            response.contentType() shouldBe ContentType.Application.Json
         }
     }
 
@@ -87,8 +87,8 @@ class KtorFeatureTest : KtorTest() {
             }
         }
         runBlocking {
-            response.bodyAsText() shouldBeEqualTo "{\"data\":{\"actor\":{\"name\":\"${georgeName}STUFF\"}}}"
-            response.contentType() shouldBeEqualTo ContentType.Application.Json
+            response.bodyAsText() shouldBe "{\"data\":{\"actor\":{\"name\":\"${georgeName}STUFF\"}}}"
+            response.contentType() shouldBe ContentType.Application.Json
         }
 
         response = server("query") {
@@ -97,8 +97,8 @@ class KtorFeatureTest : KtorTest() {
             }
         }
         runBlocking {
-            response.bodyAsText() shouldBeEqualTo "{\"data\":{\"actor\":{\"nickname\":\"Hodor and $georgeName\"}}}"
-            response.contentType() shouldBeEqualTo ContentType.Application.Json
+            response.bodyAsText() shouldBe "{\"data\":{\"actor\":{\"nickname\":\"Hodor and $georgeName\"}}}"
+            response.contentType() shouldBe ContentType.Application.Json
         }
     }
 
@@ -134,8 +134,8 @@ class KtorFeatureTest : KtorTest() {
             }
         }
         runBlocking {
-            response.bodyAsText() shouldBeEqualTo "{\"data\":{\"test\":\"success: InputTwo(one=InputOne(enum=M1, id=M1), quantity=3434, tokens=[23, 34, 21, 434])\"}}"
-            response.contentType() shouldBeEqualTo ContentType.Application.Json
+            response.bodyAsText() shouldBe "{\"data\":{\"test\":\"success: InputTwo(one=InputOne(enum=M1, id=M1), quantity=3434, tokens=[23, 34, 21, 434])\"}}"
+            response.contentType() shouldBe ContentType.Application.Json
         }
     }
 
@@ -153,8 +153,8 @@ class KtorFeatureTest : KtorTest() {
             }
         }
         runBlocking {
-            response.bodyAsText() shouldBeEqualTo "{\"errors\":[{\"message\":\"Property nickname on Actor does not exist\",\"locations\":[{\"line\":3,\"column\":1}],\"path\":[],\"extensions\":{\"type\":\"GRAPHQL_VALIDATION_FAILED\"}}]}"
-            response.contentType() shouldBeEqualTo ContentType.Application.Json
+            response.bodyAsText() shouldBe "{\"errors\":[{\"message\":\"Property nickname on Actor does not exist\",\"locations\":[{\"line\":3,\"column\":1}],\"path\":[],\"extensions\":{\"type\":\"GRAPHQL_VALIDATION_FAILED\"}}]}"
+            response.contentType() shouldBe ContentType.Application.Json
         }
     }
 
@@ -172,7 +172,7 @@ class KtorFeatureTest : KtorTest() {
             }
         }
         runBlocking {
-            response.status shouldBeEqualTo HttpStatusCode.Unauthorized
+            response.status shouldBe HttpStatusCode.Unauthorized
         }
     }
 }

--- a/kgraphql-ktor/src/test/kotlin/com/apurebase/kgraphql/KtorMultipleEndpoints.kt
+++ b/kgraphql-ktor/src/test/kotlin/com/apurebase/kgraphql/KtorMultipleEndpoints.kt
@@ -1,5 +1,6 @@
 package com.apurebase.kgraphql
 
+import io.kotest.matchers.shouldBe
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.post
@@ -8,7 +9,6 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.testing.testApplication
-import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
 class KtorMultipleEndpoints : KtorTest() {
@@ -39,12 +39,12 @@ class KtorMultipleEndpoints : KtorTest() {
         client.post("/open") {
             header(HttpHeaders.ContentType, "application/json;charset=UTF-8")
             setBody(query)
-        }.bodyAsText() shouldBeEqualTo "{\"data\":{\"check\":\"Open\"}}"
+        }.bodyAsText() shouldBe "{\"data\":{\"check\":\"Open\"}}"
 
         client.post("/closed") {
             header(HttpHeaders.ContentType, "application/json;charset=UTF-8")
             setBody(query)
-        }.bodyAsText() shouldBeEqualTo "{\"data\":{\"check\":\"Closed\"}}"
+        }.bodyAsText() shouldBe "{\"data\":{\"check\":\"Closed\"}}"
     }
 
     @Test
@@ -57,7 +57,7 @@ class KtorMultipleEndpoints : KtorTest() {
             }
         }
 
-        client.get("/graphql").status shouldBeEqualTo HttpStatusCode.NotFound
+        client.get("/graphql").status shouldBe HttpStatusCode.NotFound
     }
 
     @Test
@@ -76,8 +76,8 @@ class KtorMultipleEndpoints : KtorTest() {
                 .readText()
 
         val response = client.get("/graphql")
-        response.status shouldBeEqualTo HttpStatusCode.OK
-        response.bodyAsText() shouldBeEqualTo playgroundHtml
+        response.status shouldBe HttpStatusCode.OK
+        response.bodyAsText() shouldBe playgroundHtml
     }
 
     @Test
@@ -91,8 +91,8 @@ class KtorMultipleEndpoints : KtorTest() {
         }
 
         val response = client.get("/graphql?schema")
-        response.status shouldBeEqualTo HttpStatusCode.OK
-        response.bodyAsText() shouldBeEqualTo """
+        response.status shouldBe HttpStatusCode.OK
+        response.bodyAsText() shouldBe """
             type Query {
               check: String!
             }
@@ -111,6 +111,6 @@ class KtorMultipleEndpoints : KtorTest() {
             }
         }
 
-        client.get("/graphql?schema").status shouldBeEqualTo HttpStatusCode.NotFound
+        client.get("/graphql?schema").status shouldBe HttpStatusCode.NotFound
     }
 }

--- a/kgraphql/build.gradle.kts
+++ b/kgraphql/build.gradle.kts
@@ -2,6 +2,7 @@ import kotlinx.benchmark.gradle.JvmBenchmarkTarget
 
 plugins {
     id("library-conventions")
+    id("java-test-fixtures")
     alias(libs.plugins.kotlinx.benchmark)
 }
 
@@ -37,11 +38,13 @@ dependencies {
     implementation(libs.caffeine)
     implementation(libs.deferredJsonBuilder)
 
-    testImplementation(libs.hamcrest)
-    testImplementation(libs.kluent)
+    testImplementation(libs.kotest)
     testImplementation(libs.junit.jupiter.api)
     testImplementation(libs.junit.jupiter.params)
     testImplementation(libs.kotlinx.coroutines.debug)
     testImplementation(libs.kotlinx.coroutines.test)
+
+    testFixturesImplementation(libs.kotest)
+
     benchmarkImplementation(libs.kotlinx.benchmark.runtime)
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/PropertyDSL.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/PropertyDSL.kt
@@ -4,7 +4,6 @@ import com.apurebase.kgraphql.Context
 import com.apurebase.kgraphql.schema.model.FunctionWrapper
 import com.apurebase.kgraphql.schema.model.InputValueDef
 import com.apurebase.kgraphql.schema.model.PropertyDef
-import java.lang.IllegalArgumentException
 import kotlin.reflect.KType
 
 class PropertyDSL<T : Any, R>(val name: String, block: PropertyDSL<T, R>.() -> Unit) : LimitedAccessItemDSL<T>(),

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/UnionPropertyDSL.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/UnionPropertyDSL.kt
@@ -5,7 +5,6 @@ import com.apurebase.kgraphql.schema.model.FunctionWrapper
 import com.apurebase.kgraphql.schema.model.InputValueDef
 import com.apurebase.kgraphql.schema.model.PropertyDef
 import com.apurebase.kgraphql.schema.model.TypeDef
-import java.lang.IllegalArgumentException
 import kotlin.reflect.KType
 
 class UnionPropertyDSL<T : Any>(val name: String, block: UnionPropertyDSL<T>.() -> Unit) : LimitedAccessItemDSL<T>(),

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/types/ShortScalarDSL.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/types/ShortScalarDSL.kt
@@ -2,8 +2,8 @@ package com.apurebase.kgraphql.schema.dsl.types
 
 import com.apurebase.kgraphql.schema.SchemaException
 import com.apurebase.kgraphql.schema.model.ast.ValueNode
-import com.apurebase.kgraphql.schema.scalar.ShortScalarCoercion
 import com.apurebase.kgraphql.schema.scalar.ScalarCoercion
+import com.apurebase.kgraphql.schema.scalar.ShortScalarCoercion
 import kotlin.reflect.KClass
 
 class ShortScalarDSL<T : Any>(kClass: KClass<T>) : ScalarDSL<T, Short>(kClass) {

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/InputValueDef.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/InputValueDef.kt
@@ -1,7 +1,6 @@
 package com.apurebase.kgraphql.schema.model
 
 import kotlin.reflect.KClass
-import kotlin.reflect.KParameter
 import kotlin.reflect.KType
 
 class InputValueDef<T : Any>(

--- a/kgraphql/src/main/kotlin/nidomiro/kdataloader/DataLoader.kt
+++ b/kgraphql/src/main/kotlin/nidomiro/kdataloader/DataLoader.kt
@@ -1,7 +1,6 @@
 package nidomiro.kdataloader
 
 import kotlinx.coroutines.Deferred
-import kotlin.jvm.JvmName
 import nidomiro.kdataloader.statistics.DataLoaderStatistics
 
 typealias BatchLoader<K, R> = suspend (ids: List<K>) -> List<ExecutionResult<R>>

--- a/kgraphql/src/main/kotlin/nidomiro/kdataloader/factories/TimedAutoDispatcherDataLoaderFactory.kt
+++ b/kgraphql/src/main/kotlin/nidomiro/kdataloader/factories/TimedAutoDispatcherDataLoaderFactory.kt
@@ -3,8 +3,8 @@ package nidomiro.kdataloader.factories
 import nidomiro.kdataloader.BatchLoader
 import nidomiro.kdataloader.DataLoaderOptions
 import nidomiro.kdataloader.ExecutionResult
-import nidomiro.kdataloader.TimedAutoDispatcherImpl
 import nidomiro.kdataloader.TimedAutoDispatcherDataLoaderOptions
+import nidomiro.kdataloader.TimedAutoDispatcherImpl
 
 class TimedAutoDispatcherDataLoaderFactory<K, R>(
     optionsFactory: () -> TimedAutoDispatcherDataLoaderOptions<K, R>,

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/DataLoaderTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/DataLoaderTest.kt
@@ -3,15 +3,13 @@ package com.apurebase.kgraphql
 import com.apurebase.kgraphql.schema.DefaultSchema
 import com.apurebase.kgraphql.schema.dsl.SchemaBuilder
 import com.apurebase.kgraphql.schema.execution.Executor
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import nidomiro.kdataloader.ExecutionResult
-import org.amshove.kluent.shouldBeEqualTo
-import org.hamcrest.CoreMatchers
-import org.hamcrest.MatcherAssert
 import org.junit.jupiter.api.Assertions.assertTimeoutPreemptively
 import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.RepeatedTest
@@ -253,32 +251,32 @@ class DataLoaderTest {
                 DynamicTest.dynamicTest("test-$it") {
                     val result = schema.executeBlocking(query).also(::println).deserialize()
 
-                    result.extract<String>("data/abc[0]/value") shouldBeEqualTo "Testing 1"
-                    result.extract<String>("data/abc[0]/person/fullName") shouldBeEqualTo "Jógvan Olsen"
-                    result.extract<String>("data/abc[0]/simpleChild/value") shouldBeEqualTo "NewChild!"
-                    result.extract<String?>("data/abc[0]/simpleChild/person") shouldBeEqualTo null
-                    result.extract<String?>("data/abc[0]/simpleChild/simpleChild/value") shouldBeEqualTo "NewChild!"
+                    result.extract<String>("data/abc[0]/value") shouldBe "Testing 1"
+                    result.extract<String>("data/abc[0]/person/fullName") shouldBe "Jógvan Olsen"
+                    result.extract<String>("data/abc[0]/simpleChild/value") shouldBe "NewChild!"
+                    result.extract<String?>("data/abc[0]/simpleChild/person") shouldBe null
+                    result.extract<String?>("data/abc[0]/simpleChild/simpleChild/value") shouldBe "NewChild!"
 
-                    result.extract<String>("data/abc[1]/value") shouldBeEqualTo "Testing 2"
-                    result.extract<String?>("data/abc[1]/person") shouldBeEqualTo null
-                    result.extract<String>("data/abc[1]/simpleChild/value") shouldBeEqualTo "NewChild!"
-                    result.extract<String?>("data/abc[1]/simpleChild/person") shouldBeEqualTo null
-                    result.extract<String?>("data/abc[1]/simpleChild/simpleChild/value") shouldBeEqualTo "NewChild!"
+                    result.extract<String>("data/abc[1]/value") shouldBe "Testing 2"
+                    result.extract<String?>("data/abc[1]/person") shouldBe null
+                    result.extract<String>("data/abc[1]/simpleChild/value") shouldBe "NewChild!"
+                    result.extract<String?>("data/abc[1]/simpleChild/person") shouldBe null
+                    result.extract<String?>("data/abc[1]/simpleChild/simpleChild/value") shouldBe "NewChild!"
 
-                    result.extract<String>("data/abc[2]/value") shouldBeEqualTo "Testing 3"
-                    result.extract<String?>("data/abc[2]/person/fullName") shouldBeEqualTo "Høgni Juul"
-                    result.extract<String>("data/abc[2]/simpleChild/value") shouldBeEqualTo "NewChild!"
-                    result.extract<String?>("data/abc[2]/simpleChild/person") shouldBeEqualTo null
-                    result.extract<String?>("data/abc[2]/simpleChild/simpleChild/value") shouldBeEqualTo "NewChild!"
+                    result.extract<String>("data/abc[2]/value") shouldBe "Testing 3"
+                    result.extract<String?>("data/abc[2]/person/fullName") shouldBe "Høgni Juul"
+                    result.extract<String>("data/abc[2]/simpleChild/value") shouldBe "NewChild!"
+                    result.extract<String?>("data/abc[2]/simpleChild/person") shouldBe null
+                    result.extract<String?>("data/abc[2]/simpleChild/simpleChild/value") shouldBe "NewChild!"
 
                     if (withTypeName) {
-                        result.extract<String>("data/abc[0]/__typename") shouldBeEqualTo "ABC"
-                        result.extract<String>("data/abc[0]/person/__typename") shouldBeEqualTo "Person"
-                        result.extract<String>("data/abc[0]/simpleChild/__typename") shouldBeEqualTo "ABC"
-                        result.extract<String>("data/abc[1]/__typename") shouldBeEqualTo "ABC"
-                        result.extract<String>("data/abc[1]/simpleChild/__typename") shouldBeEqualTo "ABC"
-                        result.extract<String>("data/abc[2]/__typename") shouldBeEqualTo "ABC"
-                        result.extract<String>("data/abc[2]/simpleChild/__typename") shouldBeEqualTo "ABC"
+                        result.extract<String>("data/abc[0]/__typename") shouldBe "ABC"
+                        result.extract<String>("data/abc[0]/person/__typename") shouldBe "Person"
+                        result.extract<String>("data/abc[0]/simpleChild/__typename") shouldBe "ABC"
+                        result.extract<String>("data/abc[1]/__typename") shouldBe "ABC"
+                        result.extract<String>("data/abc[1]/simpleChild/__typename") shouldBe "ABC"
+                        result.extract<String>("data/abc[2]/__typename") shouldBe "ABC"
+                        result.extract<String>("data/abc[2]/simpleChild/__typename") shouldBe "ABC"
                     }
                 }
             }
@@ -336,11 +334,7 @@ class DataLoaderTest {
             """.trimIndent()
 
             val result = schema.executeBlocking(query).also(::println).deserialize()
-
-            MatcherAssert.assertThat(
-                result.extract<String>("data/abc[0]/simpleChild/value"),
-                CoreMatchers.equalTo("NewChild!")
-            )
+            result.extract<String>("data/abc[0]/simpleChild/value") shouldBe "NewChild!"
         }
     }
 
@@ -387,9 +381,9 @@ class DataLoaderTest {
             """.trimIndent()
             val result = schema.executeBlocking(query).also(::println).deserialize()
 
-            result.extract<String>("data/abc[0]/person/fullName") shouldBeEqualTo "${jogvan.firstName} ${jogvan.lastName}"
-            result.extract<String?>("data/abc[1]/person") shouldBeEqualTo null
-            result.extract<String>("data/abc[2]/person/fullName") shouldBeEqualTo "${juul.firstName} ${juul.lastName}"
+            result.extract<String>("data/abc[0]/person/fullName") shouldBe "${jogvan.firstName} ${jogvan.lastName}"
+            result.extract<String?>("data/abc[1]/person") shouldBe null
+            result.extract<String>("data/abc[2]/person/fullName") shouldBe "${juul.firstName} ${juul.lastName}"
         }
     }
 
@@ -414,8 +408,8 @@ class DataLoaderTest {
             val result = schema.executeBlocking(query).also(::println).deserialize()
 
 
-            result.extract<String>("data/people[0]/respondsTo/fullName") shouldBeEqualTo "${juul.firstName} ${juul.lastName}"
-            result.extract<String>("data/people[1]/colleagues[0]/fullName") shouldBeEqualTo "${jogvan.firstName} ${jogvan.lastName}"
+            result.extract<String>("data/people[0]/respondsTo/fullName") shouldBe "${juul.firstName} ${juul.lastName}"
+            result.extract<String>("data/people[1]/colleagues[0]/fullName") shouldBe "${jogvan.firstName} ${jogvan.lastName}"
         }
     }
 
@@ -437,13 +431,13 @@ class DataLoaderTest {
             """.trimIndent()
 
             val result = schema.executeBlocking(query).also(::println).deserialize()
-            counters.treeChild.prepare.get() shouldBeEqualTo 2
-            counters.treeChild.loader.get() shouldBeEqualTo 1
+            counters.treeChild.prepare.get() shouldBe 2
+            counters.treeChild.loader.get() shouldBe 1
 
 
-            result.extract<Int>("data/tree[1]/id") shouldBeEqualTo 2
-            result.extract<Int>("data/tree[0]/child/id") shouldBeEqualTo 14
-            result.extract<Int>("data/tree[1]/child/id") shouldBeEqualTo 15
+            result.extract<Int>("data/tree[1]/id") shouldBe 2
+            result.extract<Int>("data/tree[0]/child/id") shouldBe 14
+            result.extract<Int>("data/tree[1]/child/id") shouldBe 15
         }
     }
 
@@ -461,13 +455,13 @@ class DataLoaderTest {
 
             val result = schema.executeBlocking(query).also(::println).deserialize()
 
-            counters.treeChild.prepare.get() shouldBeEqualTo 4
-            counters.treeChild.loader.get() shouldBeEqualTo 1
+            counters.treeChild.prepare.get() shouldBe 4
+            counters.treeChild.loader.get() shouldBe 1
 
-            result.extract<Int>("data/first[1]/id") shouldBeEqualTo 2
-            result.extract<Int>("data/first[0]/child/id") shouldBeEqualTo 14
-            result.extract<Int>("data/first[1]/child/id") shouldBeEqualTo 15
-            result.extract<Int>("data/second[1]/child/id") shouldBeEqualTo 15
+            result.extract<Int>("data/first[1]/id") shouldBe 2
+            result.extract<Int>("data/first[0]/child/id") shouldBe 14
+            result.extract<Int>("data/first[1]/child/id") shouldBe 15
+            result.extract<Int>("data/second[1]/child/id") shouldBe 15
 
         }
     }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/GraphQLErrorTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/GraphQLErrorTest.kt
@@ -1,11 +1,11 @@
 package com.apurebase.kgraphql
 
+import io.kotest.matchers.shouldBe
 import kotlinx.serialization.json.add
 import kotlinx.serialization.json.addJsonObject
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
-import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
 class GraphQLErrorTest {
@@ -30,7 +30,7 @@ class GraphQLErrorTest {
             })
         }.toString()
 
-        graphqlError.serialize() shouldBeEqualTo expectedJson
+        graphqlError.serialize() shouldBe expectedJson
     }
 
     @Test
@@ -64,7 +64,7 @@ class GraphQLErrorTest {
             })
         }.toString()
 
-        graphqlError.serialize() shouldBeEqualTo expectedJson
+        graphqlError.serialize() shouldBe expectedJson
     }
 
     @Test
@@ -110,6 +110,6 @@ class GraphQLErrorTest {
             })
         }.toString()
 
-        graphqlError.serialize() shouldBeEqualTo expectedJson
+        graphqlError.serialize() shouldBe expectedJson
     }
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/access/AccessRulesTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/access/AccessRulesTest.kt
@@ -6,8 +6,7 @@ import com.apurebase.kgraphql.defaultSchema
 import com.apurebase.kgraphql.deserialize
 import com.apurebase.kgraphql.expect
 import com.apurebase.kgraphql.extract
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.MatcherAssert.assertThat
+import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 
 class AccessRulesTest {
@@ -44,7 +43,7 @@ class AccessRulesTest {
             schema.executeBlocking("{black_mamba{name}}", context = context { +"LAKERS" })
         ).extract<String>("data/black_mamba/name")
 
-        assertThat(kobe, equalTo("KOBE"))
+        kobe shouldBe "KOBE"
     }
 
     @Test
@@ -58,10 +57,7 @@ class AccessRulesTest {
 
     @Test
     fun `allow property resolver access rule`() {
-        assertThat(
-            deserialize(schema.executeBlocking("{white_mamba {item}}")).extract<String>("data/white_mamba/item"),
-            equalTo("item")
-        )
+        deserialize(schema.executeBlocking("{white_mamba {item}}")).extract<String>("data/white_mamba/item") shouldBe "item"
     }
 
     @Test

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/demo/StarWarsSchema.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/demo/StarWarsSchema.kt
@@ -1,7 +1,7 @@
 package com.apurebase.kgraphql.demo
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.apurebase.kgraphql.KGraphQL
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 
 enum class Episode {
     NEWHOPE, EMPIRE, JEDI

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/BaseSchemaTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/BaseSchemaTest.kt
@@ -103,7 +103,16 @@ abstract class BaseSchemaTest {
         }
         query("people") {
             description = "List of all people"
-            resolver { -> listOf(davidFincher, bradPitt, morganFreeman, christianBale, christopherNolan, martinScorsese) }
+            resolver { ->
+                listOf(
+                    davidFincher,
+                    bradPitt,
+                    morganFreeman,
+                    christianBale,
+                    christopherNolan,
+                    martinScorsese
+                )
+            }
         }
         query("randomPerson") {
             description = "not really random person"

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/DataLoaderExecutionTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/DataLoaderExecutionTest.kt
@@ -4,11 +4,10 @@ import com.apurebase.kgraphql.defaultSchema
 import com.apurebase.kgraphql.deserialize
 import com.apurebase.kgraphql.extract
 import com.apurebase.kgraphql.schema.execution.Executor
+import io.kotest.matchers.collections.shouldHaveSize
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import nidomiro.kdataloader.ExecutionResult
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.hasSize
 import org.junit.jupiter.api.RepeatedTest
 import kotlin.random.Random
 import kotlin.random.nextInt
@@ -102,8 +101,8 @@ class DataLoaderExecutionTest {
             )
         )
 
-        assertThat(result.extract<List<*>>("data/data1"), hasSize(250))
-        assertThat(result.extract<List<*>>("data/data2"), hasSize(200))
-        assertThat(result.extract<List<*>>("data/data3"), hasSize(1000))
+        result.extract<List<*>>("data/data1") shouldHaveSize 250
+        result.extract<List<*>>("data/data2") shouldHaveSize 200
+        result.extract<List<*>>("data/data3") shouldHaveSize 1000
     }
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/EnumTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/EnumTest.kt
@@ -5,8 +5,7 @@ import com.apurebase.kgraphql.assertNoErrors
 import com.apurebase.kgraphql.defaultSchema
 import com.apurebase.kgraphql.deserialize
 import com.apurebase.kgraphql.extract
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.MatcherAssert.assertThat
+import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 
 class EnumTest : BaseSchemaTest() {
@@ -15,15 +14,15 @@ class EnumTest : BaseSchemaTest() {
     fun `query with enum field`() {
         val map = execute("{film{type}}")
         assertNoErrors(map)
-        assertThat(map.extract<String>("data/film/type"), equalTo("FULL_LENGTH"))
+        map.extract<String>("data/film/type") shouldBe "FULL_LENGTH"
     }
 
     @Test
     fun `query with enum argument`() {
         val map = execute("{ films: filmsByType(type: FULL_LENGTH){title, type}}")
         assertNoErrors(map)
-        assertThat(map.extract<String>("data/films[0]/type"), equalTo("FULL_LENGTH"))
-        assertThat(map.extract<String>("data/films[1]/type"), equalTo("FULL_LENGTH"))
+        map.extract<String>("data/films[0]/type") shouldBe "FULL_LENGTH"
+        map.extract<String>("data/films[1]/type") shouldBe "FULL_LENGTH"
     }
 
     @Test
@@ -47,6 +46,6 @@ class EnumTest : BaseSchemaTest() {
         ).deserialize()
 
         assertNoErrors(map)
-        assertThat(map.extract<String>("data/search"), equalTo("You searched for: FULL_LENGTH"))
+        map.extract<String>("data/search") shouldBe "You searched for: FULL_LENGTH"
     }
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/InputObjectTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/InputObjectTest.kt
@@ -1,11 +1,9 @@
 package com.apurebase.kgraphql.integration
 
 import com.apurebase.kgraphql.KGraphQL
+import com.apurebase.kgraphql.expect
 import com.apurebase.kgraphql.schema.SchemaException
-import org.amshove.kluent.invoking
-import org.amshove.kluent.shouldBeEqualTo
-import org.amshove.kluent.shouldThrow
-import org.amshove.kluent.withMessage
+import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 
 class InputObjectTest {
@@ -24,7 +22,7 @@ class InputObjectTest {
         }
 
         val sdl = schema.printSchema()
-        sdl shouldBeEqualTo """
+        sdl shouldBe """
             type Mutation {
               addPerson(person: PersonInput!): Person!
             }
@@ -51,7 +49,7 @@ class InputObjectTest {
               getPerson(name: "foo") { name age }
             }
         """.trimIndent()
-        ) shouldBeEqualTo """
+        ) shouldBe """
             {"data":{"getPerson":{"name":"foo","age":42}}}
         """.trimIndent()
 
@@ -61,7 +59,7 @@ class InputObjectTest {
               addPerson(person: { name: "bar", age: 20 }) { name age }
             }
         """.trimIndent()
-        ) shouldBeEqualTo """
+        ) shouldBe """
             {"data":{"addPerson":{"name":"bar","age":20}}}
         """.trimIndent()
 
@@ -75,7 +73,7 @@ class InputObjectTest {
             }
         """.trimIndent(),
             variables = variables
-        ) shouldBeEqualTo """
+        ) shouldBe """
             {"data":{"addPerson":{"name":"foobar","age":60}}}
         """.trimIndent()
     }
@@ -103,7 +101,7 @@ class InputObjectTest {
         }
 
         val sdl = schema.printSchema()
-        sdl shouldBeEqualTo """
+        sdl shouldBe """
             type Mutation {
               addPerson(person: PersonInput!): Person!
             }
@@ -130,7 +128,7 @@ class InputObjectTest {
               getPerson(name: "foo") { name age }
             }
         """.trimIndent()
-        ) shouldBeEqualTo """
+        ) shouldBe """
             {"data":{"getPerson":{"name":"foo","age":42}}}
         """.trimIndent()
 
@@ -140,7 +138,7 @@ class InputObjectTest {
               addPerson(person: { inputName: "bar", inputAge: 20 }) { name age }
             }
         """.trimIndent()
-        ) shouldBeEqualTo """
+        ) shouldBe """
             {"data":{"addPerson":{"name":"bar","age":20}}}
         """.trimIndent()
 
@@ -154,14 +152,14 @@ class InputObjectTest {
             }
         """.trimIndent(),
             variables = variables
-        ) shouldBeEqualTo """
+        ) shouldBe """
             {"data":{"addPerson":{"name":"foobar","age":60}}}
         """.trimIndent()
     }
 
     @Test
     fun `property name must not start with __ when configured`() {
-        invoking {
+        expect<SchemaException>("Illegal name '__name'. Names starting with '__' are reserved for introspection system") {
             KGraphQL.schema {
                 inputType<Person> {
                     property(Person::name) {
@@ -173,6 +171,6 @@ class InputObjectTest {
                     resolver { person: Person -> person }
                 }
             }
-        } shouldThrow SchemaException::class withMessage "Illegal name '__name'. Names starting with '__' are reserved for introspection system"
+        }
     }
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/LongScalarTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/LongScalarTest.kt
@@ -4,8 +4,7 @@ import com.apurebase.kgraphql.KGraphQL
 import com.apurebase.kgraphql.defaultSchema
 import com.apurebase.kgraphql.deserialize
 import com.apurebase.kgraphql.extract
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.MatcherAssert.assertThat
+import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 
 class LongScalarTest {
@@ -21,7 +20,7 @@ class LongScalarTest {
 
         val response = schema.executeBlocking("{ long }")
         val long = deserialize(response).extract<Long>("data/long")
-        assertThat(long, equalTo(Long.MAX_VALUE))
+        long shouldBe Long.MAX_VALUE
     }
 
     @Test
@@ -42,7 +41,7 @@ class LongScalarTest {
         val isLong = deserialize(
             schema.executeBlocking("{ isLong(long: ${Int.MAX_VALUE.toLong() + 1}) }")
         ).extract<String>("data/isLong")
-        assertThat(isLong, equalTo("YES"))
+        isLong shouldBe "YES"
     }
 
     data class VeryLong(val long: Long)
@@ -62,7 +61,6 @@ class LongScalarTest {
 
         val value = Int.MAX_VALUE.toLong() + 2
         val response = deserialize(schema.executeBlocking("{ number(number: $value) }"))
-        assertThat(response.extract<Long>("data/number"), equalTo(value))
+        response.extract<Long>("data/number") shouldBe value
     }
-
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/ObjectTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/ObjectTest.kt
@@ -1,11 +1,9 @@
 package com.apurebase.kgraphql.integration
 
 import com.apurebase.kgraphql.KGraphQL
+import com.apurebase.kgraphql.expect
 import com.apurebase.kgraphql.schema.SchemaException
-import org.amshove.kluent.invoking
-import org.amshove.kluent.shouldBeEqualTo
-import org.amshove.kluent.shouldThrow
-import org.amshove.kluent.withMessage
+import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 
 class ObjectTest {
@@ -20,7 +18,7 @@ class ObjectTest {
         }
 
         val sdl = schema.printSchema()
-        sdl shouldBeEqualTo """
+        sdl shouldBe """
             type Person {
               age: Int!
               name: String!
@@ -38,7 +36,7 @@ class ObjectTest {
               getPerson(name: "foo") { name age }
             }
         """.trimIndent()
-        ) shouldBeEqualTo """
+        ) shouldBe """
             {"data":{"getPerson":{"name":"foo","age":42}}}
         """.trimIndent()
     }
@@ -61,7 +59,7 @@ class ObjectTest {
         }
 
         val sdl = schema.printSchema()
-        sdl shouldBeEqualTo """
+        sdl shouldBe """
             type Person {
               newAge: Int!
               newName: String!
@@ -79,14 +77,14 @@ class ObjectTest {
               getPerson(name: "foo") { newName newAge }
             }
         """.trimIndent()
-        ) shouldBeEqualTo """
+        ) shouldBe """
             {"data":{"getPerson":{"newName":"foo","newAge":42}}}
         """.trimIndent()
     }
 
     @Test
     fun `property name must not start with __ when configured`() {
-        invoking {
+        expect<SchemaException>("Illegal name '__name'. Names starting with '__' are reserved for introspection system") {
             KGraphQL.schema {
                 type<Person> {
                     property(Person::name) {
@@ -98,6 +96,6 @@ class ObjectTest {
                     resolver { name: String -> Person(name = name, age = 42) }
                 }
             }
-        } shouldThrow SchemaException::class withMessage "Illegal name '__name'. Names starting with '__' are reserved for introspection system"
+        }
     }
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/ParallelExecutionTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/ParallelExecutionTest.kt
@@ -3,9 +3,8 @@ package com.apurebase.kgraphql.integration
 import com.apurebase.kgraphql.KGraphQL
 import com.apurebase.kgraphql.deserialize
 import com.apurebase.kgraphql.extract
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.delay
-import org.hamcrest.CoreMatchers
-import org.hamcrest.MatcherAssert
 import org.junit.jupiter.api.Test
 import kotlin.random.Random
 
@@ -56,13 +55,13 @@ class ParallelExecutionTest {
         val query = "{getAll{id,children{id}}}"
         val map = deserialize(suspendPropertySchema.executeBlocking(query))
 
-        MatcherAssert.assertThat(map.extract<Int>("data/getAll[0]/id"), CoreMatchers.equalTo(0))
-        MatcherAssert.assertThat(map.extract<Int>("data/getAll[500]/id"), CoreMatchers.equalTo(500))
-        MatcherAssert.assertThat(map.extract<Int>("data/getAll[766]/id"), CoreMatchers.equalTo(766))
+        map.extract<Int>("data/getAll[0]/id") shouldBe 0
+        map.extract<Int>("data/getAll[500]/id") shouldBe 500
+        map.extract<Int>("data/getAll[766]/id") shouldBe 766
 
-        MatcherAssert.assertThat(map.extract<Int>("data/getAll[5]/children[5]/id"), CoreMatchers.equalTo(55))
-        MatcherAssert.assertThat(map.extract<Int>("data/getAll[75]/children[9]/id"), CoreMatchers.equalTo(759))
-        MatcherAssert.assertThat(map.extract<Int>("data/getAll[888]/children[50]/id"), CoreMatchers.equalTo(8930))
+        map.extract<Int>("data/getAll[5]/children[5]/id") shouldBe 55
+        map.extract<Int>("data/getAll[75]/children[9]/id") shouldBe 759
+        map.extract<Int>("data/getAll[888]/children[50]/id") shouldBe 8930
     }
 
     val query = "{\n" + (0..999).joinToString("") { "automated_${it}\n" } + " }"
@@ -70,20 +69,20 @@ class ParallelExecutionTest {
     @Test
     fun `1000 synchronous resolvers sleeping with Thread sleep`() {
         val map = deserialize(syncResolversSchema.executeBlocking(query))
-        MatcherAssert.assertThat(map.extract<String>("data/automated_0"), CoreMatchers.equalTo("0"))
-        MatcherAssert.assertThat(map.extract<String>("data/automated_271"), CoreMatchers.equalTo("271"))
-        MatcherAssert.assertThat(map.extract<String>("data/automated_314"), CoreMatchers.equalTo("314"))
-        MatcherAssert.assertThat(map.extract<String>("data/automated_500"), CoreMatchers.equalTo("500"))
-        MatcherAssert.assertThat(map.extract<String>("data/automated_999"), CoreMatchers.equalTo("999"))
+        map.extract<String>("data/automated_0") shouldBe "0"
+        map.extract<String>("data/automated_271") shouldBe "271"
+        map.extract<String>("data/automated_314") shouldBe "314"
+        map.extract<String>("data/automated_500") shouldBe "500"
+        map.extract<String>("data/automated_999") shouldBe "999"
     }
 
     @Test
     fun `1000 suspending resolvers sleeping with suspending delay`() {
         val map = deserialize(suspendResolverSchema.executeBlocking(query))
-        MatcherAssert.assertThat(map.extract<String>("data/automated_0"), CoreMatchers.equalTo("0"))
-        MatcherAssert.assertThat(map.extract<String>("data/automated_271"), CoreMatchers.equalTo("271"))
-        MatcherAssert.assertThat(map.extract<String>("data/automated_314"), CoreMatchers.equalTo("314"))
-        MatcherAssert.assertThat(map.extract<String>("data/automated_500"), CoreMatchers.equalTo("500"))
-        MatcherAssert.assertThat(map.extract<String>("data/automated_999"), CoreMatchers.equalTo("999"))
+        map.extract<String>("data/automated_0") shouldBe "0"
+        map.extract<String>("data/automated_271") shouldBe "271"
+        map.extract<String>("data/automated_314") shouldBe "314"
+        map.extract<String>("data/automated_500") shouldBe "500"
+        map.extract<String>("data/automated_999") shouldBe "999"
     }
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/QueryTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/QueryTest.kt
@@ -1,18 +1,15 @@
 package com.apurebase.kgraphql.integration
 
-import com.apurebase.kgraphql.GraphQLError
+import com.apurebase.kgraphql.ValidationException
 import com.apurebase.kgraphql.assertNoErrors
 import com.apurebase.kgraphql.defaultSchema
 import com.apurebase.kgraphql.deserialize
 import com.apurebase.kgraphql.extract
 import com.apurebase.kgraphql.helpers.getFields
 import com.apurebase.kgraphql.schema.execution.Execution
-import org.amshove.kluent.invoking
-import org.amshove.kluent.shouldBeEqualTo
-import org.amshove.kluent.shouldThrow
-import org.amshove.kluent.with
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.MatcherAssert.assertThat
+import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.throwable.shouldHaveMessage
 import org.junit.jupiter.api.Test
 
 class QueryTest : BaseSchemaTest() {
@@ -20,136 +17,119 @@ class QueryTest : BaseSchemaTest() {
     fun `query nested selection set`() {
         val map = execute("{film{title, director{name, age}}}")
         assertNoErrors(map)
-        assertThat(map.extract<String>("data/film/title"), equalTo(prestige.title))
-        assertThat(map.extract<String>("data/film/director/name"), equalTo(prestige.director.name))
-        assertThat(map.extract<Int>("data/film/director/age"), equalTo(prestige.director.age))
+        map.extract<String>("data/film/title") shouldBe prestige.title
+        map.extract<String>("data/film/director/name") shouldBe prestige.director.name
+        map.extract<Int>("data/film/director/age") shouldBe prestige.director.age
     }
 
     @Test
     fun `query collection field`() {
         val map = execute("{film{title, director{favActors{name, age}}}}")
         assertNoErrors(map)
-        assertThat(
-            map.extract<Map<String, String>>("data/film/director/favActors[0]"), equalTo(
-                mapOf(
-                    "name" to prestige.director.favActors[0].name,
-                    "age" to prestige.director.favActors[0].age
-                )
+        map.extract<Map<String, String>>("data/film/director/favActors[0]") shouldBe
+            mapOf(
+                "name" to prestige.director.favActors[0].name,
+                "age" to prestige.director.favActors[0].age
             )
-        )
     }
 
     @Test
     fun `query scalar field`() {
         val map = execute("{film{id}}")
         assertNoErrors(map)
-        assertThat(map.extract<String>("data/film/id"), equalTo("${prestige.id.literal}:${prestige.id.numeric}"))
+        map.extract<String>("data/film/id") shouldBe "${prestige.id.literal}:${prestige.id.numeric}"
     }
 
     @Test
     fun `query with selection set on collection`() {
         val map = execute("{film{title, director{favActors{name}}}}")
         assertNoErrors(map)
-        assertThat(
-            map.extract<Map<String, String>>("data/film/director/favActors[0]"),
-            equalTo(mapOf("name" to prestige.director.favActors[0].name))
-        )
+        map.extract<Map<String, String>>("data/film/director/favActors[0]") shouldBe mapOf("name" to prestige.director.favActors[0].name)
     }
 
     @Test
     fun `query with selection set on collection 2`() {
         val map = execute("{film{title, director{favActors{age}}}}")
         assertNoErrors(map)
-        assertThat(
-            map.extract<Map<String, Int>>("data/film/director/favActors[0]"),
-            equalTo(mapOf("age" to prestige.director.favActors[0].age))
-        )
+        map.extract<Map<String, Int>>("data/film/director/favActors[0]") shouldBe mapOf("age" to prestige.director.favActors[0].age)
     }
 
     @Test
     fun `query with invalid field name`() {
-        invoking {
+        val exception = shouldThrowExactly<ValidationException> {
             execute("{film{title, director{name, favDish}}}")
-        } shouldThrow GraphQLError::class with {
-            message shouldBeEqualTo "Property favDish on Director does not exist"
-            extensions shouldBeEqualTo mapOf(
-                "type" to "GRAPHQL_VALIDATION_FAILED"
-            )
         }
+        exception shouldHaveMessage  "Property favDish on Director does not exist"
+        exception.extensions shouldBe mapOf(
+            "type" to "GRAPHQL_VALIDATION_FAILED"
+        )
     }
 
     @Test
     fun `query with argument`() {
         val map = execute("{filmByRank(rank: 1){title}}")
         assertNoErrors(map)
-        assertThat(map.extract<String>("data/filmByRank/title"), equalTo("Prestige"))
+        map.extract<String>("data/filmByRank/title") shouldBe "Prestige"
     }
 
     @Test
     fun `query with argument 2`() {
         val map = execute("{filmByRank(rank: 2){title}}")
         assertNoErrors(map)
-        assertThat(map.extract<String>("data/filmByRank/title"), equalTo("Se7en"))
+        map.extract<String>("data/filmByRank/title") shouldBe "Se7en"
     }
 
     @Test
     fun `query with alias`() {
         val map = execute("{bestFilm: filmByRank(rank: 1){title}}")
         assertNoErrors(map)
-        assertThat(map.extract<String>("data/bestFilm/title"), equalTo("Prestige"))
+        map.extract<String>("data/bestFilm/title") shouldBe "Prestige"
     }
 
     @Test
     fun `query with field alias`() {
         val map = execute("{filmByRank(rank: 2){fullTitle: title}}")
         assertNoErrors(map)
-        assertThat(map.extract<String>("data/filmByRank/fullTitle"), equalTo("Se7en"))
+        map.extract<String>("data/filmByRank/fullTitle") shouldBe "Se7en"
     }
 
     @Test
     fun `query with multiple aliases`() {
         val map = execute("{bestFilm: filmByRank(rank: 1){title}, secondBestFilm: filmByRank(rank: 2){title}}")
         assertNoErrors(map)
-        assertThat(map.extract<String>("data/bestFilm/title"), equalTo("Prestige"))
-        assertThat(map.extract<String>("data/secondBestFilm/title"), equalTo("Se7en"))
+        map.extract<String>("data/bestFilm/title") shouldBe "Prestige"
+        map.extract<String>("data/secondBestFilm/title") shouldBe "Se7en"
     }
 
     @Test
     fun `query with ignored property`() {
-        invoking {
+        val exception = shouldThrowExactly<ValidationException> {
             execute("{scenario{author, content}}")
-        } shouldThrow GraphQLError::class with {
-            message shouldBeEqualTo "Property author on Scenario does not exist"
-            extensions shouldBeEqualTo mapOf(
-                "type" to "GRAPHQL_VALIDATION_FAILED"
-            )
         }
+        exception shouldHaveMessage  "Property author on Scenario does not exist"
+        exception.extensions shouldBe mapOf(
+            "type" to "GRAPHQL_VALIDATION_FAILED"
+        )
     }
 
     @Test
     fun `query with interface`() {
         val map = execute("{randomPerson{name \n age}}")
-        assertThat(
-            map.extract<Map<String, String>>("data/randomPerson"), equalTo(
-                mapOf(
-                    "name" to davidFincher.name,
-                    "age" to davidFincher.age
-                )
+        map.extract<Map<String, String>>("data/randomPerson") shouldBe
+            mapOf(
+                "name" to davidFincher.name,
+                "age" to davidFincher.age
             )
-        )
     }
 
     @Test
     fun `query with collection elements interface`() {
         val map = execute("{people{name, age}}")
-        assertThat(
-            map.extract<Map<String, String>>("data/people[0]"), equalTo(
-                mapOf(
-                    "name" to davidFincher.name,
-                    "age" to davidFincher.age
-                )
+        map.extract<Map<String, String>>("data/people[0]") shouldBe
+            mapOf(
+                "name" to davidFincher.name,
+                "age" to davidFincher.age
             )
-        )
     }
 
     @Test
@@ -158,7 +138,7 @@ class QueryTest : BaseSchemaTest() {
         for (i in 0..4) {
             val isOld = map.extract<Boolean>("data/actors[$i]/isOld")
             val age = map.extract<Int>("data/actors[$i]/age")
-            assertThat(isOld, equalTo(age > 500))
+            isOld shouldBe (age > 500)
         }
     }
 
@@ -167,10 +147,7 @@ class QueryTest : BaseSchemaTest() {
         val map = execute("{actors{name, picture(big: true)}}")
         for (i in 0..4) {
             val name = map.extract<String>("data/actors[$i]/name").replace(' ', '_')
-            assertThat(
-                map.extract<String>("data/actors[$i]/picture"),
-                equalTo("http://picture.server/pic/$name?big=true")
-            )
+            map.extract<String>("data/actors[$i]/picture") shouldBe "http://picture.server/pic/$name?big=true"
         }
     }
 
@@ -179,10 +156,7 @@ class QueryTest : BaseSchemaTest() {
         val map = execute("{actors{name, picture}}")
         for (i in 0..4) {
             val name = map.extract<String>("data/actors[$i]/name").replace(' ', '_')
-            assertThat(
-                map.extract<String>("data/actors[$i]/picture"),
-                equalTo("http://picture.server/pic/$name?big=false")
-            )
+            map.extract<String>("data/actors[$i]/picture") shouldBe "http://picture.server/pic/$name?big=false"
         }
     }
 
@@ -191,10 +165,7 @@ class QueryTest : BaseSchemaTest() {
         val map = execute("{actors{name, pictureWithArgs}}")
         for (i in 0..4) {
             val name = map.extract<String>("data/actors[$i]/name").replace(' ', '_')
-            assertThat(
-                map.extract<String>("data/actors[$i]/pictureWithArgs"),
-                equalTo("http://picture.server/pic/$name?big=false")
-            )
+            map.extract<String>("data/actors[$i]/pictureWithArgs") shouldBe "http://picture.server/pic/$name?big=false"
         }
     }
 
@@ -219,31 +190,30 @@ class QueryTest : BaseSchemaTest() {
     @Test
     fun `query with transformed property`() {
         val map = execute("{scenario{id, content(uppercase: false)}}")
-        assertThat(map.extract<String>("data/scenario/content"), equalTo("Very long scenario"))
+        map.extract<String>("data/scenario/content") shouldBe "Very long scenario"
 
         val map2 = execute("{scenario{id, content(uppercase: true)}}")
-        assertThat(map2.extract<String>("data/scenario/content"), equalTo("VERY LONG SCENARIO"))
+        map2.extract<String>("data/scenario/content") shouldBe "VERY LONG SCENARIO"
     }
 
     @Test
     fun `query with invalid field arguments`() {
-        invoking {
+        val exception = shouldThrowExactly<ValidationException> {
             execute("{scenario{id(uppercase: true), content}}")
-        } shouldThrow GraphQLError::class with {
-            message shouldBeEqualTo "Property id on type Scenario has no arguments, found: [uppercase]"
-            extensions shouldBeEqualTo mapOf(
-                "type" to "GRAPHQL_VALIDATION_FAILED"
-            )
         }
+        exception shouldHaveMessage "Property id on type Scenario has no arguments, found: [uppercase]"
+        exception.extensions shouldBe mapOf(
+            "type" to "GRAPHQL_VALIDATION_FAILED"
+        )
     }
 
     @Test
     fun `query with external fragment`() {
         val map = execute("{film{title, ...dir }} fragment dir on Film {director{name, age}}")
         assertNoErrors(map)
-        assertThat(map.extract<String>("data/film/title"), equalTo(prestige.title))
-        assertThat(map.extract<String>("data/film/director/name"), equalTo(prestige.director.name))
-        assertThat(map.extract<Int>("data/film/director/age"), equalTo(prestige.director.age))
+        map.extract<String>("data/film/title") shouldBe prestige.title
+        map.extract<String>("data/film/director/name") shouldBe prestige.director.name
+        map.extract<Int>("data/film/director/age") shouldBe prestige.director.age
     }
 
     @Test
@@ -276,9 +246,9 @@ class QueryTest : BaseSchemaTest() {
             """.trimIndent()
         )
         assertNoErrors(map)
-        assertThat(map.extract<String>("data/film/title"), equalTo(prestige.title))
-        assertThat(map.extract<String>("data/film/director/name"), equalTo(prestige.director.name))
-        assertThat(map.extract<Int>("data/film/director/age"), equalTo(prestige.director.age))
+        map.extract<String>("data/film/title") shouldBe prestige.title
+        map.extract<String>("data/film/director/name") shouldBe prestige.director.name
+        map.extract<Int>("data/film/director/age") shouldBe prestige.director.age
     }
 
     @Test
@@ -315,9 +285,9 @@ class QueryTest : BaseSchemaTest() {
             """.trimIndent()
         )
         assertNoErrors(map)
-        assertThat(map.extract<String>("data/film/title"), equalTo(prestige.title))
-        assertThat(map.extract<String>("data/film/director/name"), equalTo(prestige.director.name))
-        assertThat(map.extract<Int>("data/film/director/age"), equalTo(prestige.director.age))
+        map.extract<String>("data/film/title") shouldBe prestige.title
+        map.extract<String>("data/film/director/name") shouldBe prestige.director.name
+        map.extract<Int>("data/film/director/age") shouldBe prestige.director.age
     }
 
     @Test
@@ -344,9 +314,9 @@ class QueryTest : BaseSchemaTest() {
             """.trimIndent()
         )
         assertNoErrors(map)
-        assertThat(map.extract<String>("data/film/title"), equalTo(prestige.title))
-        assertThat(map.extract<String>("data/film/director/name"), equalTo(prestige.director.name))
-        assertThat(map.extract<Int>("data/film/director/age"), equalTo(prestige.director.age))
+        map.extract<String>("data/film/title") shouldBe prestige.title
+        map.extract<String>("data/film/director/name") shouldBe prestige.director.name
+        map.extract<Int>("data/film/director/age") shouldBe prestige.director.age
     }
 
     @Test
@@ -362,9 +332,9 @@ class QueryTest : BaseSchemaTest() {
             """.trimIndent()
         )
         assertNoErrors(map)
-        assertThat(map.extract<String>("data/film/title"), equalTo(prestige.title))
-        assertThat(map.extract<String>("data/film/director/name"), equalTo(prestige.director.name))
-        assertThat(map.extract<Int>("data/film/director/age"), equalTo(prestige.director.age))
+        map.extract<String>("data/film/title") shouldBe prestige.title
+        map.extract<String>("data/film/director/name") shouldBe prestige.director.name
+        map.extract<Int>("data/film/director/age") shouldBe prestige.director.age
     }
 
     @Test
@@ -385,17 +355,18 @@ class QueryTest : BaseSchemaTest() {
             """.trimIndent()
         )
         assertNoErrors(map)
-        assertThat(map.extract<String>("data/film/title"), equalTo(prestige.title))
-        assertThat(map.extract<String>("data/film/director/name"), equalTo(prestige.director.name))
-        assertThat(map.extract<Int>("data/film/director/age"), equalTo(prestige.director.age))
-        assertThat(map.extract<String>("data/film/__typename"), equalTo("Film"))
+        map.extract<String>("data/film/title") shouldBe prestige.title
+        map.extract<String>("data/film/director/name") shouldBe prestige.director.name
+        map.extract<Int>("data/film/director/age") shouldBe prestige.director.age
+        map.extract<String>("data/film/__typename") shouldBe "Film"
 
     }
 
     @Test
     fun `query with missing fragment type`() {
-        invoking {
-            execute("""
+        val exception = shouldThrowExactly<ValidationException> {
+            execute(
+                """
                 {
                     film {
                         ...on MissingType {
@@ -403,44 +374,44 @@ class QueryTest : BaseSchemaTest() {
                         }
                     }
                 }
-            """.trimIndent())
-        } shouldThrow GraphQLError::class with {
-            message shouldBeEqualTo "Unknown type MissingType in type condition on fragment"
-            extensions shouldBeEqualTo mapOf(
-                "type" to "GRAPHQL_VALIDATION_FAILED"
+            """.trimIndent()
             )
         }
+        exception shouldHaveMessage  "Unknown type MissingType in type condition on fragment"
+        exception.extensions shouldBe mapOf(
+            "type" to "GRAPHQL_VALIDATION_FAILED"
+        )
     }
 
     @Test
     fun `query with missing named fragment type`() {
-        invoking {
-            execute("""
+        val exception = shouldThrowExactly<ValidationException> {
+            execute(
+                """
                 {
                     film {
                         ...film_title
                     }
                 }
                 
-            """.trimIndent())
-        } shouldThrow GraphQLError::class with {
-            message shouldBeEqualTo "Fragment film_title not found"
-            extensions shouldBeEqualTo mapOf(
-                "type" to "GRAPHQL_VALIDATION_FAILED"
+            """.trimIndent()
             )
         }
+        exception shouldHaveMessage  "Fragment film_title not found"
+        exception.extensions shouldBe mapOf(
+            "type" to "GRAPHQL_VALIDATION_FAILED"
+        )
     }
 
     @Test
     fun `query with missing selection set`() {
-        invoking {
+        val exception = shouldThrowExactly<ValidationException> {
             execute("{film}")
-        } shouldThrow GraphQLError::class with {
-            message shouldBeEqualTo "Missing selection set on property film of type Film"
-            extensions shouldBeEqualTo mapOf(
-                "type" to "GRAPHQL_VALIDATION_FAILED"
-            )
         }
+        exception shouldHaveMessage  "Missing selection set on property film of type Film"
+        exception.extensions shouldBe mapOf(
+            "type" to "GRAPHQL_VALIDATION_FAILED"
+        )
     }
 
     data class SampleNode(val id: Int, val name: String, val fields: List<String>? = null)
@@ -482,9 +453,9 @@ class QueryTest : BaseSchemaTest() {
         """.trimIndent()
         ).deserialize()
 
-        result.extract<List<String>>("data/root/fields") shouldBeEqualTo listOf("fields")
-        result.extract<Int>("data/root/kids[0]/id") shouldBeEqualTo 1
-        result.extract<String>("data/root/kids[0]/name") shouldBeEqualTo "kids-Testing"
-        result.extract<List<String>>("data/root/kids[0]/fields") shouldBeEqualTo listOf("id", "fields", "name")
+        result.extract<List<String>>("data/root/fields") shouldBe listOf("fields")
+        result.extract<Int>("data/root/kids[0]/id") shouldBe 1
+        result.extract<String>("data/root/kids[0]/name") shouldBe "kids-Testing"
+        result.extract<List<String>>("data/root/kids[0]/fields") shouldBe listOf("id", "fields", "name")
     }
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/github/GitHubIssue105.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/github/GitHubIssue105.kt
@@ -3,7 +3,7 @@ package com.apurebase.kgraphql.integration.github
 import com.apurebase.kgraphql.KGraphQL
 import com.apurebase.kgraphql.deserialize
 import com.apurebase.kgraphql.extract
-import org.amshove.kluent.shouldBeEqualTo
+import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 import java.time.Instant
 
@@ -60,8 +60,8 @@ class GitHubIssue105 {
         }""".trimIndent()
         ).deserialize()
 
-        results.extract<String>("data/contactStatus/userId") shouldBeEqualTo "Leopard2A5"
-        results.extract<String>("data/contactStatus/__typename") shouldBeEqualTo "Onboarded"
+        results.extract<String>("data/contactStatus/userId") shouldBe "Leopard2A5"
+        results.extract<String>("data/contactStatus/__typename") shouldBe "Onboarded"
     }
 
     @Test
@@ -98,7 +98,7 @@ class GitHubIssue105 {
         }""".trimIndent()
         ).deserialize()
 
-        results.extract<String>("data/carrier/contactStatus/userId") shouldBeEqualTo "Leopard2A5"
-        results.extract<String>("data/carrier/contactStatus/__typename") shouldBeEqualTo "Onboarded"
+        results.extract<String>("data/carrier/contactStatus/userId") shouldBe "Leopard2A5"
+        results.extract<String>("data/carrier/contactStatus/__typename") shouldBe "Onboarded"
     }
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/github/GitHubIssue109.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/github/GitHubIssue109.kt
@@ -3,7 +3,7 @@ package com.apurebase.kgraphql.integration.github
 import com.apurebase.kgraphql.KGraphQL
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.amshove.kluent.shouldContain
+import io.kotest.matchers.collections.shouldContain
 import org.junit.jupiter.api.Test
 
 class GitHubIssue109 {

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/github/GitHubIssue137.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/github/GitHubIssue137.kt
@@ -3,7 +3,7 @@ package com.apurebase.kgraphql.integration.github
 import com.apurebase.kgraphql.KGraphQL
 import com.apurebase.kgraphql.deserialize
 import com.apurebase.kgraphql.extract
-import org.amshove.kluent.shouldBeEqualTo
+import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 
 class GitHubIssue137 {
@@ -34,6 +34,6 @@ class GitHubIssue137 {
                     ]
                 }
             """
-        ).deserialize().extract<String>("data/search") shouldBeEqualTo "1_2: Search"
+        ).deserialize().extract<String>("data/search") shouldBe "1_2: Search"
     }
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/merge/MapMergeTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/merge/MapMergeTest.kt
@@ -1,11 +1,10 @@
 package com.apurebase.kgraphql.merge
 
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.apurebase.kgraphql.expect
 import com.apurebase.kgraphql.schema.execution.merge
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.MatcherAssert.assertThat
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
+import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 
 class MapMergeTest {
@@ -18,7 +17,7 @@ class MapMergeTest {
 
         existing.merge("param2", update)
 
-        assertThat(existing["param2"], equalTo(update))
+        existing["param2"] shouldBe update
     }
 
     @Test
@@ -28,7 +27,7 @@ class MapMergeTest {
 
         existing.merge("sub", update)
 
-        assertThat(existing["sub"], equalTo(update))
+        existing["sub"] shouldBe update
     }
 
     @Test
@@ -37,9 +36,14 @@ class MapMergeTest {
         val existing = createMap("param" to existingValue)
         val update = jsonNodeFactory.textNode("value2")
 
-        expect<IllegalStateException>("trying to merge different simple nodes for param") { existing.merge("param", update) }
+        expect<IllegalStateException>("trying to merge different simple nodes for param") {
+            existing.merge(
+                "param",
+                update
+            )
+        }
 
-        assertThat(existing["param"], equalTo(existingValue))
+        existing["param"] shouldBe existingValue
     }
 
     @Test
@@ -48,10 +52,15 @@ class MapMergeTest {
         val existing = createMap("param" to existingValue)
         val update = jsonNodeFactory.objectNode()
 
-        expect<IllegalStateException>("trying to merge object with simple node for param") { existing.merge("param", update) }
+        expect<IllegalStateException>("trying to merge object with simple node for param") {
+            existing.merge(
+                "param",
+                update
+            )
+        }
 
         val expected: JsonNode? = jsonNodeFactory.textNode("value1")
-        assertThat(existing["param"], equalTo(expected))
+        existing["param"] shouldBe expected
     }
 
     @Test
@@ -60,9 +69,14 @@ class MapMergeTest {
         val existing = createMap("param" to existingObj)
         val update = jsonNodeFactory.textNode("value2")
 
-        expect<IllegalStateException>("trying to merge simple node with object node for param") { existing.merge("param", update) }
+        expect<IllegalStateException>("trying to merge simple node with object node for param") {
+            existing.merge(
+                "param",
+                update
+            )
+        }
 
-        assertThat(existing["param"], equalTo(existingObj))
+        existing["param"] shouldBe existingObj
     }
 
     private fun createMap(vararg pairs: Pair<String, JsonNode?>) = mutableMapOf(*pairs)

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/merge/ObjectNodeMergeTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/merge/ObjectNodeMergeTest.kt
@@ -1,11 +1,10 @@
 package com.apurebase.kgraphql.merge
 
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.apurebase.kgraphql.expect
 import com.apurebase.kgraphql.schema.execution.merge
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.MatcherAssert.assertThat
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
+import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 
 class ObjectNodeMergeTest {
@@ -19,7 +18,7 @@ class ObjectNodeMergeTest {
         existing.merge(update)
 
         val expected: JsonNode? = jsonNodeFactory.textNode("value2")
-        assertThat(existing.get("param2"), equalTo(expected))
+        existing.get("param2") shouldBe expected
     }
 
     @Test
@@ -31,7 +30,7 @@ class ObjectNodeMergeTest {
         existing.merge(update)
 
         val expected: JsonNode? = jsonNodeFactory.objectNode().put("param2", "value2")
-        assertThat(existing.get("sub"), equalTo(expected))
+        existing.get("sub") shouldBe expected
     }
 
     @Test
@@ -39,10 +38,12 @@ class ObjectNodeMergeTest {
         val existing = jsonNodeFactory.objectNode().put("param", "value1")
         val update = jsonNodeFactory.objectNode().put("param", "value2")
 
-        expect<IllegalStateException>("trying to merge different simple nodes for param") { existing.merge(update) }
+        expect<IllegalStateException>("trying to merge different simple nodes for param") {
+            existing.merge(update)
+        }
 
         val expected: JsonNode? = jsonNodeFactory.textNode("value1")
-        assertThat(existing.get("param"), equalTo(expected))
+        existing.get("param") shouldBe expected
     }
 
     @Test
@@ -51,10 +52,12 @@ class ObjectNodeMergeTest {
         val update = jsonNodeFactory.objectNode()
         update.putObject("param")
 
-        expect<IllegalStateException>("trying to merge object with simple node for param") { existing.merge(update) }
+        expect<IllegalStateException>("trying to merge object with simple node for param") {
+            existing.merge(update)
+        }
 
         val expected: JsonNode? = jsonNodeFactory.textNode("value1")
-        assertThat(existing.get("param"), equalTo(expected))
+        existing.get("param") shouldBe expected
     }
 
     @Test
@@ -63,8 +66,10 @@ class ObjectNodeMergeTest {
         val existingObj: JsonNode? = existing.putObject("param").put("other", "value1")
         val update = jsonNodeFactory.objectNode().put("param", "value2")
 
-        expect<IllegalStateException>("trying to merge simple node with object node for param") { existing.merge(update) }
+        expect<IllegalStateException>("trying to merge simple node with object node for param") {
+            existing.merge(update)
+        }
 
-        assertThat(existing.get("param"), equalTo(existingObj))
+        existing.get("param") shouldBe existingObj
     }
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/request/DedentBlockStringTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/request/DedentBlockStringTest.kt
@@ -3,7 +3,7 @@ package com.apurebase.kgraphql.request
 import com.apurebase.kgraphql.schema.structure.dedentBlockStringValue
 import com.apurebase.kgraphql.schema.structure.getBlockStringIndentation
 import com.apurebase.kgraphql.schema.structure.printBlockString
-import org.amshove.kluent.shouldBeEqualTo
+import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 
 class DedentBlockStringTest {
@@ -23,7 +23,7 @@ class DedentBlockStringTest {
             "    Yours,",
             "      GraphQL."
         )
-        dedentBlockStringValue(rawValue) shouldBeEqualTo joinLines(
+        dedentBlockStringValue(rawValue) shouldBe joinLines(
             "Hello,",
             "  World!",
             "",
@@ -45,7 +45,7 @@ class DedentBlockStringTest {
             "",
             ""
         )
-        dedentBlockStringValue(rawValue) shouldBeEqualTo joinLines(
+        dedentBlockStringValue(rawValue) shouldBe joinLines(
             "Hello,",
             "  World!",
             "",
@@ -67,7 +67,7 @@ class DedentBlockStringTest {
             "        ",
             "  "
         )
-        dedentBlockStringValue(rawValue) shouldBeEqualTo joinLines(
+        dedentBlockStringValue(rawValue) shouldBe joinLines(
             "Hello,",
             "  World!",
             "",
@@ -85,7 +85,7 @@ class DedentBlockStringTest {
             "    Yours,",
             "      GraphQL."
         )
-        dedentBlockStringValue(rawValue) shouldBeEqualTo joinLines(
+        dedentBlockStringValue(rawValue) shouldBe joinLines(
             "    Hello,",
             "  World!",
             "",
@@ -105,7 +105,7 @@ class DedentBlockStringTest {
             "      GraphQL. ",
             "               "
         )
-        dedentBlockStringValue(rawValue) shouldBeEqualTo joinLines(
+        dedentBlockStringValue(rawValue) shouldBe joinLines(
             "Hello,     ",
             "  World!   ",
             "           ",
@@ -120,48 +120,48 @@ class DedentBlockStringTest {
     ///////////////////////////////////////////
     @Test
     fun `returns zero for an empty array`() {
-        getBlockStringIndentation(listOf()) shouldBeEqualTo 0
+        getBlockStringIndentation(listOf()) shouldBe 0
     }
 
     @Test
     fun `do not take first line into account`() {
-        getBlockStringIndentation(listOf("  a")) shouldBeEqualTo 0
-        getBlockStringIndentation(listOf(" a", "  b")) shouldBeEqualTo 2
+        getBlockStringIndentation(listOf("  a")) shouldBe 0
+        getBlockStringIndentation(listOf(" a", "  b")) shouldBe 2
     }
 
     @Test
     fun `returns minimal indentation length`() {
-        getBlockStringIndentation(listOf("", " a", "  b")) shouldBeEqualTo 1
-        getBlockStringIndentation(listOf("", "  a", " b")) shouldBeEqualTo 1
-        getBlockStringIndentation(listOf("", "  a", " b", "c")) shouldBeEqualTo 0
+        getBlockStringIndentation(listOf("", " a", "  b")) shouldBe 1
+        getBlockStringIndentation(listOf("", "  a", " b")) shouldBe 1
+        getBlockStringIndentation(listOf("", "  a", " b", "c")) shouldBe 0
     }
 
     @Test
     fun `count both tab and space as single character`() {
-        getBlockStringIndentation(listOf("", "\ta", "          b")) shouldBeEqualTo 1
+        getBlockStringIndentation(listOf("", "\ta", "          b")) shouldBe 1
         getBlockStringIndentation(
             listOf(
                 "",
                 "\t a",
                 "          b"
             )
-        ) shouldBeEqualTo 2
+        ) shouldBe 2
         getBlockStringIndentation(
             listOf(
                 "",
                 " \t a",
                 "          b"
             )
-        ) shouldBeEqualTo 3
+        ) shouldBe 3
     }
 
     @Test
     fun `do not take empty lines into account`() {
-        getBlockStringIndentation(listOf("a", "\t")) shouldBeEqualTo 0
-        getBlockStringIndentation(listOf("a", " ")) shouldBeEqualTo 0
-        getBlockStringIndentation(listOf("a", " ", "  b")) shouldBeEqualTo 2
-        getBlockStringIndentation(listOf("a", " ", "  b")) shouldBeEqualTo 2
-        getBlockStringIndentation(listOf("a", "", " b")) shouldBeEqualTo 1
+        getBlockStringIndentation(listOf("a", "\t")) shouldBe 0
+        getBlockStringIndentation(listOf("a", " ")) shouldBe 0
+        getBlockStringIndentation(listOf("a", " ", "  b")) shouldBe 2
+        getBlockStringIndentation(listOf("a", " ", "  b")) shouldBe 2
+        getBlockStringIndentation(listOf("a", "", " b")) shouldBe 1
     }
 
     //////////////////////////////////////////
@@ -170,23 +170,23 @@ class DedentBlockStringTest {
     @Test
     fun `by default print block strings as single line`() {
         val str = "one liner"
-        printBlockString(str) shouldBeEqualTo "\"\"\"one liner\"\"\""
-        printBlockString(str, "", true) shouldBeEqualTo "\"\"\"\none liner\n\"\"\""
+        printBlockString(str) shouldBe "\"\"\"one liner\"\"\""
+        printBlockString(str, "", true) shouldBe "\"\"\"\none liner\n\"\"\""
     }
 
     @Test
     fun `correctly prints single-line with leading space`() {
         val str = "    space-led string"
-        printBlockString(str) shouldBeEqualTo "\"\"\"    space-led string\"\"\""
-        printBlockString(str, "", true) shouldBeEqualTo "\"\"\"    space-led string\n\"\"\""
+        printBlockString(str) shouldBe "\"\"\"    space-led string\"\"\""
+        printBlockString(str, "", true) shouldBe "\"\"\"    space-led string\n\"\"\""
     }
 
     @Test
     fun `correctly prints single-line with leading space and quotation`() {
         val str = "    space-led value \"quoted string\""
 
-        printBlockString(str) shouldBeEqualTo "\"\"\"    space-led value \"quoted string\"\n\"\"\""
-        printBlockString(str, "", true) shouldBeEqualTo "\"\"\"    space-led value \"quoted string\"\n\"\"\""
+        printBlockString(str) shouldBe "\"\"\"    space-led value \"quoted string\"\n\"\"\""
+        printBlockString(str, "", true) shouldBe "\"\"\"    space-led value \"quoted string\"\n\"\"\""
     }
 
     @Test
@@ -198,7 +198,7 @@ class DedentBlockStringTest {
             "     string"
         )
 
-        printBlockString(str) shouldBeEqualTo joinLines(
+        printBlockString(str) shouldBe joinLines(
             "\"\"\"",
             "    first  ",
             "  line     ",

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaInheritanceTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaInheritanceTest.kt
@@ -1,11 +1,9 @@
 package com.apurebase.kgraphql.schema
 
-import com.apurebase.kgraphql.GraphQLError
 import com.apurebase.kgraphql.KGraphQL
+import com.apurebase.kgraphql.ValidationException
 import com.apurebase.kgraphql.deserialize
-import org.amshove.kluent.invoking
-import org.amshove.kluent.shouldThrow
-import org.amshove.kluent.withMessage
+import com.apurebase.kgraphql.expect
 import org.junit.jupiter.api.Test
 import java.util.UUID
 
@@ -33,12 +31,12 @@ class SchemaInheritanceTest {
             query("c") { resolver { -> C(name, age) } }
         }
 
-        invoking {
+        expect<ValidationException>("Property id on B does not exist") {
             deserialize(schema.executeBlocking("{b{id, name, age}}"))
-        } shouldThrow GraphQLError::class withMessage "Property id on B does not exist"
+        }
 
-        invoking {
+        expect<ValidationException>("Property id on C does not exist") {
             deserialize(schema.executeBlocking("{c{id, name, age}}"))
-        } shouldThrow GraphQLError::class withMessage "Property id on C does not exist"
+        }
     }
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaPrinterTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaPrinterTest.kt
@@ -1,7 +1,7 @@
 package com.apurebase.kgraphql.schema
 
 import com.apurebase.kgraphql.KGraphQL
-import org.amshove.kluent.shouldBeEqualTo
+import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.util.UUID
@@ -61,7 +61,7 @@ class SchemaPrinterTest {
             type<Author>()
         }
 
-        SchemaPrinter().print(schema) shouldBeEqualTo """
+        SchemaPrinter().print(schema) shouldBe """
             type Author {
               books: [Book!]!
               name: String!
@@ -88,7 +88,7 @@ class SchemaPrinterTest {
             type<NestedLists>()
         }
 
-        SchemaPrinter().print(schema) shouldBeEqualTo """
+        SchemaPrinter().print(schema) shouldBe """
             type NestedLists {
               nested1: [[String]!]!
               nested2: [[[[[String!]]!]]!]!
@@ -135,7 +135,7 @@ class SchemaPrinterTest {
             }
         }
 
-        SchemaPrinter().print(schema) shouldBeEqualTo """
+        SchemaPrinter().print(schema) shouldBe """
             type Author {
               books: [Book!]!
               name: String!
@@ -180,7 +180,7 @@ class SchemaPrinterTest {
             }
         }
 
-        SchemaPrinter().print(schema) shouldBeEqualTo """
+        SchemaPrinter().print(schema) shouldBe """
             type Child1 {
               one: String!
             }
@@ -213,7 +213,7 @@ class SchemaPrinterTest {
             type<OtherInterface>()
         }
 
-        SchemaPrinter().print(schema) shouldBeEqualTo """
+        SchemaPrinter().print(schema) shouldBe """
             type Complex implements BaseInterface & OtherInterface {
               base: String!
               extra: Int!
@@ -259,7 +259,7 @@ class SchemaPrinterTest {
             }
         }
 
-        SchemaPrinter().print(schema) shouldBeEqualTo """
+        SchemaPrinter().print(schema) shouldBe """
             type Mutation {
               add(input: TestObjectInput!): TestObject!
             }
@@ -295,7 +295,7 @@ class SchemaPrinterTest {
             }
         }
 
-        SchemaPrinter().print(schema) shouldBeEqualTo """
+        SchemaPrinter().print(schema) shouldBe """
             scalar LocalDate
             
             scalar UUID
@@ -320,7 +320,7 @@ class SchemaPrinterTest {
             }
         }
 
-        SchemaPrinter().print(schema) shouldBeEqualTo """
+        SchemaPrinter().print(schema) shouldBe """
             type Query {
               dummy: String!
             }
@@ -359,7 +359,7 @@ class SchemaPrinterTest {
             }
         }
 
-        SchemaPrinter().print(schema) shouldBeEqualTo """
+        SchemaPrinter().print(schema) shouldBe """
             type Query {
               getNullString: String
               getObject(nullObject: Boolean!): TestObject
@@ -390,7 +390,7 @@ class SchemaPrinterTest {
             }
         }
 
-        SchemaPrinter().print(schema) shouldBeEqualTo """
+        SchemaPrinter().print(schema) shouldBe """
             type Mutation {
               addFloat(float: Float!): Float!
               addString(string: String!): String!
@@ -412,7 +412,7 @@ class SchemaPrinterTest {
             enum<TestEnum>()
         }
 
-        SchemaPrinter().print(schema) shouldBeEqualTo """
+        SchemaPrinter().print(schema) shouldBe """
             type Query {
               dummy: String!
             }
@@ -450,7 +450,7 @@ class SchemaPrinterTest {
             }
         }
 
-        SchemaPrinter().print(schema) shouldBeEqualTo """
+        SchemaPrinter().print(schema) shouldBe """
             type Mutation {
               addStringWithDefault(prefix: String! = "_", string: String!, suffix: String): String!
             }
@@ -500,7 +500,7 @@ class SchemaPrinterTest {
             }
         }
 
-        SchemaPrinter().print(schema) shouldBeEqualTo """
+        SchemaPrinter().print(schema) shouldBe """
             type DeprecatedObject {
               new: String!
               old: String! @deprecated(reason: "deprecated old value")
@@ -576,7 +576,7 @@ class SchemaPrinterTest {
                 includeSchemaDefinition = true,
                 includeDescriptions = true
             )
-        ).print(schema) shouldBeEqualTo """
+        ).print(schema) shouldBe """
             schema {
               "Query object"
               query: Query
@@ -666,7 +666,7 @@ class SchemaPrinterTest {
             }
         }
 
-        SchemaPrinter(SchemaPrinterConfig(includeDescriptions = false)).print(schema) shouldBeEqualTo """
+        SchemaPrinter(SchemaPrinterConfig(includeDescriptions = false)).print(schema) shouldBe """
             type Mutation {
               addObject(toAdd: TestObjectInput!): TestObject!
             }
@@ -704,7 +704,7 @@ class SchemaPrinterTest {
             type<TestObject>()
         }
 
-        SchemaPrinter(SchemaPrinterConfig(includeBuiltInDirectives = true)).print(schema) shouldBeEqualTo """
+        SchemaPrinter(SchemaPrinterConfig(includeBuiltInDirectives = true)).print(schema) shouldBe """
             type Query {
               dummy: String!
             }
@@ -731,7 +731,7 @@ class SchemaPrinterTest {
             type<TestObject>()
         }
 
-        SchemaPrinter(SchemaPrinterConfig(includeSchemaDefinition = true)).print(schema) shouldBeEqualTo """
+        SchemaPrinter(SchemaPrinterConfig(includeSchemaDefinition = true)).print(schema) shouldBe """
             schema {
               query: Query
             }
@@ -758,7 +758,7 @@ class SchemaPrinterTest {
             }
         }
 
-        SchemaPrinter().print(schema) shouldBeEqualTo """
+        SchemaPrinter().print(schema) shouldBe """
             schema {
               query: Query
             }
@@ -785,7 +785,7 @@ class SchemaPrinterTest {
             }
         }
 
-        SchemaPrinter().print(schema) shouldBeEqualTo """
+        SchemaPrinter().print(schema) shouldBe """
             schema {
               query: Query
             }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/dsl/DataLoaderPropertyDSLTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/dsl/DataLoaderPropertyDSLTest.kt
@@ -7,10 +7,9 @@ import com.apurebase.kgraphql.extract
 import com.apurebase.kgraphql.schema.SchemaBuilderTest
 import com.apurebase.kgraphql.schema.dsl.types.TypeDSL
 import com.apurebase.kgraphql.schema.execution.Executor
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import nidomiro.kdataloader.ExecutionResult
-import org.amshove.kluent.shouldBeEqualTo
-import org.hamcrest.CoreMatchers
-import org.hamcrest.MatcherAssert
 import org.junit.jupiter.api.Test
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
@@ -48,7 +47,7 @@ class DataLoaderPropertyDSLTest {
             }
             """.trimIndent()
         ).deserialize()
-        results.extract<String>("data/parent/child/data") shouldBeEqualTo "A 1 C 2 E 3 G 4"
+        results.extract<String>("data/parent/child/data") shouldBe "A 1 C 2 E 3 G 4"
     }
 
     class Parent(val data: String = "")
@@ -78,7 +77,7 @@ class DataLoaderPropertyDSLTest {
             }
         }
 
-        MatcherAssert.assertThat(schema.typeByKClass(SchemaBuilderTest.InputOne::class), CoreMatchers.notNullValue())
+        schema.typeByKClass(SchemaBuilderTest.InputOne::class) shouldNotBe null
     }
 
     data class Prop<T>(val resultType: KType, val resolver: () -> T)
@@ -102,7 +101,7 @@ class DataLoaderPropertyDSLTest {
             }
         }
 
-        MatcherAssert.assertThat(schema.typeByKClass(Int::class), CoreMatchers.notNullValue())
-        MatcherAssert.assertThat(schema.typeByKClass(String::class), CoreMatchers.notNullValue())
+        schema.typeByKClass(Int::class) shouldNotBe null
+        schema.typeByKClass(String::class) shouldNotBe null
     }
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/introspection/ContextSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/introspection/ContextSpecificationTest.kt
@@ -4,8 +4,7 @@ import com.apurebase.kgraphql.Context
 import com.apurebase.kgraphql.defaultSchema
 import com.apurebase.kgraphql.deserialize
 import com.apurebase.kgraphql.extract
-import org.hamcrest.CoreMatchers
-import org.hamcrest.MatcherAssert
+import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 
 class ContextSpecificationTest {
@@ -20,10 +19,7 @@ class ContextSpecificationTest {
         }
 
         val response = deserialize(schema.executeBlocking("{__schema{queryType{fields{args{name}}}}}"))
-        MatcherAssert.assertThat(
-            response.extract("data/__schema/queryType/fields[0]/args[0]/name"),
-            CoreMatchers.equalTo("limit")
-        )
+        response.extract<String>("data/__schema/queryType/fields[0]/args[0]/name") shouldBe "limit"
     }
 
     @Test
@@ -39,9 +35,6 @@ class ContextSpecificationTest {
         }
 
         val response = deserialize(schema.executeBlocking("{__schema{mutationType{fields{args{name}}}}}"))
-        MatcherAssert.assertThat(
-            response.extract("data/__schema/mutationType/fields[0]/args[0]/name"),
-            CoreMatchers.equalTo("input")
-        )
+        response.extract<String>("data/__schema/mutationType/fields[0]/args[0]/name") shouldBe "input"
     }
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/introspection/DeprecationSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/introspection/DeprecationSpecificationTest.kt
@@ -5,8 +5,8 @@ import com.apurebase.kgraphql.deserialize
 import com.apurebase.kgraphql.expect
 import com.apurebase.kgraphql.extract
 import com.apurebase.kgraphql.schema.SchemaException
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.MatcherAssert.assertThat
+import io.kotest.matchers.maps.shouldContainAll
+import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 import kotlin.reflect.typeOf
 
@@ -24,8 +24,10 @@ class DeprecationSpecificationTest {
 
         val response =
             deserialize(schema.executeBlocking("{__schema{queryType{fields(includeDeprecated: true){name, deprecationReason, isDeprecated}}}}"))
-        assertThat(response.extract("data/__schema/queryType/fields[0]/deprecationReason"), equalTo(expected))
-        assertThat(response.extract("data/__schema/queryType/fields[0]/isDeprecated"), equalTo(true))
+        response.extract<Map<String, Any?>>("data/__schema/queryType/fields[0]") shouldContainAll mapOf(
+            "deprecationReason" to expected,
+            "isDeprecated" to true
+        )
     }
 
     @Test
@@ -43,8 +45,10 @@ class DeprecationSpecificationTest {
 
         val response =
             deserialize(schema.executeBlocking("{__schema{mutationType{fields(includeDeprecated: true){name, deprecationReason, isDeprecated}}}}"))
-        assertThat(response.extract("data/__schema/mutationType/fields[0]/deprecationReason"), equalTo(expected))
-        assertThat(response.extract("data/__schema/mutationType/fields[0]/isDeprecated"), equalTo(true))
+        response.extract<Map<String, Any?>>("data/__schema/mutationType/fields[0]") shouldContainAll mapOf(
+            "deprecationReason" to expected,
+            "isDeprecated" to true
+        )
     }
 
     data class Sample(val content: String)
@@ -66,8 +70,10 @@ class DeprecationSpecificationTest {
 
         val response =
             deserialize(schema.executeBlocking("{__type(name: \"Sample\"){fields(includeDeprecated: true){isDeprecated, deprecationReason}}}"))
-        assertThat(response.extract("data/__type/fields[0]/deprecationReason/"), equalTo(expected))
-        assertThat(response.extract("data/__type/fields[0]/isDeprecated/"), equalTo(true))
+        response.extract<Map<String, Any?>>("data/__type/fields[0]") shouldContainAll mapOf(
+            "deprecationReason" to expected,
+            "isDeprecated" to true
+        )
     }
 
     @Test
@@ -88,8 +94,10 @@ class DeprecationSpecificationTest {
 
         val response =
             deserialize(schema.executeBlocking("{__type(name: \"Sample\"){fields(includeDeprecated: true){name, isDeprecated, deprecationReason}}}"))
-        assertThat(response.extract("data/__type/fields[1]/deprecationReason"), equalTo(expected))
-        assertThat(response.extract("data/__type/fields[1]/isDeprecated"), equalTo(true))
+        response.extract<Map<String, Any?>>("data/__type/fields[1]") shouldContainAll mapOf(
+            "deprecationReason" to expected,
+            "isDeprecated" to true
+        )
     }
 
     @Suppress("unused")
@@ -112,9 +120,11 @@ class DeprecationSpecificationTest {
 
         val response =
             deserialize(schema.executeBlocking("{__type(name: \"SampleEnum\"){enumValues(includeDeprecated: true){name, isDeprecated, deprecationReason}}}"))
-        assertThat(response.extract("data/__type/enumValues[0]/name"), equalTo(SampleEnum.ONE.name))
-        assertThat(response.extract("data/__type/enumValues[0]/deprecationReason"), equalTo(expected))
-        assertThat(response.extract("data/__type/enumValues[0]/isDeprecated"), equalTo(true))
+        response.extract<Map<String, Any?>>("data/__type/enumValues[0]") shouldContainAll mapOf(
+            "name" to SampleEnum.ONE.name,
+            "deprecationReason" to expected,
+            "isDeprecated" to true
+        )
     }
 
     @Test
@@ -135,12 +145,16 @@ class DeprecationSpecificationTest {
 
         val response =
             deserialize(schema.executeBlocking("{__type(name: \"InputType\"){inputFields(includeDeprecated: true){name, deprecationReason, isDeprecated}}}"))
-        assertThat(response.extract("data/__type/inputFields[0]/name"), equalTo("new"))
-        assertThat(response.extract("data/__type/inputFields[0]/deprecationReason"), equalTo(null))
-        assertThat(response.extract("data/__type/inputFields[0]/isDeprecated"), equalTo(false))
-        assertThat(response.extract("data/__type/inputFields[1]/name"), equalTo("oldOptional"))
-        assertThat(response.extract("data/__type/inputFields[1]/deprecationReason"), equalTo(expected))
-        assertThat(response.extract("data/__type/inputFields[1]/isDeprecated"), equalTo(true))
+        response.extract<Map<String, Any?>>("data/__type/inputFields[0]") shouldContainAll mapOf(
+            "name" to "new",
+            "deprecationReason" to null,
+            "isDeprecated" to false
+        )
+        response.extract<Map<String, Any?>>("data/__type/inputFields[1]") shouldContainAll mapOf(
+            "name" to "oldOptional",
+            "deprecationReason" to expected,
+            "isDeprecated" to true
+        )
     }
 
     @Test
@@ -176,16 +190,19 @@ class DeprecationSpecificationTest {
 
         val response =
             deserialize(schema.executeBlocking("{__type(name: \"InputType\"){inputFields{name, deprecationReason, isDeprecated}}}"))
-        assertThat(response.extract("data/__type/inputFields[0]/name"), equalTo("new"))
-        assertThat(response.extract("data/__type/inputFields[0]/deprecationReason"), equalTo(null))
-        assertThat(response.extract("data/__type/inputFields[0]/isDeprecated"), equalTo(false))
+        response.extract<Map<String, Any?>>("data/__type/inputFields[0]") shouldContainAll mapOf(
+            "name" to "new",
+            "deprecationReason" to null,
+            "isDeprecated" to false
+        )
         // oldOptional should not be returned
-        assertThat(response.contains("data/__type/inputFields[1]"), equalTo(false))
+        response.contains("data/__type/inputFields[1]") shouldBe false
     }
 
     @Test
     fun `optional field args may be deprecated`() {
         val expected = "deprecated field arg"
+
         @Suppress("UNUSED_ANONYMOUS_PARAMETER")
         val schema = defaultSchema {
             query("data") {
@@ -198,12 +215,16 @@ class DeprecationSpecificationTest {
 
         val response =
             deserialize(schema.executeBlocking("{__schema{queryType{fields{name, args(includeDeprecated: true){name deprecationReason isDeprecated}}}}}"))
-        assertThat(response.extract("data/__schema/queryType/fields[0]/args[0]/name"), equalTo("oldOptional"))
-        assertThat(response.extract("data/__schema/queryType/fields[0]/args[0]/deprecationReason"), equalTo(expected))
-        assertThat(response.extract("data/__schema/queryType/fields[0]/args[0]/isDeprecated"), equalTo(true))
-        assertThat(response.extract("data/__schema/queryType/fields[0]/args[1]/name"), equalTo("new"))
-        assertThat(response.extract("data/__schema/queryType/fields[0]/args[1]/deprecationReason"), equalTo(null))
-        assertThat(response.extract("data/__schema/queryType/fields[0]/args[1]/isDeprecated"), equalTo(false))
+        response.extract<Map<String, Any?>>("data/__schema/queryType/fields[0]/args[0]") shouldContainAll mapOf(
+            "name" to "oldOptional",
+            "deprecationReason" to expected,
+            "isDeprecated" to true
+        )
+        response.extract<Map<String, Any?>>("data/__schema/queryType/fields[0]/args[1]") shouldContainAll mapOf(
+            "name" to "new",
+            "deprecationReason" to null,
+            "isDeprecated" to false
+        )
     }
 
     @Test
@@ -224,6 +245,7 @@ class DeprecationSpecificationTest {
     @Test
     fun `deprecated field args should not be returned by default`() {
         val expected = "deprecated input value"
+
         @Suppress("UNUSED_ANONYMOUS_PARAMETER")
         val schema = defaultSchema {
             query("data") {
@@ -236,10 +258,12 @@ class DeprecationSpecificationTest {
 
         val response =
             deserialize(schema.executeBlocking("{__schema{queryType{fields{name, args{name deprecationReason isDeprecated}}}}}"))
-        assertThat(response.extract("data/__schema/queryType/fields[0]/args[0]/name"), equalTo("new"))
-        assertThat(response.extract("data/__schema/queryType/fields[0]/args[0]/deprecationReason"), equalTo(null))
-        assertThat(response.extract("data/__schema/queryType/fields[0]/args[0]/isDeprecated"), equalTo(false))
+        response.extract<Map<String, Any?>>("data/__schema/queryType/fields[0]/args[0]") shouldContainAll mapOf(
+            "name" to "new",
+            "deprecationReason" to null,
+            "isDeprecated" to false
+        )
         // oldOptional should not be returned
-        assertThat(response.contains("data/__schema/queryType/fields[0]/args[1]"), equalTo(false))
+        response.contains("data/__schema/queryType/fields[0]/args[1]") shouldBe false
     }
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/introspection/DocumentationSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/introspection/DocumentationSpecificationTest.kt
@@ -3,8 +3,8 @@ package com.apurebase.kgraphql.specification.introspection
 import com.apurebase.kgraphql.defaultSchema
 import com.apurebase.kgraphql.deserialize
 import com.apurebase.kgraphql.extract
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.MatcherAssert.assertThat
+import io.kotest.matchers.maps.shouldContainAll
+import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 
 class DocumentationSpecificationTest {
@@ -20,7 +20,7 @@ class DocumentationSpecificationTest {
         }
 
         val response = deserialize(schema.executeBlocking("{__schema{queryType{fields{name, description}}}}"))
-        assertThat(response.extract("data/__schema/queryType/fields[0]/description"), equalTo(expected))
+        response.extract<String>("data/__schema/queryType/fields[0]/description") shouldBe expected
     }
 
     @Test
@@ -37,7 +37,7 @@ class DocumentationSpecificationTest {
         }
 
         val response = deserialize(schema.executeBlocking("{__schema{mutationType{fields{name, description}}}}"))
-        assertThat(response.extract("data/__schema/mutationType/fields[0]/description"), equalTo(expected))
+        response.extract<String>("data/__schema/mutationType/fields[0]/description") shouldBe expected
     }
 
     data class Sample(val content: String)
@@ -55,7 +55,7 @@ class DocumentationSpecificationTest {
         }
 
         val response = deserialize(schema.executeBlocking("{__type(name: \"Sample\"){description}}"))
-        assertThat(response.extract("data/__type/description/"), equalTo(expected))
+        response.extract<String>("data/__type/description/") shouldBe expected
     }
 
     @Test
@@ -72,7 +72,7 @@ class DocumentationSpecificationTest {
         }
 
         val response = deserialize(schema.executeBlocking("{__type(name: \"Sample\"){description}}"))
-        assertThat(response.extract("data/__type/description/"), equalTo(expected))
+        response.extract<String>("data/__type/description/") shouldBe expected
     }
 
     @Test
@@ -91,7 +91,7 @@ class DocumentationSpecificationTest {
         }
 
         val response = deserialize(schema.executeBlocking("{__type(name: \"Sample\"){fields{description}}}"))
-        assertThat(response.extract("data/__type/fields[0]/description/"), equalTo(expected))
+        response.extract<String>("data/__type/fields[0]/description/") shouldBe expected
     }
 
     @Test
@@ -111,8 +111,10 @@ class DocumentationSpecificationTest {
         }
 
         val response = deserialize(schema.executeBlocking("{__type(name: \"Sample\"){fields{name, description}}}"))
-        assertThat(response.extract("data/__type/fields[1]/name/"), equalTo("add"))
-        assertThat(response.extract("data/__type/fields[1]/description/"), equalTo(expected))
+        response.extract<Map<String, Any?>>("data/__type/fields[1]") shouldContainAll mapOf(
+            "name" to "add",
+            "description" to expected
+        )
     }
 
     enum class SampleEnum { ONE, TWO, THREE }
@@ -134,8 +136,10 @@ class DocumentationSpecificationTest {
 
         val response =
             deserialize(schema.executeBlocking("{__type(name: \"SampleEnum\"){enumValues{name, description}}}"))
-        assertThat(response.extract("data/__type/enumValues[0]/name"), equalTo(SampleEnum.ONE.name))
-        assertThat(response.extract("data/__type/enumValues[0]/description"), equalTo(expected))
+        response.extract<Map<String, Any?>>("data/__type/enumValues[0]") shouldContainAll mapOf(
+            "name" to SampleEnum.ONE.name,
+            "description" to expected
+        )
     }
 
     data class Documented(val id: Int)
@@ -155,6 +159,6 @@ class DocumentationSpecificationTest {
 
         val response =
             deserialize(schema.executeBlocking("query { __type(name: \"Documented\") {  name, kind, description } }"))
-        assertThat(response.extract("data/__type/description"), equalTo(expected))
+        response.extract<String>("data/__type/description") shouldBe expected
     }
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/introspection/IntrospectionSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/introspection/IntrospectionSpecificationTest.kt
@@ -1,24 +1,21 @@
 package com.apurebase.kgraphql.specification.introspection
 
-import com.apurebase.kgraphql.GraphQLError
+import com.apurebase.kgraphql.ValidationException
 import com.apurebase.kgraphql.assertNoErrors
 import com.apurebase.kgraphql.defaultSchema
 import com.apurebase.kgraphql.deserialize
+import com.apurebase.kgraphql.expect
 import com.apurebase.kgraphql.extract
 import com.apurebase.kgraphql.request.Introspection
 import com.apurebase.kgraphql.schema.introspection.TypeKind
-import org.amshove.kluent.invoking
-import org.amshove.kluent.shouldNotBeEqualTo
-import org.amshove.kluent.shouldNotContain
-import org.amshove.kluent.shouldThrow
-import org.amshove.kluent.withMessage
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.CoreMatchers.not
-import org.hamcrest.CoreMatchers.notNullValue
-import org.hamcrest.CoreMatchers.startsWith
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.hasSize
-import org.hamcrest.collection.IsEmptyCollection.empty
+import io.kotest.inspectors.forAll
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldBeUnique
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldNotContain
+import io.kotest.matchers.string.shouldNotStartWith
 import org.junit.jupiter.api.Test
 
 class IntrospectionSpecificationTest {
@@ -31,7 +28,7 @@ class IntrospectionSpecificationTest {
             }
         }
 
-        assertThat(schema.findTypeByName("String"), notNullValue())
+        schema.findTypeByName("String") shouldNotBe null
     }
 
     data class Data(val string: String)
@@ -45,7 +42,7 @@ class IntrospectionSpecificationTest {
         }
 
         val response = deserialize(schema.executeBlocking("{sample{string, __typename}}"))
-        assertThat(response.extract("data/sample/__typename"), equalTo("Data"))
+        response.extract<String>("data/sample/__typename") shouldBe "Data"
     }
 
     @Test
@@ -57,7 +54,7 @@ class IntrospectionSpecificationTest {
         }
 
         val response = deserialize(schema.executeBlocking("{__typename}"))
-        assertThat(response.extract("data/__typename"), equalTo("Query"))
+        response.extract<String>("data/__typename") shouldBe "Query"
     }
 
     @Test
@@ -72,7 +69,7 @@ class IntrospectionSpecificationTest {
         }
 
         val response = deserialize(schema.executeBlocking("mutation {__typename}"))
-        assertThat(response.extract("data/__typename"), equalTo("Mutation"))
+        response.extract<String>("data/__typename") shouldBe "Mutation"
     }
 
     @Test
@@ -83,14 +80,15 @@ class IntrospectionSpecificationTest {
             }
         }
 
-        invoking {
+        expect<ValidationException>("Property __typename on String does not exist") {
             schema.executeBlocking("{sample{string{__typename}}}")
-        } shouldThrow GraphQLError::class withMessage "Property __typename on String does not exist"
+        }
     }
 
     enum class SampleEnum {
         VALUE
     }
+
     data class EnumData(val enum: SampleEnum)
 
     @Test
@@ -103,9 +101,9 @@ class IntrospectionSpecificationTest {
             }
         }
 
-        invoking {
+        expect<ValidationException>("Property __typename on SampleEnum does not exist") {
             schema.executeBlocking("{sample{enum{__typename}}}")
-        } shouldThrow GraphQLError::class withMessage "Property __typename on SampleEnum does not exist"
+        }
     }
 
     data class Union1(val one: String)
@@ -153,7 +151,7 @@ class IntrospectionSpecificationTest {
             )
         )
 
-        assertThat(response.extract("data/data/union/__typename"), equalTo("Union1"))
+        response.extract<String>("data/data/union/__typename") shouldBe "Union1"
     }
 
     @Test
@@ -165,9 +163,9 @@ class IntrospectionSpecificationTest {
         }
 
         val dataReturnType = schema.queryType.fields?.find { it.name == "data" }?.type!!
-        assertThat(dataReturnType.kind, equalTo(TypeKind.NON_NULL))
-        assertThat(dataReturnType.ofType?.kind, equalTo(TypeKind.LIST))
-        assertThat(dataReturnType.ofType?.ofType?.kind, equalTo(TypeKind.NON_NULL))
+        dataReturnType.kind shouldBe TypeKind.NON_NULL
+        dataReturnType.ofType?.kind shouldBe TypeKind.LIST
+        dataReturnType.ofType?.ofType?.kind shouldBe TypeKind.NON_NULL
     }
 
     @Test
@@ -179,7 +177,7 @@ class IntrospectionSpecificationTest {
         }
 
         val response = deserialize(schema.executeBlocking("{__schema{queryType{fields{name}}}}"))
-        assertThat(response.extract("data/__schema/queryType/fields[0]/name"), equalTo("data"))
+        response.extract<String>("data/__schema/queryType/fields[0]/name") shouldBe "data"
     }
 
     @Test
@@ -191,8 +189,8 @@ class IntrospectionSpecificationTest {
         }
 
         val response = deserialize(schema.executeBlocking("{__type(name: \"String\"){kind, name, description}}"))
-        assertThat(response.extract("data/__type/name"), equalTo("String"))
-        assertThat(response.extract("data/__type/kind"), equalTo("SCALAR"))
+        response.extract<String>("data/__type/name") shouldBe "String"
+        response.extract<String>("data/__type/kind") shouldBe "SCALAR"
     }
 
     data class IntString(val int: Int, val string: String)
@@ -208,10 +206,10 @@ class IntrospectionSpecificationTest {
         val inputValues = schema.queryType.fields?.first()?.args
             ?: throw AssertionError("Expected non null field")
 
-        assertThat(inputValues[0].name, equalTo("int"))
-        assertThat(inputValues[0].type.ofType?.name, equalTo("Int"))
-        assertThat(inputValues[1].name, equalTo("string"))
-        assertThat(inputValues[1].type.ofType?.name, equalTo("String"))
+        inputValues[0].name shouldBe "int"
+        inputValues[0].type.ofType?.name shouldBe "Int"
+        inputValues[1].name shouldBe "string"
+        inputValues[1].type.ofType?.name shouldBe "String"
     }
 
     @Test
@@ -231,8 +229,8 @@ class IntrospectionSpecificationTest {
         val inputValues = schema.findTypeByName("IntString")?.fields?.find { it.name == "float" }?.args
             ?: throw AssertionError("Expected non null field")
 
-        assertThat(inputValues[0].name, equalTo("doubleIt"))
-        assertThat(inputValues[0].type.ofType?.name, equalTo("Boolean"))
+        inputValues[0].name shouldBe "doubleIt"
+        inputValues[0].type.ofType?.name shouldBe "Boolean"
     }
 
     interface Inter {
@@ -256,8 +254,8 @@ class IntrospectionSpecificationTest {
         }
 
         val response = deserialize(schema.executeBlocking("{interface{value, __typename ... on Face{value2}}}"))
-        assertThat(response.extract("data/interface/__typename"), equalTo("Face"))
-        assertThat(response.extract("data/interface/value2"), equalTo(false))
+        response.extract<String>("data/interface/__typename") shouldBe "Face"
+        response.extract<Boolean>("data/interface/value2") shouldBe false
     }
 
     interface InterInter : Inter {
@@ -277,19 +275,19 @@ class IntrospectionSpecificationTest {
         }
 
         val possibleTypesOfInter = schema.findTypeByName("Inter")?.possibleTypes?.map { it.name }
-        assertThat(possibleTypesOfInter, equalTo(listOf("Face")))
+        possibleTypesOfInter shouldBe listOf("Face")
 
         val possibleTypesOfInterInter = schema.findTypeByName("InterInter")?.possibleTypes?.map { it.name }
-        assertThat(possibleTypesOfInterInter, equalTo(listOf("Face")))
+        possibleTypesOfInterInter shouldBe listOf("Face")
 
         val interfacesOfFace = schema.findTypeByName("Face")?.interfaces?.map { it.name }
-        assertThat(interfacesOfFace, equalTo(listOf("Inter", "InterInter")))
+        interfacesOfFace shouldBe listOf("Inter", "InterInter")
 
         val interfacesOfInterInter = schema.findTypeByName("InterInter")?.interfaces?.map { it.name }
-        assertThat(interfacesOfInterInter, equalTo(listOf("Inter")))
+        interfacesOfInterInter shouldBe listOf("Inter")
 
         val interfacesOfInter = schema.findTypeByName("Inter")?.interfaces?.map { it.name }
-        assertThat(interfacesOfInter, equalTo(emptyList()))
+        interfacesOfInter.shouldBeEmpty()
     }
 
     data class Book(val id: String)
@@ -314,13 +312,13 @@ class IntrospectionSpecificationTest {
     @Test
     fun `union types possible types are supported`() {
         val possibleTypes = unionSchema.findTypeByName("FaceBook")?.possibleTypes?.map { it.name }
-        assertThat(possibleTypes, equalTo(listOf<String?>("Face", "Book")))
+        possibleTypes shouldBe listOf("Face", "Book")
     }
 
     @Test
     fun `union types should not be duplicated`() {
         val facebookCount = unionSchema.model.allTypes.map { it.name }.count { it == "FaceBook" }
-        assertThat(facebookCount, equalTo(1))
+        facebookCount shouldBe 1
     }
 
     @Test
@@ -334,8 +332,8 @@ class IntrospectionSpecificationTest {
         val map = deserialize(schema.executeBlocking(Introspection.query()))
         val fields = map.extract<List<Map<String, *>>>("data/__schema/types[0]/fields")
 
-        fields.forEach { field ->
-            assertThat(field["name"] as String, not(startsWith("__")))
+        fields.forAll { field ->
+            field["name"] as String shouldNotStartWith "__"
         }
     }
 
@@ -350,11 +348,8 @@ class IntrospectionSpecificationTest {
         val map = deserialize(schema.executeBlocking(Introspection.query()))
         val types = map.extract<List<Map<Any, *>>>("data/__schema/types")
 
-        val typenames = types.map { type -> type["name"] as String }.sorted()
-
-        for (i in typenames.indices) {
-            typenames[i] shouldNotBeEqualTo typenames.getOrNull(i + 1)
-        }
+        val typenames = types.map { type -> type["name"] as String }
+        typenames.shouldBeUnique()
     }
 
     @Test
@@ -379,30 +374,30 @@ class IntrospectionSpecificationTest {
             )
         )
 
-        assertThat(response.extract<List<*>>("data/__schema/directives"), hasSize(3))
+        response.extract<List<*>>("data/__schema/directives") shouldHaveSize 3
 
-        assertThat(response.extract("data/__schema/directives[0]/name"), equalTo("skip"))
-        assertThat(response.extract("data/__schema/directives[0]/isRepeatable"), equalTo(false))
-        assertThat(response.extract<List<*>>("data/__schema/directives[0]/args"), hasSize(1))
-        assertThat(response.extract("data/__schema/directives[0]/args[0]/name"), equalTo("if"))
-        assertThat(response.extract("data/__schema/directives[0]/args[0]/type/kind"), equalTo("NON_NULL"))
-        assertThat(response.extract("data/__schema/directives[0]/args[0]/type/ofType/name"), equalTo("Boolean"))
-        assertThat(response.extract("data/__schema/directives[0]/args[0]/type/ofType/kind"), equalTo("SCALAR"))
+        response.extract<String>("data/__schema/directives[0]/name") shouldBe "skip"
+        response.extract<Boolean>("data/__schema/directives[0]/isRepeatable") shouldBe false
+        response.extract<List<*>>("data/__schema/directives[0]/args") shouldHaveSize 1
+        response.extract<String>("data/__schema/directives[0]/args[0]/name") shouldBe "if"
+        response.extract<String>("data/__schema/directives[0]/args[0]/type/kind") shouldBe "NON_NULL"
+        response.extract<String>("data/__schema/directives[0]/args[0]/type/ofType/name") shouldBe "Boolean"
+        response.extract<String>("data/__schema/directives[0]/args[0]/type/ofType/kind") shouldBe "SCALAR"
 
-        assertThat(response.extract("data/__schema/directives[1]/name"), equalTo("include"))
-        assertThat(response.extract("data/__schema/directives[1]/isRepeatable"), equalTo(false))
-        assertThat(response.extract<List<*>>("data/__schema/directives[1]/args"), hasSize(1))
-        assertThat(response.extract("data/__schema/directives[1]/args[0]/name"), equalTo("if"))
-        assertThat(response.extract("data/__schema/directives[1]/args[0]/type/kind"), equalTo("NON_NULL"))
-        assertThat(response.extract("data/__schema/directives[1]/args[0]/type/ofType/name"), equalTo("Boolean"))
-        assertThat(response.extract("data/__schema/directives[1]/args[0]/type/ofType/kind"), equalTo("SCALAR"))
+        response.extract<String>("data/__schema/directives[1]/name") shouldBe "include"
+        response.extract<Boolean>("data/__schema/directives[1]/isRepeatable") shouldBe false
+        response.extract<List<*>>("data/__schema/directives[1]/args") shouldHaveSize 1
+        response.extract<String>("data/__schema/directives[1]/args[0]/name") shouldBe "if"
+        response.extract<String>("data/__schema/directives[1]/args[0]/type/kind") shouldBe "NON_NULL"
+        response.extract<String>("data/__schema/directives[1]/args[0]/type/ofType/name") shouldBe "Boolean"
+        response.extract<String>("data/__schema/directives[1]/args[0]/type/ofType/kind") shouldBe "SCALAR"
 
-        assertThat(response.extract("data/__schema/directives[2]/name"), equalTo("deprecated"))
-        assertThat(response.extract("data/__schema/directives[2]/isRepeatable"), equalTo(false))
-        assertThat(response.extract<List<*>>("data/__schema/directives[2]/args"), hasSize(1))
-        assertThat(response.extract("data/__schema/directives[2]/args[0]/name"), equalTo("reason"))
-        assertThat(response.extract("data/__schema/directives[2]/args[0]/type/kind"), equalTo("SCALAR"))
-        assertThat(response.extract("data/__schema/directives[2]/args[0]/type/name"), equalTo("String"))
+        response.extract<String>("data/__schema/directives[2]/name") shouldBe "deprecated"
+        response.extract<Boolean>("data/__schema/directives[2]/isRepeatable") shouldBe false
+        response.extract<List<*>>("data/__schema/directives[2]/args") shouldHaveSize 1
+        response.extract<String>("data/__schema/directives[2]/args[0]/name") shouldBe "reason"
+        response.extract<String>("data/__schema/directives[2]/args[0]/type/name") shouldBe "String"
+        response.extract<String>("data/__schema/directives[2]/args[0]/type/kind") shouldBe "SCALAR"
     }
 
     /**
@@ -417,7 +412,7 @@ class IntrospectionSpecificationTest {
         }
 
         val response = deserialize(schema.executeBlocking("{__schema{queryType{interfaces{name}}}}"))
-        assertThat(response.extract<List<*>>("data/__schema/queryType/interfaces"), empty())
+        response.extract<List<*>>("data/__schema/queryType/interfaces").shouldBeEmpty()
     }
 
     /**
@@ -434,10 +429,10 @@ class IntrospectionSpecificationTest {
         val response =
             deserialize(schema.executeBlocking("{__schema{directives{name, onField, onFragment, onOperation}}}"))
         val directives = response.extract<List<Map<String, *>>>("data/__schema/directives")
-        directives.forEach { directive ->
-            assertThat(directive["onField"], notNullValue())
-            assertThat(directive["onFragment"], notNullValue())
-            assertThat(directive["onOperation"], notNullValue())
+        directives.forAll { directive ->
+            directive["onField"] shouldNotBe null
+            directive["onFragment"] shouldNotBe null
+            directive["onOperation"] shouldNotBe null
         }
     }
 

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/ArgumentsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/ArgumentsSpecificationTest.kt
@@ -6,8 +6,7 @@ import com.apurebase.kgraphql.defaultSchema
 import com.apurebase.kgraphql.deserialize
 import com.apurebase.kgraphql.executeEqualQueries
 import com.apurebase.kgraphql.schema.execution.Executor
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.MatcherAssert.assertThat
+import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 
 @Specification("2.6 Arguments")
@@ -76,9 +75,15 @@ class ArgumentsSpecificationTest {
     @Test
     fun `many arguments can exist on given field`() {
         val response = deserialize(schema.executeBlocking("{actor{favDishes(size: 2, prefix: \"b\")}}"))
-        assertThat(
-            response,
-            equalTo(mapOf<String, Any>("data" to mapOf("actor" to mapOf("favDishes" to listOf("burger", "bread")))))
+        response shouldBe mapOf<String, Any>(
+            "data" to mapOf(
+                "actor" to mapOf(
+                    "favDishes" to listOf(
+                        "burger",
+                        "bread"
+                    )
+                )
+            )
         )
     }
 
@@ -97,22 +102,19 @@ class ArgumentsSpecificationTest {
             }
         """.trimIndent()
         val response = deserialize(schema.executeBlocking(request))
-        assertThat(
-            response, equalTo(
-                mapOf<String, Any>(
-                    "data" to mapOf(
-                        "actor" to mapOf(
-                            "none" to age,
-                            "one" to age + 1,
-                            "two" to age + 2 + 3,
-                            "three" to age + 4 + 5 + 6,
-                            "four" to age + 7 + 8 + 9 + 10,
-                            "five" to age + 11 + 12 + 13 + 14 + 15
-                        )
+        response shouldBe
+            mapOf<String, Any>(
+                "data" to mapOf(
+                    "actor" to mapOf(
+                        "none" to age,
+                        "one" to age + 1,
+                        "two" to age + 2 + 3,
+                        "three" to age + 4 + 5 + 6,
+                        "four" to age + 7 + 8 + 9 + 10,
+                        "five" to age + 11 + 12 + 13 + 14 + 15
                     )
                 )
             )
-        )
     }
 
     @Test
@@ -145,16 +147,13 @@ class ArgumentsSpecificationTest {
         """.trimIndent()
 
         val response = deserialize(schema.executeBlocking(request))
-        assertThat(
-            response, equalTo(
-                mapOf<String, Any>(
-                    "data" to mapOf<String, Any>(
-                        "actor" to mapOf<String, Any>(
-                            "greeting" to "Hello, John Doe!"
-                        )
+        response shouldBe
+            mapOf<String, Any>(
+                "data" to mapOf<String, Any>(
+                    "actor" to mapOf<String, Any>(
+                        "greeting" to "Hello, John Doe!"
                     )
                 )
             )
-        )
     }
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/FieldAliasSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/FieldAliasSpecificationTest.kt
@@ -5,8 +5,7 @@ import com.apurebase.kgraphql.Specification
 import com.apurebase.kgraphql.defaultSchema
 import com.apurebase.kgraphql.deserialize
 import com.apurebase.kgraphql.extract
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.MatcherAssert.assertThat
+import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 
 @Specification("2.7 Field Alias")
@@ -32,13 +31,13 @@ class FieldAliasSpecificationTest {
     fun `can define response object field name`() {
         val map =
             deserialize(schema.executeBlocking("{actor{ageMonths: age(inMonths : true) ageYears: age(inMonths : false)}}"))
-        assertThat(map.extract<Int>("data/actor/ageMonths"), equalTo(age * 12))
-        assertThat(map.extract<Int>("data/actor/ageYears"), equalTo(age))
+        map.extract<Int>("data/actor/ageMonths") shouldBe age * 12
+        map.extract<Int>("data/actor/ageYears") shouldBe age
     }
 
     @Test
     fun `top level of a query can be given alias`() {
         val map = deserialize(schema.executeBlocking("{ bogus : actor{name}}"))
-        assertThat(map.extract<String>("data/bogus/name"), equalTo(actorName))
+        map.extract<String>("data/bogus/name") shouldBe actorName
     }
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/FieldsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/FieldsSpecificationTest.kt
@@ -5,8 +5,7 @@ import com.apurebase.kgraphql.Specification
 import com.apurebase.kgraphql.defaultSchema
 import com.apurebase.kgraphql.deserialize
 import com.apurebase.kgraphql.extract
-import org.hamcrest.CoreMatchers
-import org.hamcrest.MatcherAssert
+import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 
 @Specification("2.5 Fields")
@@ -26,7 +25,7 @@ class FieldsSpecificationTest {
     fun `field may itself contain a selection set`() {
         val response = deserialize(schema.executeBlocking("{actor{id, actualActor{name, age}}}"))
         val map = response.extract<Map<String, Any>>("data/actor/actualActor")
-        MatcherAssert.assertThat(map, CoreMatchers.equalTo(mapOf("name" to "Boguś Linda", "age" to age)))
+        map shouldBe mapOf("name" to "Boguś Linda", "age" to age)
     }
 }
 

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/ListInputCoercionTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/ListInputCoercionTest.kt
@@ -4,13 +4,9 @@ import com.apurebase.kgraphql.InvalidInputValueException
 import com.apurebase.kgraphql.Specification
 import com.apurebase.kgraphql.defaultSchema
 import com.apurebase.kgraphql.deserialize
+import com.apurebase.kgraphql.expect
 import com.apurebase.kgraphql.extract
-import org.amshove.kluent.invoking
-import org.amshove.kluent.shouldThrow
-import org.amshove.kluent.withMessage
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.CoreMatchers.nullValue
-import org.hamcrest.MatcherAssert.assertThat
+import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 
 @Specification("3.11 List", "3.12 Non-Null")
@@ -30,163 +26,163 @@ class ListInputCoercionTest {
     @Test
     fun `null should be valid for a nullable list of Int`() {
         val response = deserialize(schema.executeBlocking("{ NullableList(value: null) }"))
-        assertThat(response.extract<List<Int>>("data/NullableList"), nullValue())
+        response.extract<List<Int>>("data/NullableList") shouldBe null
     }
 
     @Test
     fun `1 should be valid for a nullable list of Int`() {
         val response = deserialize(schema.executeBlocking("{ NullableList(value: 1) }"))
-        assertThat(response.extract<List<Int>>("data/NullableList"), equalTo(listOf(1)))
+        response.extract<List<Int>>("data/NullableList") shouldBe listOf(1)
     }
 
     @Test
     fun `a list should be valid for a nullable list of Int`() {
         val response = deserialize(schema.executeBlocking("{ NullableList(value: [1, 2, 3]) }"))
-        assertThat(response.extract<List<Int>>("data/NullableList"), equalTo(listOf(1, 2, 3)))
+        response.extract<List<Int>>("data/NullableList") shouldBe listOf(1, 2, 3)
     }
 
     @Test
     fun `a list of mixed types should not be valid for a nullable list of Int`() {
-        invoking {
+        expect<InvalidInputValueException>("Cannot coerce \"b\" to numeric constant") {
             deserialize(schema.executeBlocking("{ NullableList(value: [1, \"b\", true]) }"))
-        } shouldThrow InvalidInputValueException::class withMessage "Cannot coerce \"b\" to numeric constant"
+        }
     }
 
     @Test
     fun `foo should not be valid for a nullable list of Int`() {
-        invoking {
+        expect<InvalidInputValueException>("Cannot coerce \"foo\" to numeric constant") {
             deserialize(schema.executeBlocking("{ RequiredList(value: \"foo\") }"))
-        } shouldThrow InvalidInputValueException::class withMessage "Cannot coerce \"foo\" to numeric constant"
+        }
     }
 
     @Test
     fun `null should be valid for a nullable nested list of Int`() {
         val response = deserialize(schema.executeBlocking("{ NullableNestedList(value: null) }"))
-        assertThat(response.extract<List<Int>>("data/NullableNestedList"), nullValue())
+        response.extract<List<Int>>("data/NullableNestedList") shouldBe null
     }
 
     @Test
     fun `1 should be valid for a nullable nested list of Int`() {
         val response = deserialize(schema.executeBlocking("{ NullableNestedList(value: 1) }"))
-        assertThat(response.extract<List<Int>>("data/NullableNestedList"), equalTo(listOf(listOf(1))))
+        response.extract<List<Int>>("data/NullableNestedList") shouldBe listOf(listOf(1))
     }
 
     @Test
     fun `a nested list should be valid for a nullable nested list of Int`() {
         val response = deserialize(schema.executeBlocking("{ NullableNestedList(value: [[1], [2, 3]]) }"))
-        assertThat(response.extract<List<Int>>("data/NullableNestedList"), equalTo(listOf(listOf(1), listOf(2, 3))))
+        response.extract<List<Int>>("data/NullableNestedList") shouldBe listOf(listOf(1), listOf(2, 3))
     }
 
     @Test
     fun `a non-nested list should not be valid for a nullable nested list of Int`() {
-        invoking {
-            val result = deserialize(schema.executeBlocking("{ NullableNestedList(value: [1, 2, 3]) }"))
-            println(result)
-        } shouldThrow InvalidInputValueException::class withMessage "argument '1' is not valid value of type List"
+        expect<InvalidInputValueException>("argument '1' is not valid value of type List") {
+            deserialize(schema.executeBlocking("{ NullableNestedList(value: [1, 2, 3]) }"))
+        }
     }
 
     @Test
     fun `null should not be valid for a required list of Int`() {
-        invoking {
+        expect<InvalidInputValueException>("argument 'null' is not valid value of type Int") {
             deserialize(schema.executeBlocking("{ RequiredList(value: null) }"))
-        } shouldThrow InvalidInputValueException::class withMessage "argument 'null' is not valid value of type Int"
+        }
     }
 
     @Test
     fun `a list should be valid for a required list of Int`() {
         val response = deserialize(schema.executeBlocking("{ RequiredList(value: [1, 2, 3]) }"))
-        assertThat(response.extract<List<Int?>>("data/RequiredList"), equalTo(listOf(1, 2, 3)))
+        response.extract<List<Int?>>("data/RequiredList") shouldBe listOf(1, 2, 3)
     }
 
     @Test
     fun `a list with null value should be valid for a required list of Int`() {
         val response = deserialize(schema.executeBlocking("{ RequiredList(value: [1, 2, null]) }"))
-        assertThat(response.extract<List<Int?>>("data/RequiredList"), equalTo(listOf(1, 2, null)))
+        response.extract<List<Int?>>("data/RequiredList") shouldBe listOf(1, 2, null)
     }
 
     @Test
     fun `null should be valid for a nullable set of Int`() {
         val response = deserialize(schema.executeBlocking("{ NullableSet(value: null) }"))
-        assertThat(response.extract<Set<Int>>("data/NullableSet"), nullValue())
+        response.extract<Set<Int>>("data/NullableSet") shouldBe null
     }
 
     @Test
     fun `1 should be valid for a nullable set of Int`() {
         val response = deserialize(schema.executeBlocking("{ NullableSet(value: 1) }"))
-        assertThat(response.extract<List<Int>>("data/NullableSet"), equalTo(listOf(1)))
+        response.extract<List<Int>>("data/NullableSet") shouldBe listOf(1)
     }
 
     @Test
     fun `a list should be valid for a nullable set of Int`() {
         val response = deserialize(schema.executeBlocking("{ NullableSet(value: [1, 2, 3, 1]) }"))
-        assertThat(response.extract<List<Int>>("data/NullableSet"), equalTo(listOf(1, 2, 3)))
+        response.extract<List<Int>>("data/NullableSet") shouldBe listOf(1, 2, 3)
     }
 
     @Test
     fun `a list of mixed types should not be valid for a nullable set of Int`() {
-        invoking {
+        expect<InvalidInputValueException>("Cannot coerce \"b\" to numeric constant") {
             deserialize(schema.executeBlocking("{ NullableSet(value: [1, \"b\", true]) }"))
-        } shouldThrow InvalidInputValueException::class withMessage "Cannot coerce \"b\" to numeric constant"
+        }
     }
 
     @Test
     fun `foo should not be valid for a nullable set of Int`() {
-        invoking {
+        expect<InvalidInputValueException>("Cannot coerce \"foo\" to numeric constant") {
             deserialize(schema.executeBlocking("{ RequiredSet(value: \"foo\") }"))
-        } shouldThrow InvalidInputValueException::class withMessage "Cannot coerce \"foo\" to numeric constant"
+        }
     }
 
     @Test
     fun `null should be valid for a nullable nested set of Int`() {
         val response = deserialize(schema.executeBlocking("{ NullableNestedSet(value: null) }"))
-        assertThat(response.extract<List<Int>>("data/NullableNestedSet"), nullValue())
+        response.extract<List<Int>>("data/NullableNestedSet") shouldBe null
     }
 
     @Test
     fun `1 should be valid for a nullable nested set of Int`() {
         val response = deserialize(schema.executeBlocking("{ NullableNestedSet(value: 1) }"))
-        assertThat(response.extract<List<Int>>("data/NullableNestedSet"), equalTo(listOf(listOf(1))))
+        response.extract<List<Int>>("data/NullableNestedSet") shouldBe listOf(listOf(1))
     }
 
     @Test
     fun `a nested list should be valid for a nullable nested set of Int`() {
         val response = deserialize(schema.executeBlocking("{ NullableNestedSet(value: [[1], [2, 3, 3]]) }"))
-        assertThat(response.extract<List<Int>>("data/NullableNestedSet"), equalTo(listOf(listOf(1), listOf(2, 3))))
+        response.extract<List<Int>>("data/NullableNestedSet") shouldBe listOf(listOf(1), listOf(2, 3))
     }
 
     @Test
     fun `a nested list should be valid for a nullable nested set of list of set of Int`() {
         val response =
             deserialize(schema.executeBlocking("{ NullableNestedSetListSet(value: [[[1]], [[1]], [[2, 3], [2, 3, 3]]]) }"))
-        assertThat(
-            response.extract<List<Int>>("data/NullableNestedSetListSet"),
-            equalTo(listOf(listOf(listOf(1)), listOf(listOf(2, 3), listOf(2, 3))))
+
+        response.extract<List<Int>>("data/NullableNestedSetListSet") shouldBe listOf(
+            listOf(listOf(1)),
+            listOf(listOf(2, 3), listOf(2, 3))
         )
     }
 
     @Test
     fun `a non-nested list should not be valid for a nullable nested set of Int`() {
-        invoking {
+        expect<InvalidInputValueException>("argument '1' is not valid value of type List") {
             deserialize(schema.executeBlocking("{ NullableNestedSet(value: [1, 2, 3]) }"))
-        } shouldThrow InvalidInputValueException::class withMessage "argument '1' is not valid value of type List"
+        }
     }
 
     @Test
     fun `null should not be valid for a required set of Int`() {
-        invoking {
+        expect<InvalidInputValueException>("argument 'null' is not valid value of type Int") {
             deserialize(schema.executeBlocking("{ RequiredSet(value: null) }"))
-        } shouldThrow InvalidInputValueException::class withMessage "argument 'null' is not valid value of type Int"
+        }
     }
 
     @Test
     fun `a list should be valid for a required set of Int`() {
         val response = deserialize(schema.executeBlocking("{ RequiredSet(value: [1, 2, 3]) }"))
-        assertThat(response.extract<List<Int?>>("data/RequiredSet"), equalTo(listOf(1, 2, 3)))
+        response.extract<List<Int?>>("data/RequiredSet") shouldBe listOf(1, 2, 3)
     }
 
     @Test
     fun `a list with null value should be valid for a required set of Int`() {
         val response = deserialize(schema.executeBlocking("{ RequiredSet(value: [1, 2, null]) }"))
-        assertThat(response.extract<List<Int?>>("data/RequiredSet"), equalTo(listOf(1, 2, null)))
+        response.extract<List<Int?>>("data/RequiredSet") shouldBe listOf(1, 2, null)
     }
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/QueryDocumentSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/QueryDocumentSpecificationTest.kt
@@ -1,17 +1,14 @@
 package com.apurebase.kgraphql.specification.language
 
 import com.apurebase.kgraphql.Actor
-import com.apurebase.kgraphql.GraphQLError
 import com.apurebase.kgraphql.Specification
+import com.apurebase.kgraphql.ValidationException
 import com.apurebase.kgraphql.assertNoErrors
 import com.apurebase.kgraphql.defaultSchema
 import com.apurebase.kgraphql.deserialize
+import com.apurebase.kgraphql.expect
 import com.apurebase.kgraphql.extract
-import org.amshove.kluent.invoking
-import org.amshove.kluent.shouldThrow
-import org.amshove.kluent.withMessage
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.MatcherAssert.assertThat
+import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 
 @Specification("2.2 Query Document")
@@ -29,16 +26,16 @@ class QueryDocumentSpecificationTest {
 
     @Test
     fun `anonymous operation must be the only defined operation`() {
-        invoking {
+        expect<ValidationException>("anonymous operation must be the only defined operation") {
             deserialize(schema.executeBlocking("query {fizz} mutation BUZZ {createActor(name : \"Kurt Russel\"){name}}"))
-        } shouldThrow GraphQLError::class withMessage "anonymous operation must be the only defined operation"
+        }
     }
 
     @Test
     fun `must provide operation name when multiple named operations`() {
-        invoking {
+        expect<ValidationException>("Must provide an operation name from: [FIZZ, BUZZ], found null") {
             deserialize(schema.executeBlocking("query FIZZ {fizz} mutation BUZZ {createActor(name : \"Kurt Russel\"){name}}"))
-        } shouldThrow GraphQLError::class withMessage "Must provide an operation name from: [FIZZ, BUZZ], found null"
+        }
     }
 
     @Test
@@ -50,6 +47,6 @@ class QueryDocumentSpecificationTest {
             )
         )
         assertNoErrors(map)
-        assertThat(map.extract<String>("data/fizz"), equalTo("buzz"))
+        map.extract<String>("data/fizz") shouldBe "buzz"
     }
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/SelectionSetsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/SelectionSetsSpecificationTest.kt
@@ -5,8 +5,7 @@ import com.apurebase.kgraphql.Specification
 import com.apurebase.kgraphql.defaultSchema
 import com.apurebase.kgraphql.deserialize
 import com.apurebase.kgraphql.extract
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.MatcherAssert.assertThat
+import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 
 @Specification("2.4 Selection Sets")
@@ -24,21 +23,21 @@ class SelectionSetsSpecificationTest {
     fun `operation selects the set of information it needs`() {
         val response = deserialize(schema.executeBlocking("{actor{name, age}}"))
         val map = response.extract<Map<String, Any>>("data/actor")
-        assertThat(map, equalTo(mapOf("name" to "Boguś Linda", "age" to age)))
+        map shouldBe mapOf("name" to "Boguś Linda", "age" to age)
     }
 
     @Test
     fun `operation selects the set of information it needs 2`() {
         val response = deserialize(schema.executeBlocking("{actor{name}}"))
         val map = response.extract<Map<String, Any>>("data/actor")
-        assertThat(map, equalTo(mapOf<String, Any>("name" to "Boguś Linda")))
+        map shouldBe mapOf<String, Any>("name" to "Boguś Linda")
     }
 
     @Test
     fun `operation selects the set of information it needs 3`() {
         val response = deserialize(schema.executeBlocking("{actor{age}}"))
         val map = response.extract<Map<String, Any>>("data/actor")
-        assertThat(map, equalTo(mapOf<String, Any>("age" to age)))
+        map shouldBe mapOf<String, Any>("age" to age)
     }
 
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/VariablesSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/VariablesSpecificationTest.kt
@@ -7,8 +7,7 @@ import com.apurebase.kgraphql.assertNoErrors
 import com.apurebase.kgraphql.expect
 import com.apurebase.kgraphql.extract
 import com.apurebase.kgraphql.integration.BaseSchemaTest
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.MatcherAssert.assertThat
+import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
@@ -21,17 +20,14 @@ class VariablesSpecificationTest : BaseSchemaTest() {
             variables = "{\"name\":\"Boguś Linda\", \"age\": 22}"
         )
         assertNoErrors(map)
-        assertThat(
-            map.extract<Map<String, Any>>("data/createActor"),
-            equalTo(mapOf("name" to "Boguś Linda", "age" to 22))
-        )
+        map.extract<Map<String, Any>>("data/createActor") shouldBe mapOf("name" to "Boguś Linda", "age" to 22)
     }
 
     @Test
     fun `query with int variable`() {
         val map = execute(query = "query(\$rank: Int!) {filmByRank(rank: \$rank) {title}}", variables = "{\"rank\": 1}")
         assertNoErrors(map)
-        assertThat(map.extract<Int>("data/filmByRank/title"), equalTo("Prestige"))
+        map.extract<String>("data/filmByRank/title") shouldBe "Prestige"
     }
 
     // Json only has one number type, so "1" and "1.0" are the same, and input coercion should be able to handle
@@ -41,7 +37,7 @@ class VariablesSpecificationTest : BaseSchemaTest() {
         val map =
             execute(query = "query(\$rank: Int!) {filmByRank(rank: \$rank) {title}}", variables = "{\"rank\": 1.0}")
         assertNoErrors(map)
-        assertThat(map.extract<Int>("data/filmByRank/title"), equalTo("Prestige"))
+        map.extract<String>("data/filmByRank/title") shouldBe "Prestige"
     }
 
     @Test
@@ -55,35 +51,35 @@ class VariablesSpecificationTest : BaseSchemaTest() {
     fun `query with float variable`() {
         val map = execute(query = "query(\$float: Float!) {float(float: \$float)}", variables = "{\"float\": 42.3}")
         assertNoErrors(map)
-        assertThat(map.extract<Float>("data/float"), equalTo(42.3))
+        map.extract<Float>("data/float") shouldBe 42.3
     }
 
     @Test
     fun `query with float variable in exponential notation`() {
         val map = execute(query = "query(\$float: Float!) {float(float: \$float)}", variables = "{\"float\": 2.1e1}")
         assertNoErrors(map)
-        assertThat(map.extract<Float>("data/float"), equalTo(2.1e1))
+        map.extract<Float>("data/float") shouldBe 2.1e1
     }
 
     @Test
     fun `query with float variable should allow integer input`() {
         val map = execute(query = "query(\$float: Float!) {float(float: \$float)}", variables = "{\"float\": 42}")
         assertNoErrors(map)
-        assertThat(map.extract<Float>("data/float"), equalTo(42.0))
+        map.extract<Float>("data/float") shouldBe 42.0
     }
 
     @Test
     fun `query with boolean variable`() {
         val map = execute(query = "query(\$big: Boolean!) {number(big: \$big)}", variables = "{\"big\": true}")
         assertNoErrors(map)
-        assertThat(map.extract<Int>("data/number"), equalTo(10000))
+        map.extract<Int>("data/number") shouldBe 10000
     }
 
     @Test
     fun `query with boolean variable default value`() {
         val map = execute(query = "query(\$big: Boolean = true) {number(big: \$big)}")
         assertNoErrors(map)
-        assertThat(map.extract<Int>("data/number"), equalTo(10000))
+        map.extract<Int>("data/number") shouldBe 10000
     }
 
     @Test
@@ -93,9 +89,8 @@ class VariablesSpecificationTest : BaseSchemaTest() {
             variables = "{\"type\": \"FULL_LENGTH\"}"
         )
         assertNoErrors(map)
-        assertThat(
-            map.extract<Map<String, String>>("data/filmsByType"),
-            equalTo(listOf(mapOf("title" to "Prestige"), mapOf("title" to "Se7en")))
+        map.extract<Map<String, String>>("data/filmsByType") shouldBe listOf(
+            mapOf("title" to "Prestige"), mapOf("title" to "Se7en")
         )
     }
 
@@ -106,10 +101,7 @@ class VariablesSpecificationTest : BaseSchemaTest() {
             variables = "{\"age\": 22}"
         )
         assertNoErrors(map)
-        assertThat(
-            map.extract<Map<String, Any>>("data/createActor"),
-            equalTo(mapOf("name" to "Boguś Linda", "age" to 22))
-        )
+        map.extract<Map<String, Any>>("data/createActor") shouldBe mapOf("name" to "Boguś Linda", "age" to 22)
     }
 
     @Test
@@ -121,10 +113,7 @@ class VariablesSpecificationTest : BaseSchemaTest() {
             variables = "{\"defaultAge\": 22}"
         )
         assertNoErrors(map)
-        assertThat(
-            map.extract<Map<String, Any>>("data/createActor"),
-            equalTo(mapOf("name" to "Boguś Linda", "age" to 22))
-        )
+        map.extract<Map<String, Any>>("data/createActor") shouldBe mapOf("name" to "Boguś Linda", "age" to 22)
     }
 
     @Test
@@ -135,10 +124,7 @@ class VariablesSpecificationTest : BaseSchemaTest() {
             variables = "{\"age\": 22, \"big\": true}"
         )
         assertNoErrors(map)
-        assertThat(
-            map.extract<String>("data/createActor/picture"),
-            equalTo("http://picture.server/pic/Boguś_Linda?big=true")
-        )
+        map.extract<String>("data/createActor/picture") shouldBe "http://picture.server/pic/Boguś_Linda?big=true"
     }
 
     @Test
@@ -200,14 +186,14 @@ class VariablesSpecificationTest : BaseSchemaTest() {
         val result = execute(request, variables)
 
         assertNoErrors(result)
-        assertThat(result.extract("data/createFirst/name"), equalTo("Jógvan"))
-        assertThat(result.extract("data/createSecond/age"), equalTo(2))
-        assertThat(result.extract("data/inputFirst/name"), equalTo("Olsen"))
-        assertThat(result.extract("data/inputSecond/age"), equalTo(4))
-        assertThat(result.extract("data/agesFirst/name"), equalTo("Someone"))
-        assertThat(result.extract("data/agesSecond/age"), equalTo(15))
-        assertThat(result.extract("data/inputAgesFirst/name"), equalTo("Jógvan Olsen"))
-        assertThat(result.extract("data/inputAgesSecond/age"), equalTo(22))
+        result.extract<String>("data/createFirst/name") shouldBe "Jógvan"
+        result.extract<Int>("data/createSecond/age") shouldBe 2
+        result.extract<String>("data/inputFirst/name") shouldBe "Olsen"
+        result.extract<Int>("data/inputSecond/age") shouldBe 4
+        result.extract<String>("data/agesFirst/name") shouldBe "Someone"
+        result.extract<Int>("data/agesSecond/age") shouldBe 15
+        result.extract<String>("data/inputAgesFirst/name") shouldBe "Jógvan Olsen"
+        result.extract<Int>("data/inputAgesSecond/age") shouldBe 22
     }
 
     @Test
@@ -236,7 +222,7 @@ class VariablesSpecificationTest : BaseSchemaTest() {
         val result = execute(request, variables)
 
         assertNoErrors(result)
-        assertThat(result.extract("data/agesFirst/name"), equalTo("Someone"))
-        assertThat(result.extract("data/agesSecond/age"), equalTo(15))
+        result.extract<String>("data/agesFirst/name") shouldBe "Someone"
+        result.extract<Int>("data/agesSecond/age") shouldBe 15
     }
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/DirectivesSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/DirectivesSpecificationTest.kt
@@ -5,7 +5,7 @@ import com.apurebase.kgraphql.extract
 import com.apurebase.kgraphql.integration.BaseSchemaTest
 import com.apurebase.kgraphql.schema.execution.ExecutionOptions
 import com.apurebase.kgraphql.schema.execution.Executor
-import org.amshove.kluent.shouldBeEqualTo
+import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
@@ -36,7 +36,7 @@ class DirectivesSpecificationTest : BaseSchemaTest() {
         assertThrows<IllegalArgumentException> { mapOnlyInclude.extract("data/film/year") }
 
         val mapNeither = execute("{film{title, year @include(if: true) @skip(if: false)}}")
-        mapNeither.extract<Int>("data/film/year") shouldBeEqualTo 2006
+        mapNeither.extract<Int>("data/film/year") shouldBe 2006
     }
 
     @Test
@@ -45,10 +45,10 @@ class DirectivesSpecificationTest : BaseSchemaTest() {
         assertThrows<IllegalArgumentException> { mapWithSkip.extract("data/film") }
 
         val mapWithoutSkip = execute("{ number(big: true), film @skip(if: false) { title } }")
-        mapWithoutSkip.extract<String>("data/film/title") shouldBeEqualTo "Prestige"
+        mapWithoutSkip.extract<String>("data/film/title") shouldBe "Prestige"
 
         val mapWithInclude = execute("{ number(big: true), film @include(if: true) { title } }")
-        mapWithInclude.extract<String>("data/film/title") shouldBeEqualTo "Prestige"
+        mapWithInclude.extract<String>("data/film/title") shouldBe "Prestige"
 
         val mapWithoutInclude = execute("{ number(big: true), film @include(if: false) { title } }")
         assertThrows<IllegalArgumentException> { mapWithoutInclude.extract("data/film") }
@@ -105,7 +105,7 @@ class DirectivesSpecificationTest : BaseSchemaTest() {
             "{film{title, year @include(if: true) @skip(if: false)}}",
             options = ExecutionOptions(executor = Executor.DataLoaderPrepared)
         )
-        mapNeither.extract<Int>("data/film/year") shouldBeEqualTo 2006
+        mapNeither.extract<Int>("data/film/year") shouldBe 2006
     }
 
     @Test
@@ -120,13 +120,13 @@ class DirectivesSpecificationTest : BaseSchemaTest() {
             "{ number(big: true), film @skip(if: false) { title } }",
             options = ExecutionOptions(executor = Executor.DataLoaderPrepared)
         )
-        mapWithoutSkip.extract<String>("data/film/title") shouldBeEqualTo "Prestige"
+        mapWithoutSkip.extract<String>("data/film/title") shouldBe "Prestige"
 
         val mapWithInclude = execute(
             "{ number(big: true), film @include(if: true) { title } }",
             options = ExecutionOptions(executor = Executor.DataLoaderPrepared)
         )
-        mapWithInclude.extract<String>("data/film/title") shouldBeEqualTo "Prestige"
+        mapWithInclude.extract<String>("data/film/title") shouldBe "Prestige"
 
         val mapWithoutInclude = execute(
             "{ number(big: true), film @include(if: false) { title } }",

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/EnumsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/EnumsSpecificationTest.kt
@@ -1,15 +1,12 @@
 package com.apurebase.kgraphql.specification.typesystem
 
-import com.apurebase.kgraphql.GraphQLError
+import com.apurebase.kgraphql.InvalidInputValueException
 import com.apurebase.kgraphql.KGraphQL
 import com.apurebase.kgraphql.Specification
 import com.apurebase.kgraphql.deserialize
+import com.apurebase.kgraphql.expect
 import com.apurebase.kgraphql.extract
-import org.amshove.kluent.invoking
-import org.amshove.kluent.shouldThrow
-import org.amshove.kluent.withMessage
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.MatcherAssert.assertThat
+import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 
 @Specification("3.1.5 Enums")
@@ -34,15 +31,15 @@ class EnumsSpecificationTest {
 
     @Test
     fun `string literals must not be accepted as an enum input`() {
-        invoking {
+        expect<InvalidInputValueException>("String literal '\"COOL\"' is invalid value for enum type Coolness") {
             schema.executeBlocking("{cool(cool : \"COOL\")}")
-        } shouldThrow GraphQLError::class withMessage "String literal '\"COOL\"' is invalid value for enum type Coolness"
+        }
     }
 
     @Test
     fun `string constants are accepted as an enum input`() {
         val response = deserialize(schema.executeBlocking("{cool(cool : COOL)}"))
-        assertThat(response.extract<String>("data/cool"), equalTo("COOL"))
+        response.extract<String>("data/cool") shouldBe "COOL"
     }
 
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/InterfacesSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/InterfacesSpecificationTest.kt
@@ -1,15 +1,12 @@
 package com.apurebase.kgraphql.specification.typesystem
 
-import com.apurebase.kgraphql.GraphQLError
 import com.apurebase.kgraphql.KGraphQL
 import com.apurebase.kgraphql.Specification
+import com.apurebase.kgraphql.ValidationException
 import com.apurebase.kgraphql.deserialize
+import com.apurebase.kgraphql.expect
 import com.apurebase.kgraphql.extract
-import org.amshove.kluent.invoking
-import org.amshove.kluent.shouldThrow
-import org.amshove.kluent.withMessage
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.MatcherAssert.assertThat
+import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 
 @Specification("3.1.3 Interfaces")
@@ -28,19 +25,19 @@ class InterfacesSpecificationTest {
     @Test
     fun `Interfaces represent a list of named fields and their arguments`() {
         val map = deserialize(schema.executeBlocking("{simple{exe}}"))
-        assertThat(map.extract("data/simple/exe"), equalTo("EXE"))
+        map.extract<String>("data/simple/exe") shouldBe "EXE"
     }
 
     @Test
     fun `When querying for fields on an interface type, only those fields declared on the interface may be queried`() {
-        invoking {
+        expect<ValidationException>("Property stuff on SimpleInterface does not exist") {
             schema.executeBlocking("{simple{exe, stuff}}")
-        } shouldThrow GraphQLError::class withMessage "Property stuff on SimpleInterface does not exist"
+        }
     }
 
     @Test
     fun `Query for fields of interface implementation can be done only by fragments`() {
         val map = deserialize(schema.executeBlocking("{simple{exe ... on Simple { stuff }}}"))
-        assertThat(map.extract("data/simple/stuff"), equalTo("CMD"))
+        map.extract<String>("data/simple/stuff") shouldBe "CMD"
     }
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/ListsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/ListsSpecificationTest.kt
@@ -1,17 +1,13 @@
 package com.apurebase.kgraphql.specification.typesystem
 
-import com.apurebase.kgraphql.GraphQLError
+import com.apurebase.kgraphql.InvalidInputValueException
 import com.apurebase.kgraphql.KGraphQL
 import com.apurebase.kgraphql.Specification
 import com.apurebase.kgraphql.deserialize
+import com.apurebase.kgraphql.expect
 import com.apurebase.kgraphql.extract
-import org.amshove.kluent.invoking
-import org.amshove.kluent.shouldThrow
-import org.amshove.kluent.withMessage
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.CoreMatchers.notNullValue
-import org.hamcrest.CoreMatchers.nullValue
-import org.hamcrest.MatcherAssert.assertThat
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import org.junit.jupiter.api.Test
 
 @Specification("3.1.7 Lists")
@@ -32,9 +28,9 @@ class ListsSpecificationTest {
 
         val response =
             deserialize(schema.executeBlocking("query(\$list: [String!]!) { list(list: \$list) }", variables))
-        assertThat(response.extract<String>("data/list[0]"), equalTo("GAGA"))
-        assertThat(response.extract<String>("data/list[1]"), equalTo("DADA"))
-        assertThat(response.extract<String>("data/list[2]"), equalTo("PADA"))
+        response.extract<String>("data/list[0]") shouldBe "GAGA"
+        response.extract<String>("data/list[1]") shouldBe "DADA"
+        response.extract<String>("data/list[2]") shouldBe "PADA"
     }
 
     @Test
@@ -51,7 +47,7 @@ class ListsSpecificationTest {
 
         val response =
             deserialize(schema.executeBlocking("query(\$list: [String!]!) { list(list: \$list) }", variables))
-        assertThat(response.extract<String>("data/list[1]"), nullValue())
+        response.extract<String>("data/list[1]") shouldBe null
     }
 
     @Test
@@ -66,10 +62,9 @@ class ListsSpecificationTest {
             { "list": ["GAGA", null, "DADA", "PADA"] }
         """.trimIndent()
 
-        invoking {
+        expect<InvalidInputValueException>("argument 'null' is not valid value of type String") {
             schema.executeBlocking("query(\$list: [String!]!) { list(list: \$list) }", variables)
-        } shouldThrow GraphQLError::class withMessage
-            "argument 'null' is not valid value of type String"
+        }
     }
 
     @Test
@@ -86,7 +81,7 @@ class ListsSpecificationTest {
 
         val response =
             deserialize(schema.executeBlocking("query(\$list: [String!]!) { list(list: \$list) }", variables))
-        assertThat(response.extract<String>("data/list[0]"), equalTo("GAGA"))
+        response.extract<String>("data/list[0]") shouldBe "GAGA"
     }
 
     @Test
@@ -104,7 +99,7 @@ class ListsSpecificationTest {
 
         val response =
             deserialize(schema.executeBlocking("query(\$list: [String!]!) { list(list: \$list) }", variables))
-        assertThat(response.extract<String>("data/list"), nullValue())
+        response.extract<String>("data/list") shouldBe null
     }
 
     @Test
@@ -121,7 +116,7 @@ class ListsSpecificationTest {
 
         val response =
             deserialize(schema.executeBlocking("query(\$list: [String!]!) { list(list: \$list) }", variables))
-        assertThat(response.extract<Any>("data/list"), notNullValue())
+        response.extract<Any>("data/list") shouldNotBe null
     }
 
     @Test
@@ -136,7 +131,7 @@ class ListsSpecificationTest {
         }
 
         val response = deserialize(schema.executeBlocking("{ list }"))
-        assertThat(response.extract<Iterable<String>>("data/list"), equalTo(getResult()))
+        response.extract<Iterable<String>>("data/list") shouldBe getResult()
     }
 
     @Test
@@ -152,7 +147,7 @@ class ListsSpecificationTest {
             }
         }
         val queryResponse = deserialize(schema.executeBlocking("{ getObject { list set } }"))
-        assertThat(queryResponse.toString(), equalTo("{data={getObject={list=[foo, bar, foo, bar], set=[foo, bar]}}}"))
+        queryResponse.toString() shouldBe "{data={getObject={list=[foo, bar, foo, bar], set=[foo, bar]}}}"
         val mutationResponse = deserialize(
             schema.executeBlocking(
                 """
@@ -164,10 +159,7 @@ class ListsSpecificationTest {
                 """.trimIndent()
             )
         )
-        assertThat(
-            mutationResponse.toString(),
-            equalTo("{data={addObject={list=[foo, bar, foo, bar], set=[foo, bar]}}}")
-        )
+        mutationResponse.toString() shouldBe "{data={addObject={list=[foo, bar, foo, bar], set=[foo, bar]}}}"
     }
 
     @Test
@@ -186,7 +178,7 @@ class ListsSpecificationTest {
             { "inputData": { "list": ["foo", "bar", "foo", "bar"], "set": ["foo", "bar", "foo", "bar"] } }
         """.trimIndent()
         val queryResponse = deserialize(schema.executeBlocking("{ getObject { list set } }"))
-        assertThat(queryResponse.toString(), equalTo("{data={getObject={list=[foo, bar, foo, bar], set=[foo, bar]}}}"))
+        queryResponse.toString() shouldBe "{data={getObject={list=[foo, bar, foo, bar], set=[foo, bar]}}}"
         val mutationResponse = deserialize(
             schema.executeBlocking(
                 """
@@ -198,10 +190,7 @@ class ListsSpecificationTest {
                 """.trimIndent(), variables
             )
         )
-        assertThat(
-            mutationResponse.toString(),
-            equalTo("{data={addObject={list=[foo, bar, foo, bar], set=[foo, bar]}}}")
-        )
+        mutationResponse.toString() shouldBe "{data={addObject={list=[foo, bar, foo, bar], set=[foo, bar]}}}"
     }
 
     // https://github.com/stuebingerb/KGraphQL/issues/110
@@ -214,9 +203,9 @@ class ListsSpecificationTest {
         }
 
         val response = deserialize(schema.executeBlocking("{ getNestedList }"))
-        assertThat(
-            response.extract<List<List<String>>>("data/getNestedList"),
-            equalTo(listOf(listOf("foo", "bar"), listOf("foobar")))
+        response.extract<List<List<String>>>("data/getNestedList") shouldBe listOf(
+            listOf("foo", "bar"),
+            listOf("foobar")
         )
     }
 
@@ -256,17 +245,8 @@ class ListsSpecificationTest {
                 """.trimIndent()
             )
         )
-        assertThat(
-            response.extract<List<*>>("data/createNestedLists/nested1"),
-            equalTo(listOf(listOf("foo", "bar", null)))
-        )
-        assertThat(
-            response.extract<List<*>>("data/createNestedLists/nested2"),
-            equalTo(listOf(listOf(listOf(listOf(listOf("foobar"))))))
-        )
-        assertThat(
-            response.extract<List<*>>("data/createNestedLists/nested3"),
-            nullValue()
-        )
+        response.extract<List<*>>("data/createNestedLists/nested1") shouldBe listOf(listOf("foo", "bar", null))
+        response.extract<List<*>>("data/createNestedLists/nested2") shouldBe listOf(listOf(listOf(listOf(listOf("foobar")))))
+        response.extract<List<*>>("data/createNestedLists/nested3") shouldBe null
     }
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/ObjectsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/ObjectsSpecificationTest.kt
@@ -7,11 +7,9 @@ import com.apurebase.kgraphql.expect
 import com.apurebase.kgraphql.schema.SchemaException
 import com.apurebase.kgraphql.schema.dsl.SchemaBuilder
 import com.apurebase.kgraphql.schema.execution.Executor
-import org.amshove.kluent.shouldBeEqualTo
-import org.amshove.kluent.shouldNotBe
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
-import org.hamcrest.Matchers.greaterThan
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -53,7 +51,7 @@ class ObjectsSpecificationTest {
             }
         }
 
-        schema.printSchema() shouldBeEqualTo """
+        schema.printSchema() shouldBe """
             type Query {
               underscore: Underscore!
             }
@@ -79,7 +77,7 @@ class ObjectsSpecificationTest {
             }
         }
 
-        schema.printSchema() shouldBeEqualTo """
+        schema.printSchema() shouldBe """
             type Query {
               underscore: Underscore!
             }
@@ -150,20 +148,20 @@ class ObjectsSpecificationTest {
 
         val result = schema.executeBlocking("{many{id, id2, value, active, smooth, name}}")
         with(result) {
-            assertThat(indexOf("\"name\""), greaterThan(indexOf("\"smooth\"")))
-            assertThat(indexOf("\"smooth\""), greaterThan(indexOf("\"active\"")))
-            assertThat(indexOf("\"active\""), greaterThan(indexOf("\"value\"")))
-            assertThat(indexOf("\"value\""), greaterThan(indexOf("\"id2\"")))
-            assertThat(indexOf("\"id2\""), greaterThan(indexOf("\"id\"")))
+            indexOf("\"name\"") shouldBeGreaterThan indexOf("\"smooth\"")
+            indexOf("\"smooth\"") shouldBeGreaterThan indexOf("\"active\"")
+            indexOf("\"active\"") shouldBeGreaterThan indexOf("\"value\"")
+            indexOf("\"value\"") shouldBeGreaterThan indexOf("\"id2\"")
+            indexOf("\"id2\"") shouldBeGreaterThan indexOf("\"id\"")
         }
 
         val result2 = schema.executeBlocking("{many{name, active, id2, value, smooth, id}}")
         with(result2) {
-            assertThat(indexOf("\"id\""), greaterThan(indexOf("\"smooth\"")))
-            assertThat(indexOf("\"smooth\""), greaterThan(indexOf("\"value\"")))
-            assertThat(indexOf("\"value\""), greaterThan(indexOf("\"id2\"")))
-            assertThat(indexOf("\"id2\""), greaterThan(indexOf("\"active\"")))
-            assertThat(indexOf("\"active\""), greaterThan(indexOf("\"name\"")))
+            indexOf("\"id\"") shouldBeGreaterThan indexOf("\"smooth\"")
+            indexOf("\"smooth\"") shouldBeGreaterThan indexOf("\"value\"")
+            indexOf("\"value\"") shouldBeGreaterThan indexOf("\"id2\"")
+            indexOf("\"id2\"") shouldBeGreaterThan indexOf("\"active\"")
+            indexOf("\"active\"") shouldBeGreaterThan indexOf("\"name\"")
         }
     }
 
@@ -176,10 +174,10 @@ class ObjectsSpecificationTest {
         val result =
             schema.executeBlocking("{many{active, ...Fields , smooth, id}} fragment Fields on ManyFields { id2, value }")
         with(result) {
-            assertThat(indexOf("\"id\""), greaterThan(indexOf("\"smooth\"")))
-            assertThat(indexOf("\"smooth\""), greaterThan(indexOf("\"value\"")))
-            assertThat(indexOf("\"value\""), greaterThan(indexOf("\"id2\"")))
-            assertThat(indexOf("\"id2\""), greaterThan(indexOf("\"active\"")))
+            indexOf("\"id\"") shouldBeGreaterThan indexOf("\"smooth\"")
+            indexOf("\"smooth\"") shouldBeGreaterThan indexOf("\"value\"")
+            indexOf("\"value\"") shouldBeGreaterThan indexOf("\"id2\"")
+            indexOf("\"id2\"") shouldBeGreaterThan indexOf("\"active\"")
         }
     }
 
@@ -196,10 +194,10 @@ class ObjectsSpecificationTest {
                 "fragment Few on FewFields { name } "
         )
         with(result) {
-            assertThat(indexOf("\"id\""), greaterThan(indexOf("\"smooth\"")))
-            assertThat(indexOf("\"smooth\""), greaterThan(indexOf("\"value\"")))
-            assertThat(indexOf("\"value\""), greaterThan(indexOf("\"id2\"")))
-            assertThat(indexOf("\"id2\""), greaterThan(indexOf("\"active\"")))
+            indexOf("\"id\"") shouldBeGreaterThan indexOf("\"smooth\"")
+            indexOf("\"smooth\"") shouldBeGreaterThan indexOf("\"value\"")
+            indexOf("\"value\"") shouldBeGreaterThan indexOf("\"id2\"")
+            indexOf("\"id2\"") shouldBeGreaterThan indexOf("\"active\"")
         }
     }
 
@@ -212,24 +210,24 @@ class ObjectsSpecificationTest {
         val result = schema.executeBlocking("{many{id, id2, value, id, active, smooth}}")
         with(result) {
             //ensure that "id" appears only once
-            assertThat(indexOf("\"id\""), equalTo(lastIndexOf("\"id\"")))
+            indexOf("\"id\"") shouldBe lastIndexOf("\"id\"")
 
-            assertThat(indexOf("\"smooth\""), greaterThan(indexOf("\"active\"")))
-            assertThat(indexOf("\"active\""), greaterThan(indexOf("\"value\"")))
-            assertThat(indexOf("\"value\""), greaterThan(indexOf("\"id2\"")))
-            assertThat(indexOf("\"id2\""), greaterThan(indexOf("\"id\"")))
+            indexOf("\"smooth\"") shouldBeGreaterThan indexOf("\"active\"")
+            indexOf("\"active\"") shouldBeGreaterThan indexOf("\"value\"")
+            indexOf("\"value\"") shouldBeGreaterThan indexOf("\"id2\"")
+            indexOf("\"id2\"") shouldBeGreaterThan indexOf("\"id\"")
         }
 
         val resultFragment =
             schema.executeBlocking("{many{id, id2, ...Many, active, smooth}} fragment Many on ManyFields{value, id}")
         with(resultFragment) {
             //ensure that "id" appears only once
-            assertThat(indexOf("\"id\""), equalTo(lastIndexOf("\"id\"")))
+            indexOf("\"id\"") shouldBe lastIndexOf("\"id\"")
 
-            assertThat(indexOf("\"smooth\""), greaterThan(indexOf("\"active\"")))
-            assertThat(indexOf("\"active\""), greaterThan(indexOf("\"value\"")))
-            assertThat(indexOf("\"value\""), greaterThan(indexOf("\"id2\"")))
-            assertThat(indexOf("\"id2\""), greaterThan(indexOf("\"id\"")))
+            indexOf("\"smooth\"") shouldBeGreaterThan indexOf("\"active\"")
+            indexOf("\"active\"") shouldBeGreaterThan indexOf("\"value\"")
+            indexOf("\"value\"") shouldBeGreaterThan indexOf("\"id2\"")
+            indexOf("\"id2\"") shouldBeGreaterThan indexOf("\"id\"")
         }
     }
 
@@ -276,12 +274,12 @@ class ObjectsSpecificationTest {
 
         val responseShortAfterLong = (schema.executeBlocking("{actor{long, short}}"))
         with(responseShortAfterLong) {
-            assertThat(indexOf("short"), greaterThan(indexOf("long")))
+            indexOf("short") shouldBeGreaterThan indexOf("long")
         }
 
         val responseLongAfterShort = (schema.executeBlocking("{actor{short, long}}"))
         with(responseLongAfterShort) {
-            assertThat(indexOf("long"), greaterThan(indexOf("short")))
+            indexOf("long") shouldBeGreaterThan indexOf("short")
         }
     }
 
@@ -304,7 +302,7 @@ class ObjectsSpecificationTest {
 
         val responseShortAfterLong = schema.executeBlocking("{long, short}")
         with(responseShortAfterLong) {
-            assertThat(indexOf("short"), greaterThan(indexOf("long")))
+            indexOf("short") shouldBeGreaterThan indexOf("long")
         }
     }
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/TypeSystemSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/TypeSystemSpecificationTest.kt
@@ -4,8 +4,8 @@ import com.apurebase.kgraphql.KGraphQL.Companion.schema
 import com.apurebase.kgraphql.Specification
 import com.apurebase.kgraphql.expect
 import com.apurebase.kgraphql.schema.SchemaException
-import org.amshove.kluent.shouldBeEqualTo
-import org.amshove.kluent.shouldContain
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -55,7 +55,7 @@ class TypeSystemSpecificationTest {
         }
 
         val sdl = schema.printSchema()
-        sdl shouldBeEqualTo """
+        sdl shouldBe """
             type Query {
               queryType: Type!
             }
@@ -247,7 +247,7 @@ class TypeSystemSpecificationTest {
         }
 
         val sdl = schema.printSchema()
-        sdl shouldBeEqualTo """
+        sdl shouldBe """
             type ChildType {
               childName: String!
             }
@@ -300,7 +300,7 @@ class TypeSystemSpecificationTest {
         }
 
         val sdl = schema.printSchema()
-        sdl shouldBeEqualTo """
+        sdl shouldBe """
             type Mutation {
               addType(input: TypeInput!): Type!
             }
@@ -346,7 +346,7 @@ class TypeSystemSpecificationTest {
         }
 
         val sdl = schema.printSchema()
-        sdl shouldBeEqualTo """
+        sdl shouldBe """
             type ChildType {
               childName: String!
             }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/UnionsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/UnionsSpecificationTest.kt
@@ -2,7 +2,6 @@ package com.apurebase.kgraphql.specification.typesystem
 
 import com.apurebase.kgraphql.Context
 import com.apurebase.kgraphql.ExecutionException
-import com.apurebase.kgraphql.GraphQLError
 import com.apurebase.kgraphql.KGraphQL
 import com.apurebase.kgraphql.Specification
 import com.apurebase.kgraphql.ValidationException
@@ -14,14 +13,9 @@ import com.apurebase.kgraphql.helpers.getFields
 import com.apurebase.kgraphql.integration.BaseSchemaTest
 import com.apurebase.kgraphql.schema.SchemaException
 import com.apurebase.kgraphql.schema.execution.Execution
-import org.amshove.kluent.invoking
-import org.amshove.kluent.shouldBeEqualTo
-import org.amshove.kluent.shouldThrow
-import org.amshove.kluent.with
-import org.hamcrest.CoreMatchers
-import org.hamcrest.MatcherAssert
+import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 
 @Specification("3.1.4 Unions")
 class UnionsSpecificationTest : BaseSchemaTest() {
@@ -36,16 +30,9 @@ class UnionsSpecificationTest : BaseSchemaTest() {
             val name = map.extract<String>("data/actors[$i]/name")
             val favourite = map.extract<Map<String, String>>("data/actors[$i]/favourite")
             when (name) {
-                "Brad Pitt" -> MatcherAssert.assertThat(favourite, CoreMatchers.equalTo(mapOf("name" to "Tom Hardy")))
-                "Tom Hardy" -> MatcherAssert.assertThat(
-                    favourite,
-                    CoreMatchers.equalTo(mapOf("age" to 43, "name" to "Christopher Nolan"))
-                )
-
-                "Morgan Freeman" -> MatcherAssert.assertThat(
-                    favourite,
-                    CoreMatchers.equalTo(mapOf("content" to "DUMB"))
-                )
+                "Brad Pitt" -> favourite shouldBe mapOf("name" to "Tom Hardy")
+                "Tom Hardy" -> favourite shouldBe mapOf("age" to 43, "name" to "Christopher Nolan")
+                "Morgan Freeman" -> favourite shouldBe mapOf("content" to "DUMB")
             }
         }
     }
@@ -62,26 +49,17 @@ class UnionsSpecificationTest : BaseSchemaTest() {
             val name = map.extract<String>("data/actors[$i]/name")
             val favourite = map.extract<Map<String, String>>("data/actors[$i]/favourite")
             when (name) {
-                "Brad Pitt" -> MatcherAssert.assertThat(favourite, CoreMatchers.equalTo(mapOf("name" to "Tom Hardy")))
-                "Tom Hardy" -> MatcherAssert.assertThat(
-                    favourite,
-                    CoreMatchers.equalTo(mapOf("age" to 43, "name" to "Christopher Nolan"))
-                )
-
-                "Morgan Freeman" -> MatcherAssert.assertThat(
-                    favourite,
-                    CoreMatchers.equalTo(mapOf("content" to "DUMB"))
-                )
+                "Brad Pitt" -> favourite shouldBe mapOf("name" to "Tom Hardy")
+                "Tom Hardy" -> favourite shouldBe mapOf("age" to 43, "name" to "Christopher Nolan")
+                "Morgan Freeman" -> favourite shouldBe mapOf("content" to "DUMB")
             }
         }
     }
 
     @Test
     fun `query union property with invalid selection set`() {
-        invoking {
+        expect<ValidationException>("Invalid selection set with properties: [name] on union type property favourite : [Actor, Scenario, Director]") {
             execute("{actors{name, favourite{ name }}}")
-        } shouldThrow GraphQLError::class with {
-            message shouldBeEqualTo "Invalid selection set with properties: [name] on union type property favourite : [Actor, Scenario, Director]"
         }
     }
 
@@ -100,46 +78,16 @@ class UnionsSpecificationTest : BaseSchemaTest() {
                 }
             }""".trimIndent()
         )
-        MatcherAssert.assertThat(
-            result.extract<String>("data/actors[0]/name/"),
-            CoreMatchers.equalTo("Brad Pitt")
-        )
-        MatcherAssert.assertThat(
-            result.extract<String>("data/actors[0]/favourite/__typename"),
-            CoreMatchers.equalTo("Actor")
-        )
-        MatcherAssert.assertThat(
-            result.extract<String>("data/actors[1]/name/"),
-            CoreMatchers.equalTo("Morgan Freeman")
-        )
-        MatcherAssert.assertThat(
-            result.extract<String>("data/actors[1]/favourite/__typename"),
-            CoreMatchers.equalTo("Scenario")
-        )
-        MatcherAssert.assertThat(
-            result.extract<String>("data/actors[2]/name/"),
-            CoreMatchers.equalTo("Kevin Spacey")
-        )
-        MatcherAssert.assertThat(
-            result.extract<String>("data/actors[2]/favourite/__typename"),
-            CoreMatchers.equalTo("Actor")
-        )
-        MatcherAssert.assertThat(
-            result.extract<String>("data/actors[3]/name/"),
-            CoreMatchers.equalTo("Tom Hardy")
-        )
-        MatcherAssert.assertThat(
-            result.extract<String>("data/actors[3]/favourite/__typename"),
-            CoreMatchers.equalTo("Director")
-        )
-        MatcherAssert.assertThat(
-            result.extract<String>("data/actors[4]/name/"),
-            CoreMatchers.equalTo("Christian Bale")
-        )
-        MatcherAssert.assertThat(
-            result.extract<String>("data/actors[4]/favourite/__typename"),
-            CoreMatchers.equalTo("Actor")
-        )
+        result.extract<String>("data/actors[0]/name/") shouldBe "Brad Pitt"
+        result.extract<String>("data/actors[0]/favourite/__typename") shouldBe "Actor"
+        result.extract<String>("data/actors[1]/name/") shouldBe "Morgan Freeman"
+        result.extract<String>("data/actors[1]/favourite/__typename") shouldBe "Scenario"
+        result.extract<String>("data/actors[2]/name/") shouldBe "Kevin Spacey"
+        result.extract<String>("data/actors[2]/favourite/__typename") shouldBe "Actor"
+        result.extract<String>("data/actors[3]/name/") shouldBe "Tom Hardy"
+        result.extract<String>("data/actors[3]/favourite/__typename") shouldBe "Director"
+        result.extract<String>("data/actors[4]/name/") shouldBe "Christian Bale"
+        result.extract<String>("data/actors[4]/favourite/__typename") shouldBe "Actor"
     }
 
     @Test
@@ -154,31 +102,16 @@ class UnionsSpecificationTest : BaseSchemaTest() {
                 }
             }""".trimIndent()
         )
-        MatcherAssert.assertThat(
-            result.extract<String>("data/actors[0]/favourite/__typename"),
-            CoreMatchers.equalTo("Actor")
-        )
-        MatcherAssert.assertThat(
-            result.extract<String>("data/actors[1]/favourite/__typename"),
-            CoreMatchers.equalTo("Scenario")
-        )
-        MatcherAssert.assertThat(
-            result.extract<String>("data/actors[2]/favourite/__typename"),
-            CoreMatchers.equalTo("Actor")
-        )
-        MatcherAssert.assertThat(
-            result.extract<String>("data/actors[3]/favourite/__typename"),
-            CoreMatchers.equalTo("Director")
-        )
-        MatcherAssert.assertThat(
-            result.extract<String>("data/actors[4]/favourite/__typename"),
-            CoreMatchers.equalTo("Actor")
-        )
+        result.extract<String>("data/actors[0]/favourite/__typename") shouldBe "Actor"
+        result.extract<String>("data/actors[1]/favourite/__typename") shouldBe "Scenario"
+        result.extract<String>("data/actors[2]/favourite/__typename") shouldBe "Actor"
+        result.extract<String>("data/actors[3]/favourite/__typename") shouldBe "Director"
+        result.extract<String>("data/actors[4]/favourite/__typename") shouldBe "Actor"
     }
 
     @Test
     fun `a union type should require a selection for all potential types`() {
-        invoking {
+        expect<ValidationException>("Missing selection set for type Scenario") {
             execute(
                 """{
                 actors {
@@ -190,8 +123,6 @@ class UnionsSpecificationTest : BaseSchemaTest() {
                 }
             }""".trimIndent()
             )
-        } shouldThrow ValidationException::class with {
-            message shouldBeEqualTo "Missing selection set for type Scenario"
         }
     }
 
@@ -210,27 +141,15 @@ class UnionsSpecificationTest : BaseSchemaTest() {
             }""".trimIndent()
         )
 
-        MatcherAssert.assertThat(
-            result.extract<String>("data/actors[5]/name"),
-            CoreMatchers.equalTo(rickyGervais.name)
-        )
-        MatcherAssert.assertThat(
-            result.extract("data/actors[5]/nullableFavourite"),
-            CoreMatchers.equalTo(null)
-        )
-        MatcherAssert.assertThat(
-            result.extract<String>("data/actors[3]/name"),
-            CoreMatchers.equalTo(tomHardy.name)
-        )
-        MatcherAssert.assertThat(
-            result.extract<String>("data/actors[3]/nullableFavourite/name"),
-            CoreMatchers.equalTo(christopherNolan.name)
-        )
+        result.extract<String>("data/actors[5]/name") shouldBe rickyGervais.name
+        result.extract<Any?>("data/actors[5]/nullableFavourite") shouldBe null
+        result.extract<String>("data/actors[3]/name") shouldBe tomHardy.name
+        result.extract<String>("data/actors[3]/nullableFavourite/name") shouldBe christopherNolan.name
     }
 
     @Test
     fun `Non nullable union types should fail`() {
-        invoking {
+        expect<ExecutionException>("Unexpected type of union property value, expected one of [Actor, Scenario, Director] but was null") {
             execute(
                 """{
                     actors(all: true) {
@@ -243,8 +162,6 @@ class UnionsSpecificationTest : BaseSchemaTest() {
                     }
                 }""".trimIndent()
             )
-        } shouldThrow ExecutionException::class with {
-            message shouldBeEqualTo "Unexpected type of union property value, expected one of [Actor, Scenario, Director] but was null"
         }
     }
 
@@ -325,20 +242,20 @@ class UnionsSpecificationTest : BaseSchemaTest() {
         }
             .executeBlocking(
                 """
-            {
-                f: returnUnion(isB: false) {
-                    ... on BBB { i }
-                    ... on CCC { s }
+                {
+                    f: returnUnion(isB: false) {
+                        ... on BBB { i }
+                        ... on CCC { s }
+                    }
+                    t: returnUnion(isB: true) {
+                        ... on BBB { i }
+                        ... on CCC { s }                
+                    }
                 }
-                t: returnUnion(isB: true) {
-                    ... on BBB { i }
-                    ... on CCC { s }                
-                }
-            }
-        """.trimIndent()
+                """.trimIndent()
             ).deserialize().run {
-                extract<String>("data/f/s") shouldBeEqualTo "String"
-                extract<Int>("data/t/i") shouldBeEqualTo 1
+                extract<String>("data/f/s") shouldBe "String"
+                extract<Int>("data/t/i") shouldBe 1
             }
     }
 
@@ -368,9 +285,9 @@ class UnionsSpecificationTest : BaseSchemaTest() {
             }
         """.trimIndent()
         ).deserialize().run {
-            extract<Int>("data/returnUnion/i") shouldBeEqualTo 1
-            assertThrows<IllegalArgumentException> { extract("data/returnUnion/s") }
-            extract<List<String>>("data/returnUnion/fields") shouldBeEqualTo listOf("i", "fields", "s")
+            extract<Int>("data/returnUnion/i") shouldBe 1
+            shouldThrowExactly<IllegalArgumentException> { extract("data/returnUnion/s") }
+            extract<List<String>>("data/returnUnion/fields") shouldBe listOf("i", "fields", "s")
         }
     }
 
@@ -400,8 +317,8 @@ class UnionsSpecificationTest : BaseSchemaTest() {
             }
         """.trimIndent()
         ).deserialize().run {
-            extract<String>("data/returnUnion[0]/__typename") shouldBeEqualTo "PrefixValue1"
-            extract<String>("data/returnUnion[1]/__typename") shouldBeEqualTo "PrefixValue2"
+            extract<String>("data/returnUnion[0]/__typename") shouldBe "PrefixValue1"
+            extract<String>("data/returnUnion[1]/__typename") shouldBe "PrefixValue2"
         }
     }
 }

--- a/kgraphql/src/testFixtures/kotlin/com/apurebase/kgraphql/CommonTestUtils.kt
+++ b/kgraphql/src/testFixtures/kotlin/com/apurebase/kgraphql/CommonTestUtils.kt
@@ -1,0 +1,13 @@
+package com.apurebase.kgraphql
+
+import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.throwable.shouldHaveMessage
+import io.kotest.matchers.types.instanceOf
+import kotlin.reflect.KClass
+
+infix fun Any?.shouldBeInstanceOf(clazz: KClass<*>) = this shouldBe instanceOf(clazz)
+
+inline fun <reified T : Exception> expect(message: String, block: () -> Unit) {
+    shouldThrowExactly<T>(block) shouldHaveMessage message
+}


### PR DESCRIPTION
Consolidates test frameworks to reduce the amount of dependencies, and get rid of archived or unmaintained libraries.

Resolves #6