### PR TITLE
fix: fix coercion for Long and Short

### DIFF
--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/helpers/KGraphQLExtensions.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/helpers/KGraphQLExtensions.kt
@@ -1,6 +1,7 @@
 package com.apurebase.kgraphql.helpers
 
 import com.apurebase.kgraphql.schema.builtin.BuiltInScalars
+import com.apurebase.kgraphql.schema.builtin.ExtendedBuiltInScalars
 import com.apurebase.kgraphql.schema.execution.Execution
 import com.apurebase.kgraphql.schema.introspection.TypeKind
 import com.apurebase.kgraphql.schema.introspection.__Type
@@ -130,4 +131,6 @@ fun JsonNode?.toValueNode(expectedType: __Type): ValueNode = when (this) {
     else -> error("Unexpected value: $this")
 }
 
-private fun __Type.isInt() = unwrapped().name == BuiltInScalars.INT.typeDef.name
+// A list of types that are "int", i.e. do not accept floating point values
+private fun __Type.isInt() =
+    unwrapped().name == BuiltInScalars.INT.typeDef.name || unwrapped().name == ExtendedBuiltInScalars.LONG.typeDef.name || unwrapped().name == ExtendedBuiltInScalars.SHORT.typeDef.name

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/builtin/BuiltInScalars.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/builtin/BuiltInScalars.kt
@@ -142,7 +142,7 @@ object LONG_COERCION : StringScalarCoercion<Long> {
     override fun deserialize(raw: String, valueNode: ValueNode) = when (valueNode) {
         is NumberValueNode -> valueNode.value
         else -> throw InvalidInputValueException(
-            "Cannot coerce ${valueNode.valueNodeName} to expected numeric constant",
+            "Cannot coerce ${valueNode.valueNodeName} to numeric constant",
             valueNode
         )
     }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/BaseSchemaTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/BaseSchemaTest.kt
@@ -44,6 +44,8 @@ abstract class BaseSchemaTest {
             useDefaultPrettyPrinter = true
         }
 
+        extendedScalars()
+
         query("number") {
             description = "returns little of big number"
             resolver { big: Boolean -> if (big) 10000 else 0 }
@@ -90,6 +92,28 @@ abstract class BaseSchemaTest {
             description = "ranked films"
             resolver { rank: Int ->
                 when (rank) {
+                    1 -> prestige
+                    2 -> se7en
+                    3 -> theBigShave
+                    else -> null
+                }
+            }
+        }
+        query("filmByRankLong") {
+            description = "ranked films"
+            resolver { rank: Long ->
+                when (rank) {
+                    1L -> prestige
+                    2L -> se7en
+                    3L -> theBigShave
+                    else -> null
+                }
+            }
+        }
+        query("filmByRankShort") {
+            description = "ranked films"
+            resolver { rank: Short ->
+                when (rank.toInt()) {
                     1 -> prestige
                     2 -> se7en
                     3 -> theBigShave

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/VariablesSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/VariablesSpecificationTest.kt
@@ -47,6 +47,40 @@ class VariablesSpecificationTest : BaseSchemaTest() {
         }
     }
 
+    // Json only has one number type, so "1" and "1.0" are the same, and input coercion should be able to handle
+    // the value accordingly
+    @Test
+    fun `query with long variable should allow whole floating point numbers`() {
+        val map =
+            execute(query = "query(\$rank: Long!) {filmByRankLong(rank: \$rank) {title}}", variables = "{\"rank\": 1.0}")
+        assertNoErrors(map)
+        map.extract<String>("data/filmByRankLong/title") shouldBe "Prestige"
+    }
+
+    @Test
+    fun `query with long variable should not allow floating point numbers that are not whole`() {
+        expect<InvalidInputValueException>("Cannot coerce 1.01 to numeric constant") {
+            execute(query = "query(\$rank: Long!) {filmByRankLong(rank: \$rank) {title}}", variables = "{\"rank\": 1.01}")
+        }
+    }
+
+    // Json only has one number type, so "1" and "1.0" are the same, and input coercion should be able to handle
+    // the value accordingly
+    @Test
+    fun `query with short variable should allow whole floating point numbers`() {
+        val map =
+            execute(query = "query(\$rank: Short!) {filmByRankShort(rank: \$rank) {title}}", variables = "{\"rank\": 1.0}")
+        assertNoErrors(map)
+        map.extract<String>("data/filmByRankShort/title") shouldBe "Prestige"
+    }
+
+    @Test
+    fun `query with short variable should not allow floating point numbers that are not whole`() {
+        expect<InvalidInputValueException>("Cannot coerce 1.01 to numeric constant") {
+            execute(query = "query(\$rank: Short!) {filmByRankShort(rank: \$rank) {title}}", variables = "{\"rank\": 1.01}")
+        }
+    }
+
     @Test
     fun `query with float variable`() {
         val map = execute(query = "query(\$float: Float!) {float(float: \$float)}", variables = "{\"float\": 42.3}")


### PR DESCRIPTION
#247 refactored variable handling and only implemented proper parsing for `Int` but not for `Long` and `Short`.