### PR TITLE
fix: explicit error handling for variable deserialization

### DIFF
--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/helpers/KGraphQLExtensions.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/helpers/KGraphQLExtensions.kt
@@ -1,5 +1,6 @@
 package com.apurebase.kgraphql.helpers
 
+import com.apurebase.kgraphql.InvalidInputValueException
 import com.apurebase.kgraphql.schema.builtin.BuiltInScalars
 import com.apurebase.kgraphql.schema.builtin.ExtendedBuiltInScalars
 import com.apurebase.kgraphql.schema.execution.Execution
@@ -117,7 +118,11 @@ fun JsonNode?.toValueNode(expectedType: __Type): ValueNode = when (this) {
             val inputFields = checkNotNull(expectedType.unwrapped().inputFields) {
                 "Expected INPUT_OBJECT for ${expectedType.unwrapped().name} but got ${expectedType.kind}"
             }
-            val expectedPropType = inputFields.first { it.name == prop.key }.type
+            val expectedPropType = inputFields.firstOrNull { it.name == prop.key }?.type
+                ?: throw InvalidInputValueException(
+                    "Property '${prop.key}' on '${expectedType.unwrapped().name}' does not exist",
+                    null
+                )
             ValueNode.ObjectValueNode.ObjectFieldNode(
                 null,
                 NameNode(prop.key, null),

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/QueryTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/QueryTest.kt
@@ -182,7 +182,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `query with nulabble generic input type`() {
+    fun `query with nullable generic input type`() {
         val map = execute("{actorsByTagsNullable{name}}")
         assertNoErrors(map)
     }
@@ -374,7 +374,7 @@ class QueryTest : BaseSchemaTest() {
                         }
                     }
                 }
-            """.trimIndent()
+                """.trimIndent()
             )
         }
         exception shouldHaveMessage "Unknown type MissingType in type condition on fragment"
@@ -393,8 +393,7 @@ class QueryTest : BaseSchemaTest() {
                         ...film_title
                     }
                 }
-                
-            """.trimIndent()
+                """.trimIndent()
             )
         }
         exception shouldHaveMessage "Fragment film_title not found"
@@ -426,8 +425,8 @@ class QueryTest : BaseSchemaTest() {
                 }
             }
             type<SampleNode> {
-                property<List<SampleNode>>("children") {
-                    resolver { parent, amount: Int, node: Execution.Node ->
+                property("children") {
+                    resolver { _, amount: Int, node: Execution.Node ->
                         (1..amount).map {
                             SampleNode(it, "${node.aliasOrKey}-Testing", fields = node.getFields())
                         }
@@ -450,7 +449,7 @@ class QueryTest : BaseSchemaTest() {
                 id
                 name
             }
-        """.trimIndent()
+            """.trimIndent()
         ).deserialize()
 
         result.extract<List<String>>("data/root/fields") shouldBe listOf("fields")


### PR DESCRIPTION
With #247, non-existing properties of input objects are reported as error, but more as a side-effect of no longer using Jackson. This adds explicit error handling for such cases.