### PR TITLE
refactor!: remove deprecated GraphQLError properties

### DIFF
--- a/kgraphql-ktor-stitched/src/main/kotlin/com/apurebase/kgraphql/stitched/RemoteExecutionError.kt
+++ b/kgraphql-ktor-stitched/src/main/kotlin/com/apurebase/kgraphql/stitched/RemoteExecutionError.kt
@@ -10,7 +10,9 @@ import com.apurebase.kgraphql.schema.execution.Execution
 class RemoteExecutionException(message: String, node: Execution.Remote) : GraphQLError(
     message = message,
     nodes = listOf(node.selectionNode),
-    extensionsErrorType = BuiltInErrorCodes.INTERNAL_SERVER_ERROR.name,
-    extensionsErrorDetail = mapOf("remoteUrl" to node.remoteUrl, "remoteOperation" to node.remoteOperation)
+    extensions = mapOf(
+        "type" to BuiltInErrorCodes.INTERNAL_SERVER_ERROR.name,
+        "detail" to mapOf("remoteUrl" to node.remoteUrl, "remoteOperation" to node.remoteOperation)
+    )
 )
 

--- a/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/execution/StitchedSchemaExecutionTest.kt
+++ b/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/execution/StitchedSchemaExecutionTest.kt
@@ -2895,8 +2895,10 @@ class StitchedSchemaExecutionTest {
                         resolver<String> {
                             throw GraphQLError(
                                 message = "don't call me local!",
-                                extensionsErrorType = BuiltInErrorCodes.INTERNAL_SERVER_ERROR.name,
-                                extensionsErrorDetail = mapOf("localErrorKey" to "localErrorValue")
+                                extensions = mapOf(
+                                    "type" to BuiltInErrorCodes.INTERNAL_SERVER_ERROR.name,
+                                    "detail" to mapOf("localErrorKey" to "localErrorValue")
+                                )
                             )
                         }
                     }
@@ -2930,14 +2932,14 @@ class StitchedSchemaExecutionTest {
             header(HttpHeaders.ContentType, ContentType.Application.Json)
             setBody(graphqlRequest("{ failRemote }"))
         }.bodyAsText() shouldBe """
-            {"errors":[{"message":"don't call me remote!","locations":[{"line":1,"column":3}],"path":[],"extensions":{"type":"BAD_USER_INPUT","remoteUrl":"remote","remoteOperation":"failRemote","remoteErrorKey":["remoteErrorValue1","remoteErrorValue2"]}}]}
+            {"errors":[{"message":"don't call me remote!","locations":[{"line":1,"column":3}],"path":[],"extensions":{"remoteUrl":"remote","remoteOperation":"failRemote","type":"BAD_USER_INPUT","remoteErrorKey":["remoteErrorValue1","remoteErrorValue2"]}}]}
         """.trimIndent()
 
         client.post("local") {
             header(HttpHeaders.ContentType, ContentType.Application.Json)
             setBody(graphqlRequest("{ failRemote2 }"))
         }.bodyAsText() shouldBe """
-            {"errors":[{"message":"Error(s) during remote execution","locations":[{"line":1,"column":3}],"path":[],"extensions":{"type":"INTERNAL_SERVER_ERROR","remoteUrl":"remote","remoteOperation":"failRemote2"}}]}
+            {"errors":[{"message":"Error(s) during remote execution","locations":[{"line":1,"column":3}],"path":[],"extensions":{"remoteUrl":"remote","remoteOperation":"failRemote2","type":"INTERNAL_SERVER_ERROR"}}]}
         """.trimIndent()
     }
 

--- a/kgraphql/api/kgraphql.api
+++ b/kgraphql/api/kgraphql.api
@@ -42,11 +42,9 @@ public final class com/apurebase/kgraphql/ExtensionsKt {
 }
 
 public class com/apurebase/kgraphql/GraphQLError : java/lang/Exception {
-	public fun <init> (Ljava/lang/String;Ljava/util/List;Lcom/apurebase/kgraphql/schema/model/ast/Source;Ljava/util/List;Ljava/lang/Throwable;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lcom/apurebase/kgraphql/schema/model/ast/Source;Ljava/util/List;Ljava/lang/Throwable;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Lcom/apurebase/kgraphql/schema/model/ast/Source;Ljava/util/List;Ljava/lang/Throwable;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lcom/apurebase/kgraphql/schema/model/ast/Source;Ljava/util/List;Ljava/lang/Throwable;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getExtensions ()Ljava/util/Map;
-	public final fun getExtensionsErrorDetail ()Ljava/util/Map;
-	public final fun getExtensionsErrorType ()Ljava/lang/String;
 	public final fun getLocations ()Ljava/util/List;
 	public final fun getNodes ()Ljava/util/List;
 	public final fun getOriginalError ()Ljava/lang/Throwable;

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/GraphQLError.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/GraphQLError.kt
@@ -45,24 +45,9 @@ open class GraphQLError(
     val originalError: Throwable? = null,
 
     /**
-     * The type of the error, based on Apollo Server's built-in error codes:
-     *   https://www.apollographql.com/docs/apollo-server/data/errors#built-in-error-codes
-     *
-     * For supported built-in codes see [BuiltInErrorCodes].
-     */
-    @Deprecated(message = "Use extensions with key 'type'")
-    val extensionsErrorType: String = BuiltInErrorCodes.INTERNAL_SERVER_ERROR.name,
-
-    /**
-     * Details regarding this error.
-     */
-    @Deprecated(message = "Use extensions with key 'detail'")
-    val extensionsErrorDetail: Map<String, Any?>? = null,
-
-    /**
      * Custom error extensions.
      */
-    open val extensions: Map<String, Any?>? = null
+    open val extensions: Map<String, Any?>? = mapOf("type" to BuiltInErrorCodes.INTERNAL_SERVER_ERROR.name)
 ) : Exception(message) {
 
     /**
@@ -116,13 +101,9 @@ open class GraphQLError(
                 put("path", buildJsonArray {
                     // TODO: Build this path. https://spec.graphql.org/June2018/#example-90475
                 })
-                val legacyExtensions = mutableMapOf<String, Any?>().apply {
-                    put("type", extensionsErrorType)
-                    extensionsErrorDetail?.let { detail ->
-                        put("detail", detail)
-                    }
+                extensions?.let {
+                    put("extensions", it.toJsonElement())
                 }
-                put("extensions", (legacyExtensions + extensions.orEmpty()).toJsonElement())
             }
         })
     }.toString()

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/GraphQLErrorTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/GraphQLErrorTest.kt
@@ -11,10 +11,9 @@ import org.junit.jupiter.api.Test
 class GraphQLErrorTest {
 
     @Test
-    fun `test graphql error with custom error type`() {
+    fun `graphql error should default to INTERNAL_SERVER_ERROR type`() {
         val graphqlError = GraphQLError(
-            message = "test",
-            extensionsErrorType = "AUTHORIZATION_ERROR"
+            message = "test"
         )
 
         val expectedJson = buildJsonObject {
@@ -24,7 +23,7 @@ class GraphQLErrorTest {
                     put("locations", buildJsonArray {})
                     put("path", buildJsonArray {})
                     put("extensions", buildJsonObject {
-                        put("type", "AUTHORIZATION_ERROR")
+                        put("type", "INTERNAL_SERVER_ERROR")
                     })
                 }
             })
@@ -34,41 +33,7 @@ class GraphQLErrorTest {
     }
 
     @Test
-    fun `test graphql error with custom error type and detail`() {
-        val graphqlError = GraphQLError(
-            message = "test",
-            extensionsErrorType = "VALIDATION_ERROR",
-            extensionsErrorDetail = mapOf<String, Any?>(
-                "singleCheck" to mapOf("email" to "not an email", "age" to "Limited to 150"),
-                "multiCheck" to "The 'from' number must not exceed the 'to' number"
-            )
-        )
-
-        val expectedJson = buildJsonObject {
-            put("errors", buildJsonArray {
-                addJsonObject {
-                    put("message", "test")
-                    put("locations", buildJsonArray {})
-                    put("path", buildJsonArray {})
-                    put("extensions", buildJsonObject {
-                        put("type", "VALIDATION_ERROR")
-                        put("detail", buildJsonObject {
-                            put("singleCheck", buildJsonObject {
-                                put("email", "not an email")
-                                put("age", "Limited to 150")
-                            })
-                            put("multiCheck", "The 'from' number must not exceed the 'to' number")
-                        })
-                    })
-                }
-            })
-        }.toString()
-
-        graphqlError.serialize() shouldBe expectedJson
-    }
-
-    @Test
-    fun `test graphql error with custom extensions, type and detail`() {
+    fun `test graphql error with custom extensions`() {
         val graphqlError = GraphQLError(
             message = "test",
             extensions = mapOf(
@@ -78,10 +43,6 @@ class GraphQLErrorTest {
                     "singleCheck" to mapOf("email" to "not an email", "age" to "Limited to 150"),
                     "multiCheck" to "The 'from' number must not exceed the 'to' number"
                 )
-            ),
-            extensionsErrorType = "this is overwritten by extensions[type]",
-            extensionsErrorDetail = mapOf<String, Any?>(
-                "ignoredCheck" to "this is overwritten by extensions[detail]"
             )
         )
 
@@ -93,17 +54,17 @@ class GraphQLErrorTest {
                     put("path", buildJsonArray {})
                     put("extensions", buildJsonObject {
                         put("type", "VALIDATION_ERROR")
+                        put("listProperty", buildJsonArray {
+                            add("value1")
+                            add("value2")
+                            add(3)
+                        })
                         put("detail", buildJsonObject {
                             put("singleCheck", buildJsonObject {
                                 put("email", "not an email")
                                 put("age", "Limited to 150")
                             })
                             put("multiCheck", "The 'from' number must not exceed the 'to' number")
-                        })
-                        put("listProperty", buildJsonArray {
-                            add("value1")
-                            add("value2")
-                            add(3)
                         })
                     })
                 }


### PR DESCRIPTION
Removes the deprecated `extensionsErrorType` and `extensionsErrorDetail` from `GraphQLError`.

BREAKING CHANGE: error type and detail must now be provided as `Map` via `extensions` property