### PR TITLE
fix!: prevent duplicate object fields

### DIFF
--- a/kgraphql-ktor-stitched/src/main/kotlin/com/apurebase/kgraphql/stitched/schema/dsl/StitchedSchemaBuilder.kt
+++ b/kgraphql-ktor-stitched/src/main/kotlin/com/apurebase/kgraphql/stitched/schema/dsl/StitchedSchemaBuilder.kt
@@ -52,14 +52,14 @@ class StitchedSchemaBuilder {
 
     private fun mergeSchemaDefinitions(local: SchemaDefinition, stitched: StitchedSchemaDefinition) =
         StitchedSchemaDefinition(
-            objects = local.objects + stitched.objects,
+            objects = (local.objects + stitched.objects).distinctBy { it.kClass },
             queries = local.queries + stitched.queries,
-            scalars = local.scalars + stitched.scalars,
+            scalars = (local.scalars + stitched.scalars).distinctBy { it.kClass },
             mutations = local.mutations + stitched.mutations,
             subscriptions = local.subscriptions + stitched.subscriptions,
-            enums = local.enums + stitched.enums,
+            enums = (local.enums + stitched.enums).distinctBy { it.kClass },
             unions = local.unions + stitched.unions,
-            directives = local.directives + stitched.directives,
+            directives = (local.directives + stitched.directives).distinct(),
             inputObjects = local.inputObjects + stitched.inputObjects,
             remoteSchemas = stitched.remoteSchemas,
             stitchedProperties = stitched.stitchedProperties

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaBuilderTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaBuilderTest.kt
@@ -805,13 +805,6 @@ class SchemaBuilderTest {
         schema.typeByKClass(InputOne::class) shouldNotBe null
     }
 
-    private inline fun <T : Any, reified P : Any> TypeDSL<T>.createGenericPropertyExplicitly(returnType: KType, x: P) {
-        property("data") {
-            resolver { _ -> x }
-            setReturnType(returnType)
-        }
-    }
-
     data class Prop<T>(val resultType: KType, val resolver: () -> T)
 
     @Test
@@ -825,8 +818,11 @@ class SchemaBuilderTest {
                 resolver { -> "dummy" }
             }
             type<Scenario> {
-                props.forEach { prop ->
-                    createGenericPropertyExplicitly(prop.resultType, prop.resolver())
+                props.forEachIndexed { index, prop ->
+                    property("data_$index") {
+                        resolver { _ -> prop.resolver }
+                        setReturnType(prop.resultType)
+                    }
                 }
             }
         }


### PR DESCRIPTION
Ensures that all fields of an Object type have unique names.

Resolves #243

BREAKING CHANGE: Schema compilation that previously succeeded may now fail if the schema contains types with duplicate fields.