### PR TITLE
refactor: minor cleanup

### DIFF
--- a/buildSrc/src/main/kotlin/library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/library-conventions.gradle.kts
@@ -1,4 +1,3 @@
-import com.vanniktech.maven.publish.SonatypeHost
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
 plugins {
@@ -26,7 +25,7 @@ dokka {
 }
 
 mavenPublishing {
-    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+    publishToMavenCentral()
     signAllPublications()
     pom {
         name.set("KGraphQL")

--- a/kgraphql-ktor/src/test/kotlin/com/apurebase/kgraphql/KtorMultipleEndpointsTest.kt
+++ b/kgraphql-ktor/src/test/kotlin/com/apurebase/kgraphql/KtorMultipleEndpointsTest.kt
@@ -11,7 +11,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.server.testing.testApplication
 import org.junit.jupiter.api.Test
 
-class KtorMultipleEndpoints : KtorTest() {
+class KtorMultipleEndpointsTest : KtorTest() {
 
     @Test
     fun `basic multiple endpoints test`() = testApplication {


### PR DESCRIPTION
- Rename `KtorMultipleEndpoints` to `KtorMultipleEndpointsTest` for proper test class suffix
- Resolve `'SonatypeHost' is deprecated` warning (cf. https://central.sonatype.org/news/20250326_ossrh_sunset/)