### PR TITLE
feat: property transformation to different type

### DIFF
--- a/kgraphql-ktor/src/test/kotlin/com/apurebase/kgraphql/KtorFeatureTest.kt
+++ b/kgraphql-ktor/src/test/kotlin/com/apurebase/kgraphql/KtorFeatureTest.kt
@@ -76,7 +76,11 @@ class KtorFeatureTest : KtorTest() {
                 }
 
                 transformation(Actor::name) { name: String, addStuff: Boolean?, ctx: Context ->
-                    if (addStuff == true) name + ctx[UserData::class]?.stuff else name
+                    if (addStuff == true) {
+                        name + ctx[UserData::class]?.stuff
+                    } else {
+                        name
+                    }
                 }
             }
         }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/types/TypeDSL.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/types/TypeDSL.kt
@@ -32,43 +32,43 @@ open class TypeDSL<T : Any>(
 
     val dataloadedExtensionProperties = mutableSetOf<PropertyDef.DataLoadedFunction<T, *, *>>()
 
-    fun <R, E> transformation(kProperty: KProperty1<T, R>, function: suspend (R, E) -> R) {
+    fun <R1, R2, E> transformation(kProperty: KProperty1<T, R1>, function: suspend (R1, E) -> R2) {
         transformationProperties.add(Transformation(kProperty, FunctionWrapper.on(function, true)))
     }
 
-    fun <R, E, W> transformation(kProperty: KProperty1<T, R>, function: suspend (R, E, W) -> R) {
+    fun <R1, R2, E, W> transformation(kProperty: KProperty1<T, R1>, function: suspend (R1, E, W) -> R2) {
         transformationProperties.add(Transformation(kProperty, FunctionWrapper.on(function, true)))
     }
 
-    fun <R, E, W, Q> transformation(kProperty: KProperty1<T, R>, function: suspend (R, E, W, Q) -> R) {
+    fun <R1, R2, E, W, Q> transformation(kProperty: KProperty1<T, R1>, function: suspend (R1, E, W, Q) -> R2) {
         transformationProperties.add(Transformation(kProperty, FunctionWrapper.on(function, true)))
     }
 
-    fun <R, E, W, Q, A> transformation(kProperty: KProperty1<T, R>, function: suspend (R, E, W, Q, A) -> R) {
+    fun <R1, R2, E, W, Q, A> transformation(kProperty: KProperty1<T, R1>, function: suspend (R1, E, W, Q, A) -> R2) {
         transformationProperties.add(Transformation(kProperty, FunctionWrapper.on(function, true)))
     }
 
-    fun <R, E, W, Q, A, S> transformation(kProperty: KProperty1<T, R>, function: suspend (R, E, W, Q, A, S) -> R) {
+    fun <R1, R2, E, W, Q, A, S> transformation(kProperty: KProperty1<T, R1>, function: suspend (R1, E, W, Q, A, S) -> R2) {
         transformationProperties.add(Transformation(kProperty, FunctionWrapper.on(function, true)))
     }
 
-    fun <R, E, W, Q, A, S, B> transformation(
-        kProperty: KProperty1<T, R>,
-        function: suspend (R, E, W, Q, A, S, B) -> R
+    fun <R1, R2, E, W, Q, A, S, B> transformation(
+        kProperty: KProperty1<T, R1>,
+        function: suspend (R1, E, W, Q, A, S, B) -> R2
     ) {
         transformationProperties.add(Transformation(kProperty, FunctionWrapper.on(function, true)))
     }
 
-    fun <R, E, W, Q, A, S, B, U> transformation(
-        kProperty: KProperty1<T, R>,
-        function: suspend (R, E, W, Q, A, S, B, U) -> R
+    fun <R1, R2, E, W, Q, A, S, B, U> transformation(
+        kProperty: KProperty1<T, R1>,
+        function: suspend (R1, E, W, Q, A, S, B, U) -> R2
     ) {
         transformationProperties.add(Transformation(kProperty, FunctionWrapper.on(function, true)))
     }
 
-    fun <R, E, W, Q, A, S, B, U, C> transformation(
-        kProperty: KProperty1<T, R>,
-        function: suspend (R, E, W, Q, A, S, B, U, C) -> R
+    fun <R1, R2, E, W, Q, A, S, B, U, C> transformation(
+        kProperty: KProperty1<T, R1>,
+        function: suspend (R1, E, W, Q, A, S, B, U, C) -> R2
     ) {
         transformationProperties.add(Transformation(kProperty, FunctionWrapper.on(function, true)))
     }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/SchemaCompilation.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/SchemaCompilation.kt
@@ -509,7 +509,7 @@ open class SchemaCompilation(
         kqlProperty: PropertyDef.Kotlin<*, *>?,
         transformation: Transformation<*, *>?
     ): Field.Kotlin<*, *> {
-        val returnType = handlePossiblyWrappedType(kProperty.returnType, TypeCategory.QUERY)
+        val returnType = handlePossiblyWrappedType(transformation?.kFunction?.returnType ?: kProperty.returnType, TypeCategory.QUERY)
         val inputValues = if (transformation != null) {
             handleInputValues("$kProperty transformation", transformation.transformation, emptyList())
         } else {


### PR DESCRIPTION
Allows property transformation to change the return type. This allows to e.g. make nullable properties non-nullable in the response, or change the type to something completely different.

Resolves #321