### PR TITLE
docs: enhance documentation

### DIFF
--- a/docs/content/Plugins/ktor.md
+++ b/docs/content/Plugins/ktor.md
@@ -27,18 +27,19 @@ You first need to add the KGraphQL-ktor package to your dependency
 To set up KGraphQL you'll need to install the GraphQL feature like you would any
 other [ktor feature](https://ktor.io/servers/features.html).
 
-```kotlin
-fun Application.module() {
-  install(GraphQL) {
-    playground = true 
-    schema {
-      query("hello") {
-        resolver { -> "World!" }
+=== "Example"
+    ```kotlin
+    fun Application.module() {
+      install(GraphQL) {
+        playground = true 
+        schema {
+          query("hello") {
+            resolver { -> "World!" }
+          }
+        }
       }
     }
-  }
-}
-```
+    ```
 
 Now you have a fully working GraphQL server. We have also set `playground = true`, so when running this you will be able
 to open [http://localhost:8080/graphql](http://localhost:8080/graphql) _(your port number may vary)_ in your browser and
@@ -62,11 +63,12 @@ set of configuration as described in the table below.
 Sometimes you would need to wrap your route within something. A good example of this would be the `authenticate`
 function provided by [ktor Authentication feature](https://ktor.io/docs/server-auth.html).
 
-```kotlin
-wrap {
-  authenticate(optional = true, build = it)
-}
-```
+=== "Example"
+    ```kotlin
+    wrap {
+      authenticate(optional = true, build = it)
+    }
+    ```
 
 This works great alongside the [context](#context) to provide a context to the KGraphQL resolvers.
 
@@ -74,31 +76,30 @@ This works great alongside the [context](#context) to provide a context to the K
 
 To get access to the context
 
-```kotlin
-context { call ->
-  // access to authentication is only available if this is wrapped inside a `authenticate` before hand. 
-  call.authentication.principal<User>()?.let {
-    +it
-  }
-}
-schema {
-  query("hello") {
-    resolver { ctx: Context ->
-      val user = ctx.get<User>()!!
-      "Hello ${user.name}"
+=== "Example"
+    ```kotlin
+    context { call ->
+      // access to authentication is only available if this is wrapped inside a `authenticate` before hand. 
+      call.authentication.principal<User>()?.let {
+        +it
+      }
     }
-  }  
-}
-```
+    schema {
+      query("hello") {
+        resolver { ctx: Context ->
+          val user = ctx.get<User>()!!
+          "Hello ${user.name}"
+        }
+      }  
+    }
+    ```
 
 ## Schema Definition Language (SDL)
 
 The [Schema Definition Language](https://graphql.org/learn/schema/#type-language) (or Type System Definition Language) is a human-readable, language-agnostic
 representation of a GraphQL schema.
 
-See the following comparison:
-
-=== "KGraphQL"
+=== "Example"
     ```kotlin
     schema {
         data class SampleData(

--- a/docs/content/Reference/Type System/enums.md
+++ b/docs/content/Reference/Type System/enums.md
@@ -1,41 +1,71 @@
 # Enums
 
 GraphQL Enums are a variant on the Scalar type, which represents one of a finite set of possible values. They directly
-map to Kotlin enums.
+map to Kotlin enums:
 
-*Example*
-
-```kotlin
-enum class Coolness {
-    NOT_COOL, COOL, TOTALLY_COOL
-}
-
-val schema = KGraphQL.schema {
-    enum<Coolness> {
-        description = "State of coolness"
-        value(Coolness.COOL) {
-            description = "really cool"
-        }
+=== "Example"
+    ```kotlin
+    enum class Coolness {
+        NOT_COOL, COOL, TOTALLY_COOL
     }
     
-    query("cool") {
-        resolver { cool: Coolness -> cool.toString() }
+    val schema = KGraphQL.schema {
+        enum<Coolness> {
+            description = "State of coolness"
+            value(Coolness.COOL) {
+                description = "really cool"
+            }
+        }
+        
+        query("cool") {
+            resolver { cool: Coolness -> cool.toString() }
+        }
     }
-}
-```
+    ```
+=== "SDL"
+    ```graphql
+    type Query {
+      cool(cool: Coolness!): String!
+    }
+
+    "State of coolness"
+    enum Coolness {
+      "really cool"
+      COOL
+      NOT_COOL
+      TOTALLY_COOL
+    }
+    ```
 
 Enum values can be [deprecated](../deprecation.md):
 
-*Example*
+=== "Example"
+    ```kotlin
+    enum class Coolness {
+        NOT_COOL, COOL, TOTALLY_COOL
+    }
 
-```kotlin
-enum class SampleEnum { ONE, TWO, THREE }
+    val schema = KGraphQL.schema {
+        enum<Coolness> {
+            value(Coolness.NOT_COOL) {
+                deprecate("Be cool!")
+            }
+        }
 
-val schema = defaultSchema {
-    enum<SampleEnum> {
-        value(SampleEnum.ONE) {
-            deprecate("deprecated enum value")
+        query("cool") {
+            resolver { cool: Coolness -> cool.toString() }
         }
     }
-}
-```
+    ```
+=== "SDL"
+    ```graphql
+    type Query {
+      cool(cool: Coolness!): String!
+    }
+    
+    enum Coolness {
+      COOL
+      NOT_COOL @deprecated(reason: "Be cool!")
+      TOTALLY_COOL
+    }
+    ```

--- a/docs/content/Reference/Type System/input-objects.md
+++ b/docs/content/Reference/Type System/input-objects.md
@@ -3,7 +3,7 @@ title: Input Objects
 weight: 4
 ---
 
-An GraphQL Input Object defines a set of input fields; the input fields are either scalars, enums, or other input
+A GraphQL Input Object defines a set of input fields; the input fields are either scalars, enums, or other input
 objects. Like Object and Interface types, Input Object types are inferred from defined operations, but can be explicitly
 declared as well.
 
@@ -11,118 +11,134 @@ declared as well.
 
 Input Objects take their fields from the primary constructor, supporting property and non-property parameters.
 
-*Example Definition*
-
-```kotlin
-// Non-data class with a constructor parameter that is not a property
-class NonDataClass(param1: String = "Hello", val param3: Boolean?) {
-    var param2: Int = param1.length
-}
-
-val schema = KGraphQL.schema {
-    query("test") {
-        resolver { input: NonDataClass -> input }
+=== "Example"
+    ```kotlin
+    // Non-data class with a constructor parameter that is not a property
+    class NonDataClass(param1: String = "Hello", val param3: Boolean?) {
+        var param2: Int = param1.length
     }
-}
-```
-
-*Resulting SDL*
-
-```graphql
-type NonDataClass {
-  param2: Int!
-  param3: Boolean
-}
-
-type Query {
-  test(input: NonDataClassInput!): NonDataClass!
-}
-
-input NonDataClassInput {
-  param1: String!
-  param3: Boolean
-}
-```
+    
+    val schema = KGraphQL.schema {
+        query("test") {
+            resolver { input: NonDataClass -> input }
+        }
+    }
+    ```
+=== "SDL"
+    ```graphql
+    type NonDataClass {
+      param2: Int!
+      param3: Boolean
+    }
+    
+    type Query {
+      test(input: NonDataClassInput!): NonDataClass!
+    }
+    
+    input NonDataClassInput {
+      param1: String!
+      param3: Boolean
+    }
+    ```
 
 ## Input Type Name
 
 To avoid equal names between input and query types, input types get an automated `"Input"` suffix unless their name
 already ends with `"Input"` or they have explicit configuration in the DSL via `inputType {}`.
 
-*Example*
-
-```kotlin
-schema {
-    mutation("addType") {
-        resolver { input: Type -> input }
-    }
-    mutation("addFoo") {
-        resolver { input: FooInput -> Foo(input.name) }
-    }
-}
-```
-
 In this case, the input type `Type` will automatically be renamed to `TypeInput` but `FooInput` will not become
 `FooInputInput`:
 
-```graphql
-type Foo {
-  name: String!
-}
+=== "Example"
+    ```kotlin
+    class Type(val name: String)
+    data class FooInput(val name: String)
+    data class Foo(val name: String)
 
-type Mutation {
-  addFoo(input: FooInput!): Foo!
-  addType(input: TypeInput!): Type!
-}
-
-type Type {
-  name: String!
-}
-
-input FooInput {
-  name: String!
-}
-
-input TypeInput {
-  name: String!
-}
-```
-
-This behavior applies recursively to nested types as well:
-
-```kotlin
-schema {
-    mutation("addParent") {
-        resolver { input: ParentType -> input }
+    val schema = KGraphQL.schema {
+        query("getFoo") {
+            resolver { -> Foo("bar") }
+        }
+        mutation("addType") {
+            resolver { input: Type -> input }
+        }
+        mutation("addFoo") {
+            resolver { input: FooInput -> Foo(input.name) }
+        }
     }
-}
-```
+    ```
+=== "SDL"
+    ```graphql
+    type Foo {
+      name: String!
+    }
+    
+    type Mutation {
+      addFoo(input: FooInput!): Foo!
+      addType(input: TypeInput!): Type!
+    }
+    
+    type Query {
+      getFoo: Foo!
+    }
+    
+    type Type {
+      name: String!
+    }
+    
+    input FooInput {
+      name: String!
+    }
+    
+    input TypeInput {
+      name: String!
+    }
+    ```
 
-The nested `ChildType` will also be renamed to `ChildTypeInput`:
+This behavior applies recursively to nested types as well. The nested `ChildType` will also be renamed to `ChildTypeInput`:
 
-```graphql
-type ChildType {
-  childName: String!
-}
-
-type Mutation {
-  addParent(input: ParentTypeInput!): ParentType!
-}
-
-type ParentType {
-  child: ChildType!
-  parentName: String!
-}
-
-input ChildTypeInput {
-  childName: String!
-}
-
-input ParentTypeInput {
-  child: ChildTypeInput!
-  parentName: String!
-}
-```
+=== "Example"
+    ```kotlin
+    class ChildType(val childName: String)
+    class ParentType(val parentName: String, val child: ChildType)
+    
+    val schema = KGraphQL.schema {
+        query("getParent") {
+            resolver { -> ParentType("parent", ChildType("child")) }
+        }
+        mutation("addParent") {
+            resolver { input: ParentType -> input }
+        }
+    }
+    ```
+=== "SDL"
+    ```graphql
+    type ChildType {
+      childName: String!
+    }
+    
+    type Mutation {
+      addParent(input: ParentTypeInput!): ParentType!
+    }
+    
+    type ParentType {
+      child: ChildType!
+      parentName: String!
+    }
+    
+    type Query {
+      getParent: ParentType!
+    }
+    
+    input ChildTypeInput {
+      childName: String!
+    }
+    
+    input ParentTypeInput {
+      child: ChildTypeInput!
+      parentName: String!
+    }
+    ```
 
 ## Runtime
 
@@ -133,64 +149,83 @@ is provided explicitly. Due to a limitation in Kotlin, default values are not vi
 
 Input types can be configured via the `inputType` DSL.
 
-*Example*
-
-```kotlin
-inputType<InputObject> {
-    name = "MyInputObject"
-    description = "Description for input object"
-    
-    InputObject::foo.configure {
-        deprecate("Deprecated old input value")
+=== "Example"
+    ```kotlin
+    inputType<InputObject> {
+        name = "MyInputObject"
+        description = "Description for input object"
+        
+        InputObject::foo.configure {
+            deprecate("Deprecated old input value")
+        }
     }
-}
-```
+    ```
 
 Whenever an input type is configured via DSL the automatic suffix will *not* be appended, regardless of the name.
 
-*Example*
-
-```kotlin
-schema {
-    mutation("addType") {
-        resolver { input: InputType -> Type(input.name) }
-    }
-    mutation("addParent") {
-        resolver { input: ParentType -> input }
-    }
-    inputType<InputType>()
-    inputType<ParentType> {
-        name = "MyParentInputType"
-    }
-}
-```
-
-Both, `InputType` and `ParentType` are explicitly configured, and therefore will keep their original name (a custom
+Here, both `InputType` and `ParentType` are explicitly configured, and therefore will keep their original name (a custom
 `name` is not required).
 
-```graphql
-type ChildType {
-  childName: String!
-}
-
-type Mutation {
-  addParent(input: MyParentInputType!): ParentType!
-}
-
-type ParentType {
-  child: ChildType!
-  parentName: String!
-}
-
-input ChildTypeInput {
-  childName: String!
-}
-
-input MyParentInputType {
-  child: ChildTypeInput!
-  parentName: String!
-}
-```
+=== "Example"
+    ```kotlin
+    class InputType(val name: String)
+    class Type(val name: String)
+    class ChildType(val childName: String)
+    class ParentType(val parentName: String, val child: ChildType)
+    
+    val schema = KGraphQL.schema {
+        query("getType") {
+            resolver { -> Type("type") }
+        }
+        mutation("addType") {
+            resolver { input: InputType -> Type(input.name) }
+        }
+        mutation("addParent") {
+            resolver { input: ParentType -> input }
+        }
+        inputType<InputType>()
+        inputType<ParentType> {
+            name = "MyParentInputType"
+        }
+    }
+    ```
+=== "SDL"
+    ```graphql
+    type ChildType {
+      childName: String!
+    }
+    
+    type Mutation {
+      addParent(input: MyParentInputType!): ParentType!
+      addType(input: InputType!): Type!
+    }
+    
+    type ParentType {
+      child: ChildType!
+      parentName: String!
+    }
+    
+    type Query {
+      getType: Type!
+    }
+    
+    type Type {
+      name: String!
+    }
+    
+    input ChildTypeInput {
+      childName: String!
+    }
+    
+    input InputType {
+      name: String!
+    }
+    
+    input MyParentInputType {
+      child: ChildTypeInput!
+      parentName: String!
+    }
+    ```
 
 ## Limitations
 

--- a/docs/content/Reference/Type System/overview.md
+++ b/docs/content/Reference/Type System/overview.md
@@ -3,7 +3,7 @@
 The Type System is fundamental of a GraphQL schema. Types or based on Kotlin classes and own defined type definitions
 provided via DSL.
 
-## Type System creation
+## Type System Creation
 
 KGraphQL is able to inspect operations and partially infer schema type system, so schema creator does not have to
 explicitly declare every type (but it may if needed). Unions, Enums and Scalars require explicit definition in Schema
@@ -21,20 +21,15 @@ either Object or Interface. Rules are following:
 
 ## Built-in Types
 
-By default, every schema has following built-in types:
-
-### Scalars
+By default, every schema has following built-in [scalars](scalars.md):
 
 * **String** - represents textual data, represented as UTF‐8 character sequences
-* **Short** - represents a signed 16‐bit numeric non‐fractional value
 * **Int** - represents a signed 32‐bit numeric non‐fractional value
-* **Long** - represents a signed 64‐bit numeric non‐fractional value. Long type is not part of GraphQL specification,
-  but it is built in primitive type in Kotlin language.
 * **Float** - represents signed double‐precision fractional values as specified by IEEE 754. KGraphQL represents Kotlin
   primitive Double and Float values as GraphQL Float.
 * **Boolean** - represents true or false
 
-## Introspection types
+## Introspection Types
 
 Introspection interface aligns to [GraphQL specification](https://spec.graphql.org/October2021/#sec-Introspection) with
 additions from the current working draft (deprecated input fields and repeatable directives).

--- a/docs/content/Reference/Type System/scalars.md
+++ b/docs/content/Reference/Type System/scalars.md
@@ -4,33 +4,48 @@ weight: 1
 ---
 
 As defined by specification, scalar represents a primitive value in GraphQL. In KGraphQL, besides built-in scalar types,
-client code can declare custom scalar type, which can coerce to String, Boolean, Int, Long or Float (Kotlin Double).
+client code can declare custom scalar type, which can coerce to `String`, `Boolean`, `Int`, `Long` or `Float` (`kotlin.Double`).
 
-KGraphQL provides a group of DSL methods: `stringScalar { }`, `booleanScalar { }`, `intScalar{ }`, `longScalar{ }`,
-`floatScalar{ }`. They differ only by the Kotlin primitive type they coerce to.
+KGraphQL provides a group of DSL methods to define scalars:
 
-Scalar has to define its coercion functions `deserialize` and `serialize` or coercion object which implements correct
-subtype of `com.apurebase.kgraphql.schema.scalar.ScalarCoercion`.
+* `stringScalar { }`
+* `booleanScalar { }`
+* `intScalar { }`
+* `longScalar { }`
+* `floatScalar { }`
 
-*Example of direct coercion functions declaration*
+They differ only by the Kotlin primitive type they coerce to.
 
-```kotlin
-stringScalar<UUID> {
-  deserialize = { uuid: String -> UUID.fromString(uuid) }
-  serialize = UUID::toString
-}
-```
+Every scalar has to define its coercion functions `deserialize` and `serialize`, or a coercion object that implements the
+correct subtype of `com.apurebase.kgraphql.schema.scalar.ScalarCoercion`:
 
-*Example of coercion object declaration*
-
-```kotlin
-stringScalar<UUID> {
-  coercion = object : StringScalarCoercion<UUID> {
-    override fun serialize(instance: UUID): String = instance.toString()
-    override fun deserialize(raw: String, valueNode: ValueNode?): UUID = UUID.fromString(raw)
-  }
-}
-```
+=== "Example (direct coercion function)"
+    ```kotlin
+    stringScalar<UUID> {
+      deserialize = { uuid: String -> UUID.fromString(uuid) }
+      serialize = UUID::toString
+    }
+    ```
+=== "Example (coercion object)"
+    ```kotlin
+    stringScalar<UUID> {
+      coercion = object : StringScalarCoercion<UUID> {
+        override fun serialize(instance: UUID): String = instance.toString()
+        override fun deserialize(raw: String, valueNode: ValueNode?): UUID = UUID.fromString(raw)
+      }
+    }
+    ```
 
 In addition to the built-in types, KGraphQL provides support for `Long` and `Short` which can be added to a schema
 using `extendedScalars()`.
+
+=== "Example"
+    ```kotlin
+    val schema = KGraphQL.schema {
+        extendedScalars()
+    
+        query("getLong") {
+            resolver { -> 3L }
+        }
+    }
+    ```

--- a/docs/content/Reference/Type System/unions.md
+++ b/docs/content/Reference/Type System/unions.md
@@ -8,68 +8,120 @@ fields between those types.
 
 There are 2 ways of defining a union type.
 
-### Manual
+### Manual Configuration
 
-*Example*
-
-```kotlin
-data class UnionMember1(val one: String)
-data class UnionMember2(val two: String)
-
-KgraphQL.schema {
-    val unionExample = unionType("UnionExample"){
-        type<UnionMember1>()
-        type<UnionMember2>()
-    }
-
-    type<MyType> {
-        unionProperty("unionExample") {
-            returnType = unionExample
-            resolver { _, isOne: Boolean ->
-                if (isOne) {
-                  UnionMember1(one = "Hello")
-                } else {
-                  UnionMember2(two = "World")
+=== "Example"
+    ```kotlin
+    class MyType
+    data class UnionMember1(val one: String)
+    data class UnionMember2(val two: String)
+    
+    val schema = KGraphQL.schema {
+        val unionExample = unionType("UnionExample"){
+            type<UnionMember1>()
+            type<UnionMember2>()
+        }
+    
+        query("myType") {
+            resolver { -> MyType() }
+        }
+    
+        type<MyType> {
+            unionProperty("unionExample") {
+                returnType = unionExample
+                resolver { _, isOne: Boolean ->
+                    if (isOne) {
+                        UnionMember1(one = "Hello")
+                    } else {
+                        UnionMember2(two = "World")
+                    }
                 }
             }
         }
     }
-}
-```
+    ```
+=== "SDL"
+    ```graphql
+    type MyType {
+      unionExample(isOne: Boolean!): UnionExample!
+    }
+    
+    type Query {
+      myType: MyType!
+    }
+    
+    type UnionMember1 {
+      one: String!
+    }
+    
+    type UnionMember2 {
+      two: String!
+    }
+    
+    union UnionExample = UnionMember1 | UnionMember2
+    ```
 
-*Currently there is a limitation on union return types for `query` definitions. This is currently only supported via
-sealed classes. See more information below.*
+(!) Currently there is a limitation on union return types for `query` definitions. This is currently only supported via
+sealed classes. See more information below.
 
 ### Sealed Class
 
-*Example*
+Sealed classes will automatically result in a union type.
 
-```kotlin
-sealed class UnionExample {
-    class UnionMember1(val one: String): UnionExample()
-    class UnionMember2(val two: String): UnionExample()
-}
-
-KgraphQL.schema {
-    unionType<UnionExample>()
-
-    // Query definition example:
-    query("unionQuery") {
-        resolver { isOne: Boolean ->
-            if (isOne) UnionMember1(one = "Hello")
-            else UnionMember2(two = "World")
-        }
+=== "Example"
+    ```kotlin
+    class MyType
+    
+    sealed class UnionExample {
+        class UnionMember1(val one: String) : UnionExample()
+        class UnionMember2(val two: String) : UnionExample()
     }
-
-    // Type property example:
-    type<MyType> {
-        property<UnionExample>("unionProperty") {
-            resolver { _, isOne: Boolean ->
-                if (isOne) UnionMember1(one = "Hello")
-                else UnionMember2(two = "World")
+    
+    val schema = KGraphQL.schema {
+        unionType<UnionExample>()
+    
+        // Query definition example:
+        query("unionQuery") {
+            resolver { isOne: Boolean ->
+                if (isOne) {
+                    UnionExample.UnionMember1(one = "Hello")
+                } else {
+                    UnionExample.UnionMember2(two = "World")
+                }
+            }
+        }
+    
+        // Type property example:
+        type<MyType> {
+            property<UnionExample>("unionProperty") {
+                resolver { _, isOne: Boolean ->
+                    if (isOne) {
+                        UnionExample.UnionMember1(one = "Hello")
+                    } else {
+                        UnionExample.UnionMember2(two = "World")
+                    }
+                }
             }
         }
     }
-}
-```
-
+    ```
+=== "SDL"
+    ```graphql
+    type MyType {
+      unionProperty(isOne: Boolean!): UnionExample!
+    }
+    
+    type Query {
+      unionQuery(isOne: Boolean!): UnionExample!
+    }
+    
+    type UnionMember1 {
+      one: String!
+    }
+    
+    type UnionMember2 {
+      two: String!
+    }
+    
+    union UnionExample = UnionMember1 | UnionMember2
+    ```

--- a/docs/content/Reference/accessRule.md
+++ b/docs/content/Reference/accessRule.md
@@ -2,24 +2,23 @@
 
 It's possible to add restriction unto your resolvers by using the `accessRule`.
 
-*Example*
-
-```kotlin
-type<MyType> {
-    property<String>("secretData") {
-        // Some resolver
-        resolver { ctx: Context -> myService.getSecret(ctx.userId) }
-        
-        // Return an exception or null
-        accessRule { item: MyType, ctx: Content ->
-            if (item.ownerId != ctx.userId) {
-              IncorrectOwnerException()
-            } else {
-              null
+=== "Example"
+    ```kotlin
+    type<MyType> {
+        property<String>("secretData") {
+            // Some resolver
+            resolver { ctx: Context -> myService.getSecret(ctx.userId) }
+            
+            // Return an exception or null
+            accessRule { item: MyType, ctx: Content ->
+                if (item.ownerId != ctx.userId) {
+                  IncorrectOwnerException()
+                } else {
+                  null
+                }
             }
         }
     }
-}
-```
+    ```
 
 When an exception is returned it will not call the resolver and return an error with the specified exception.

--- a/docs/content/Reference/configuration.md
+++ b/docs/content/Reference/configuration.md
@@ -15,14 +15,13 @@ KGraphQL schema allows configuration of the following properties:
 | introspection                  | Schema allows introspection (also affects SDL). Introspection can be disabled in production to reduce attack surface. | `true`                                                                                                                                                                   |
 | plugins                        | (unused?)                                                                                                             |                                                                                                                                                                          |
 
-*Example*
-
-```kotlin
-KGraphQL.schema {
-    configure {
-        useDefaultPrettyPrinter = true
-        objectMapper = jacksonObjectMapper()
-        useCachingDocumentParser = false
+=== "Example"
+    ```kotlin
+    KGraphQL.schema {
+        configure {
+            useDefaultPrettyPrinter = true
+            objectMapper = jacksonObjectMapper()
+            useCachingDocumentParser = false
+        }
     }
-}
-```
+    ```

--- a/docs/content/Reference/deprecation.md
+++ b/docs/content/Reference/deprecation.md
@@ -2,20 +2,34 @@
 title: Deprecation
 ---
 
-Schema creator is able to deprecate fields, operations, enum values, and input values. DSL builders for those schema
+Schema creators are able to deprecate fields, operations, enum values, and input values. DSL builders for those schema
 elements expose method `deprecate(reason: String)`. Deprecation is visible in schema introspection system with fields
 `isDeprecated: Boolean` and `deprecationReason: String`.
 
 Input values may only be deprecated if they are not required, cf. [3.13.3@deprecated](https://spec.graphql.org/draft/#sec--deprecated).
 
-*Example*
+=== "Example"
+    ```kotlin
+    data class Sample(val content: String)
 
-```kotlin
-data class Sample(val content: String)
-
-type<Sample> {
-    Sample::content.configure {
-        deprecate("deprecated property")
+    val schema = KGraphQL.schema { 
+        query("sample") {
+            resolver { -> Sample("Hello world") }
+        }
+        type<Sample> {
+            Sample::content.configure {
+                deprecate("deprecated property")
+            }
+        }
     }
-}
-```
+    ```
+=== "SDL"
+    ```graphql
+    type Query {
+      sample: Sample!
+    }
+    
+    type Sample {
+      content: String! @deprecated(reason: "deprecated property")
+    }
+    ```

--- a/docs/content/Reference/operations.md
+++ b/docs/content/Reference/operations.md
@@ -17,42 +17,40 @@ In KGraphQL, operation is declared in `SchemaBuilder` block. Every operation has
 | name     | name of operation       |
 | resolver | [Resolver](resolver.md) |
 
-Selection set is automatically created based on resolver return type. By default, selection set for specific class
-contains all its member properties (without extension properties), but it can be customized (TBD Type wiki page).
+Selection set is automatically created based on resolver return type. By default, the selection set for a specific class
+contains all of its member properties (without extension properties), but it can be customized (cf. [Objects and Interfaces](Type%20System/objects-and-interfaces.md)).
 Operations can be [deprecated](deprecation.md)
 
-Subscription is not supported yet.
+Subscriptions are not supported yet.
 
 ### Query
 
-`query` allows to create resolver for query operation.
+`query` allows to create a resolver for a query operation.
 
-*Example*
-
-```kotlin
-data class Hero(val name: String, val age: Int)
-
-query("hero") {
-    description = "returns formatted name of R2-D2"
-    resolver { -> Hero("R2-D2", 40) } 
-}
-```
+=== "Example"
+    ```kotlin
+    data class Hero(val name: String, val age: Int)
+    
+    query("hero") {
+        description = "returns formatted name of R2-D2"
+        resolver { -> Hero("R2-D2", 40) } 
+    }
+    ```
 
 This example adds query with name hero, which returns new instance of R2-D2 Hero. It can be queried with selection set
 for name or age, example query: `{hero{name, age}}`
 
 ### Mutation
 
-`mutation` allows to create resolver for mutation operation.
+`mutation` allows to create a resolver for a mutation operation.
 
-*Example*
-
-```kotlin
-mutation("createHero") {
-    description = "Creates hero with specified name"
-    resolver { name: String -> name } 
-}
-```
+=== "Example"
+    ```kotlin
+    mutation("createHero") {
+        description = "Creates hero with specified name"
+        resolver { name: String -> name } 
+    }
+    ```
 
 This example adds mutation with name `createHero`, which returns passed name.
 

--- a/docs/content/Reference/resolver.md
+++ b/docs/content/Reference/resolver.md
@@ -9,11 +9,12 @@ Properties](Type%20System/objects-and-interfaces.md/#extension-properties) and [
 Resolver clause accepts kotlin function and returns its DSL item, which is entry point for additional customization of
 resolver
 
-```kotlin
-query("item") {
-    resolver { -> Item(id, "Item Name") }
-}
-```
+=== "Example"
+    ```kotlin
+    query("item") {
+        resolver { -> Item(id, "Item Name") }
+    }
+    ```
 
 ## Arguments
 
@@ -23,17 +24,16 @@ query("item") {
 `arg` exposes possibility to customize argument default value. Default value is automatically used if query doesn't
 provide any. it is matched by argument name.
 
-*Example*
-
-```kotlin
-KGraphQL.schema {
-    query("data") {
-        resolver { int: Int, string: String? -> int }.withArgs {
-            arg<Int> { name = "int"; defaultValue = 33 }
+=== "Example"
+    ```kotlin
+    KGraphQL.schema {
+        query("data") {
+            resolver { int: Int, string: String? -> int }.withArgs {
+                arg<Int> { name = "int"; defaultValue = 33 }
+            }
         }
     }
-}
-```
+    ```
 
 ## Context
 
@@ -42,31 +42,33 @@ To get access to the context object, you can just request for the `Context` obje
 When providing `Context` as an argument for your resolver, it will be skipped and not published to your API, but
 KGraphQL will make sure to provide it to the resolver, so you can use it like the following example:
 
-```kotlin
-query("hello") {
-	resolver { country: String, ctx: Context ->
-		val user = ctx.get<User>()
-		Hello(label = "Hello ${user?.name ?: "unknown"}")
-	}
-}
-```
+=== "Example"
+    ```kotlin
+    query("hello") {
+        resolver { country: String, ctx: Context ->
+            val user = ctx.get<User>()
+            Hello(label = "Hello ${user?.name ?: "unknown"}")
+        }
+    }
+    ```
 
 Then in your query execution process you will provide a `Context` like shown here:
 
-```kotlin
-val query = """
-	query fetchHelloLabel($country: String!) {
-		hello(country: $country) {
-			label
-		}
-	}
-"""
-val variables = """
-	{"country": "English"}
-"""
-val user = User(id = 1, name = "Username")
-val ctx = context {
-	+user
-}
-schema.execute(query, variables, ctx)
-```
+=== "Example"
+    ```kotlin
+    val query = """
+        query fetchHelloLabel($country: String!) {
+            hello(country: $country) {
+                label
+            }
+        }
+    """
+    val variables = """
+        {"country": "English"}
+    """
+    val user = User(id = 1, name = "Username")
+    val ctx = context {
+        +user
+    }
+    schema.execute(query, variables, ctx)
+    ```

--- a/docs/content/Reference/stitching.md
+++ b/docs/content/Reference/stitching.md
@@ -14,48 +14,46 @@ identifiers.
 In KGraphQL, schema stitching is configured via the `stitchedSchema` DSL. Each stitched schema has 1-n *remote* schemas,
 and up to one *local* schema.
 
-*Example*:
-
-```kotlin
-stitchedSchema {
-    configure {
-        remoteExecutor = TestRemoteRequestExecutor(client, objectMapper)
-    }
-    localSchema {
-        query("local") {
-            resolver { -> "local" }
+=== "Example"
+    ```kotlin
+    stitchedSchema {
+        configure {
+            remoteExecutor = TestRemoteRequestExecutor(client, objectMapper)
+        }
+        localSchema {
+            query("local") {
+                resolver { -> "local" }
+            }
+        }
+        remoteSchema("remote1") {
+            ...
+        }
+        remoteSchema("remote2") {
+            ...
         }
     }
-    remoteSchema("remote1") {
-        ...
-    }
-    remoteSchema("remote2") {
-        ...
-    }
-}
-```
+    ```
 
 ### Remote Schema Fetching
 
 Remote schemas are usually fetched via introspection query.
 
-*Example*:
-
-```kotlin
-remoteSchema(url) {
-    runBlocking {
-        val responseText = httpClient.post(url) {
-            setBody(
-                TextContent(
-                    text = graphQLJson.toJson(mapOf("query" to Introspection.query())),
-                    contentType = ContentType.Application.Json
+=== "Example"
+    ```kotlin
+    remoteSchema(url) {
+        runBlocking {
+            val responseText = httpClient.post(url) {
+                setBody(
+                    TextContent(
+                        text = graphQLJson.toJson(mapOf("query" to Introspection.query())),
+                        contentType = ContentType.Application.Json
+                    )
                 )
-            )
-        }.bodyAsText()
-        IntrospectedSchema.fromIntrospectionResponse(responseText)
+            }.bodyAsText()
+            IntrospectedSchema.fromIntrospectionResponse(responseText)
+        }
     }
-}
-```
+    ```
 
 ### Duplicate Types
 
@@ -84,21 +82,20 @@ Fragments based on remote types work but cannot use Kotlin's type system to dete
 Therefore, queries including fragments must also request the `__typename`. Future implementation might automatically
 include this.
 
-*Example*:
-
-```graphql
-query {
-    getRemote {
-        __typename
-        foo
-        child {
+=== "Query"
+    ```graphql
+    query {
+        getRemote {
             __typename
-            ...on RemoteA { specialA }
-            ...on RemoteB { specialB }
+            foo
+            child {
+                __typename
+                ...on RemoteA { specialA }
+                ...on RemoteB { specialB }
+            }
         }
     }
-}
-```
+    ```
 
 ### Local "Remote" Execution
 
@@ -106,15 +103,14 @@ Due to current implementation details, properties stitched to a *local* query wi
 `RemoteRequestExecutor`, and therefore the schema has to provide a `localUrl`. Future implementation will likely support
 actual local execution.
 
-*Example:*
-
-```kotlin
-stitchedSchema {
-    configure {
-        localUrl = "/graphql"
+=== "Example"
+    ```kotlin
+    stitchedSchema {
+        configure {
+            localUrl = "/graphql"
+        }
     }
-}
-```
+    ```
 
 ### Linking Properties
 
@@ -125,21 +121,20 @@ calls during execution. The following example adds two fields to the `Type1` typ
 - `stitched2`, which executes the remote query `getStitched2` and provides the value of the property `foo` from the
   parent type as argument named `fooValue`
 
-*Example:*
-
-```kotlin
-type("Type1") {
-    stitchedProperty("stitched1") {
-        nullable = false
-        remoteQuery("getStitched1")
-    }
-    stitchedProperty("stitched2") {
-        remoteQuery("getStitched2").withArgs {
-            arg { name = "fooValue"; parentFieldName = "foo" }
+=== "Example"
+    ```kotlin
+    type("Type1") {
+        stitchedProperty("stitched1") {
+            nullable = false
+            remoteQuery("getStitched1")
+        }
+        stitchedProperty("stitched2") {
+            remoteQuery("getStitched2").withArgs {
+                arg { name = "fooValue"; parentFieldName = "foo" }
+            }
         }
     }
-}
-```
+    ```
 
 Stitched properties are nullable by default, and if a parent property is `null`, the remote execution is skipped and
 results in a value of `null` for the stitched property itself.

--- a/docs/content/Tutorials/starwars.md
+++ b/docs/content/Tutorials/starwars.md
@@ -6,153 +6,154 @@ weight: 1
 As example, let's partially reproduce part of Star Wars schema from official GraphQL tutorial. First, we need to define
 our domain model, by plain kotlin classes:
 
-```kotlin
-enum class Episode {
-  NEWHOPE, EMPIRE, JEDI
-}
-
-interface Character {
-  val id : String
-  val name : String?
-  val friends: List<Character>
-  val appearsIn: Set<Episode>
-}
-
-data class Human (
-  override val id: String,
-  override val name: String?,
-  override val friends: List<Character>,
-  override val appearsIn: Set<Episode>,
-  val homePlanet: String,
-  val height: Double
-) : Character
-
-data class Droid (
-  override val id: String,
-  override val name: String?,
-  override val friends: List<Character>,
-  override val appearsIn: Set<Episode>,
-  val primaryFunction : String
-) : Character
-```
+=== "Example"
+    ```kotlin
+    enum class Episode {
+      NEWHOPE, EMPIRE, JEDI
+    }
+    
+    interface Character {
+      val id : String
+      val name : String?
+      val friends: List<Character>
+      val appearsIn: Set<Episode>
+    }
+    
+    data class Human (
+      override val id: String,
+      override val name: String?,
+      override val friends: List<Character>,
+      override val appearsIn: Set<Episode>,
+      val homePlanet: String,
+      val height: Double
+    ) : Character
+    
+    data class Droid (
+      override val id: String,
+      override val name: String?,
+      override val friends: List<Character>,
+      override val appearsIn: Set<Episode>,
+      val primaryFunction : String
+    ) : Character
+    ```
 
 Next, we define our data
 
-```kotlin
-val luke = Human("2000", "Luke Skywalker", emptyList(), Episode.values().toSet(), "Tatooine", 1.72)
+=== "Example"
+    ```kotlin
+    val luke = Human("2000", "Luke Skywalker", emptyList(), Episode.values().toSet(), "Tatooine", 1.72)
+    
+    val r2d2 = Droid("2001", "R2-D2", emptyList(), Episode.values().toSet(), "Astromech")
+    ```
 
-val r2d2 = Droid("2001", "R2-D2", emptyList(), Episode.values().toSet(), "Astromech")
-```
+Then, we can create the schema:
 
-Then, we can create schema:
-
-```kotlin
-// KGraphQL#schema { } is entry point to create KGraphQL schema
-val schema = KGraphQL.schema {
-  //configure method allows you customize schema behaviour
-  configure {
-    useDefaultPrettyPrinter = true
-  }
-
-  // create query "hero" which returns instance of Character
-  query("hero") {
-    resolver { episode: Episode ->
-      when (episode) {
-        Episode.NEWHOPE, Episode.JEDI -> r2d2
-        Episode.EMPIRE -> luke
+=== "Example"
+    ```kotlin
+    // KGraphQL#schema { } is entry point to create KGraphQL schema
+    val schema = KGraphQL.schema {
+      //configure method allows you customize schema behaviour
+      configure {
+        useDefaultPrettyPrinter = true
       }
+    
+      // create query "hero" which returns instance of Character
+      query("hero") {
+        resolver { episode: Episode ->
+          when (episode) {
+            Episode.NEWHOPE, Episode.JEDI -> r2d2
+            Episode.EMPIRE -> luke
+          }
+        }
+      }
+    
+      // create query "heroes" which returns list of luke and r2d2
+      query("heroes") {
+        resolver{ -> listOf(luke, r2d2) }
+      }
+    
+      // 1kotlin classes need to be registered with "type" method 
+      // to be included in created schema type system
+      // class Character is automatically included, 
+      // as it is return type of both created queries  
+      type<Droid>()
+      type<Human>()
+      enum<Episode>()
     }
-  }
-
-  // create query "heroes" which returns list of luke and r2d2
-  query("heroes") {
-    resolver{ -> listOf(luke, r2d2) }
-  }
-
-  // 1kotlin classes need to be registered with "type" method 
-  // to be included in created schema type system
-  // class Character is automatically included, 
-  // as it is return type of both created queries  
-  type<Droid>()
-  type<Human>()
-  enum<Episode>()
-}
-```
+    ```
 
 Now, we can query our schema:
 
-```kotlin
-// query for hero from episode JEDI and take id, name for any Character, and primaryFunction for Droid or height for Human
-schema.execute("""
-  {
-    hero(episode: JEDI) {
-      id
-      name
-      ... on Droid {
-        primaryFunction
+=== "Example"
+    ```kotlin
+    // query for hero from episode JEDI and take id, name for any Character, and primaryFunction for Droid or height for Human
+    schema.execute("""
+      {
+        hero(episode: JEDI) {
+          id
+          name
+          ... on Droid {
+            primaryFunction
+          }
+          ... on Human {
+            height
+          }
+        }
       }
-      ... on Human {
-        height
+    """)
+    ```
+=== "Response"
+    ```json
+    {
+      "data" : {
+        "hero" : {
+          "id" : "2001",
+          "name" : "R2-D2",
+          "primaryFunction" : "Astromech"
+        }
       }
     }
-  }
-""")
-```
-
-Returns:
-
-```json
-{
-  "data" : {
-    "hero" : {
-      "id" : "2001",
-      "name" : "R2-D2",
-      "primaryFunction" : "Astromech"
-    }
-  }
-}
-```
+    ```
 
 Query for all heroes:
 
-```kotlin
-// query for all heroes and take id, name for any Character, and primaryFunction for Droid or height for Human
-schema.execute("""
-  {
-    heroes {
-      id
-      name
-      ... on Droid {
-        primaryFunction
+=== "Example"
+    ```kotlin
+    // query for all heroes and take id, name for any Character, and primaryFunction for Droid or height for Human
+    schema.execute("""
+      {
+        heroes {
+          id
+          name
+          ... on Droid {
+            primaryFunction
+          }
+          ... on Human {
+            height
+          }
+        }
       }
-      ... on Human {
-        height
+    """)
+    ```
+=== "Response"
+    ```json
+    {
+      "data" : {
+        "heroes" : [
+          {
+            "id" : "2000",
+            "name" : "Luke Skywalker",
+            "height" : 1.72
+          },
+          {
+            "id" : "2001",
+            "name" : "R2-D2",
+            "primaryFunction" : "Astromech"
+          }
+        ]
       }
     }
-  }
-""")
-```
+    ```
 
-Returns:
-
-```json
-{
-  "data" : {
-    "heroes" : [
-      {
-        "id" : "2000",
-        "name" : "Luke Skywalker",
-        "height" : 1.72
-      },
-      {
-        "id" : "2001",
-        "name" : "R2-D2",
-        "primaryFunction" : "Astromech"
-      }
-    ]
-  }
-}
-```
-
-As stated by GraphQL specification, client receives only what is requested. No more, no less.
+As stated by the GraphQL specification, the client receives only what is requested. No more, no less.
 


### PR DESCRIPTION
Adds documentation for #322 along with a general overhaul of existing examples in order to make the documentation a bit less cluttered and easier to read.

Examples are now consistently shown as tabbed, with multiple tabs for code, request, response, and SDL where appropriate. Some existing examples have been extended and/or fixed to compile.