### PR TITLE
feat: allow single parameter transformations

### DIFF
--- a/docs/content/Reference/Type System/objects-and-interfaces.md
+++ b/docs/content/Reference/Type System/objects-and-interfaces.md
@@ -154,7 +154,7 @@ properties non-nullable:
             resolver { -> Person(null, 42) }
         }
         type<Person> {
-            transformation(Person::name) { name: String?, ctx: Context ->
+            transformation(Person::name) { name: String? ->
                 name ?: "(no name)"
             }
         }
@@ -201,7 +201,7 @@ Transformations can even change the type to a completely different class:
             resolver { -> Person("John Smith", 42) }
         }
         type<Person> {
-            transformation(Person::age) { age: Int, ctx: Context ->
+            transformation(Person::age) { age: Int ->
                 if (age == 42) {
                     "fourty-two"
                 } else {

--- a/kgraphql/api/kgraphql.api
+++ b/kgraphql/api/kgraphql.api
@@ -814,6 +814,7 @@ public class com/apurebase/kgraphql/schema/dsl/types/TypeDSL : com/apurebase/kgr
 	public final fun property (Lkotlin/reflect/KProperty1;Lkotlin/jvm/functions/Function1;)V
 	public final fun setName (Ljava/lang/String;)V
 	public final fun transformation (Lkotlin/reflect/KProperty1;Lkotlin/jvm/functions/Function10;)V
+	public final fun transformation (Lkotlin/reflect/KProperty1;Lkotlin/jvm/functions/Function2;)V
 	public final fun transformation (Lkotlin/reflect/KProperty1;Lkotlin/jvm/functions/Function3;)V
 	public final fun transformation (Lkotlin/reflect/KProperty1;Lkotlin/jvm/functions/Function4;)V
 	public final fun transformation (Lkotlin/reflect/KProperty1;Lkotlin/jvm/functions/Function5;)V

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/types/TypeDSL.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/types/TypeDSL.kt
@@ -23,14 +23,15 @@ open class TypeDSL<T : Any>(
     var name = kClass.defaultKQLTypeName()
 
     private val transformationProperties = mutableSetOf<Transformation<T, *>>()
-
     private val extensionProperties = mutableSetOf<PropertyDef.Function<T, *>>()
-
     private val unionProperties = mutableSetOf<PropertyDef.Union<T>>()
-
     private val describedKotlinProperties = mutableMapOf<KProperty1<T, *>, PropertyDef.Kotlin<T, *>>()
 
     val dataloadedExtensionProperties = mutableSetOf<PropertyDef.DataLoadedFunction<T, *, *>>()
+
+    fun <R1, R2> transformation(kProperty: KProperty1<T, R1>, function: suspend (R1) -> R2) {
+        transformationProperties.add(Transformation(kProperty, FunctionWrapper.on(function, true)))
+    }
 
     fun <R1, R2, E> transformation(kProperty: KProperty1<T, R1>, function: suspend (R1, E) -> R2) {
         transformationProperties.add(Transformation(kProperty, FunctionWrapper.on(function, true)))

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/RequestInterpreter.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/RequestInterpreter.kt
@@ -107,7 +107,7 @@ class RequestInterpreter(private val schemaModel: SchemaModel) {
         selectionSet: SelectionSetNode?,
         propertyName: NameNode? = null
     ): List<Execution> = if (!selectionSet?.selections.isNullOrEmpty()) {
-        selectionSet!!.selections.map {
+        selectionSet.selections.map {
             handleReturnTypeChildOrFragment(it, type, ctx)
         }
     } else if (type.unwrapped().fields?.isNotEmpty() == true) {

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaBuilderTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaBuilderTest.kt
@@ -110,10 +110,10 @@ class SchemaBuilderTest {
                 resolver { id: Int -> Foo(id, numbers[id], numbers[id], id) }
             }
             type<Foo> {
-                transformation(Foo::nameWithDefault) { nameWithDefault: String?, ctx: Context ->
+                transformation(Foo::nameWithDefault) { nameWithDefault: String? ->
                     nameWithDefault ?: "(no name)"
                 }
-                transformation(Foo::transformedId) { transformedId: Int, ctx: Context ->
+                transformation(Foo::transformedId) { transformedId: Int ->
                     transformedId.toString()
                 }
             }


### PR DESCRIPTION
Previously, transformations always required two parameters, so the examples had to artificially include an unused `Context` argument:
```
type<Person> {
    transformation(Person::name) { name: String?, ctx: Context ->
        name ?: "(no name)"
    }
}
```

Now, this is no longer required and the transformation can be reduced to:
```
type<Person> {
    transformation(Person::name) { name: String? ->
        name ?: "(no name)"
    }
}
```