### PR TITLE
refactor: improve type name validation

### DIFF
--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/MutableSchemaDefinition.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/MutableSchemaDefinition.kt
@@ -140,7 +140,7 @@ open class MutableSchemaDefinition {
 
     private fun <T : Definition> addType(type: T, target: ArrayList<T>, typeCategory: String) {
         validateName(type.name)
-        if (type.checkEqualName(objects, scalars, unions, enums)) {
+        if (type.checkEqualName(objects, inputObjects, scalars, unions, enums)) {
             throw SchemaException("Cannot add $typeCategory type with duplicated name ${type.name}")
         }
         target.add(type)

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/TypeSystemSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/TypeSystemSpecificationTest.kt
@@ -17,8 +17,11 @@ class TypeSystemSpecificationTest {
     class Type(val name: kotlin.String)
     class TypeInput(val name: kotlin.String)
     class InputType(val name: kotlin.String)
+    @Suppress("unused")
     class ParentType(val parentName: kotlin.String, val child: ChildType)
+    @Suppress("unused")
     class ChildType(val childName: kotlin.String)
+    @Suppress("ClassName")
     class __Type(val name: kotlin.String)
 
     @Test
@@ -150,6 +153,25 @@ class TypeSystemSpecificationTest {
                 }
             }
         }
+        expect<SchemaException>("Cannot add Object type with duplicated name Type") {
+            schema {
+                inputType<Type>()
+                type<Type>()
+                query("getString") {
+                    resolver { -> Type("string") }
+                }
+            }
+        }
+        expect<SchemaException>("Cannot add Object type with duplicated name Type") {
+            schema {
+                type<__Type> {
+                    name = "Type"
+                }
+                query("getString") {
+                    resolver { -> Type("string") }
+                }
+            }
+        }
         expect<SchemaException>("Cannot add Input type with duplicated name Type") {
             schema {
                 type<Type>()
@@ -173,6 +195,16 @@ class TypeSystemSpecificationTest {
                     name = "TypeInput"
                 }
                 inputType<TypeInput>()
+            }
+        }
+        expect<SchemaException>("Cannot add Input type with duplicated name TypeInput") {
+            schema {
+                type<Type> {
+                    name = "TypeInput"
+                }
+                query("test") {
+                    resolver { input: TypeInput -> Type(input.name) }
+                }
             }
         }
         expect<SchemaException>("Cannot add Input type with duplicated name TypeInput") {


### PR DESCRIPTION
Validation for type name uniqueness now catches conflicts with input types a bit earlier.