### PR TITLE
feat: support Java classes as input objects

### DIFF
--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/helpers/KGraphQLExtensions.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/helpers/KGraphQLExtensions.kt
@@ -20,6 +20,8 @@ import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlin.reflect.KClass
+import kotlin.reflect.full.primaryConstructor
 
 /**
  * This returns a list of all scalar fields requested on this type.
@@ -129,3 +131,11 @@ fun JsonNode?.toValueNode(expectedType: __Type): ValueNode = when (this) {
 }
 
 internal fun Double.isWholeNumber() = this % 1.0 == 0.0
+
+/**
+ * Returns the (single) constructor to use during input value generation. This is either the
+ * [primaryConstructor] for Kotlin classes, or the single constructor for Java classes.
+ *
+ * Adapted from Jackson Kotlin's `primarilyConstructor()`
+ */
+internal fun KClass<*>.singleConstructor() = primaryConstructor ?: constructors.singleOrNull()

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/ArgumentTransformer.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/ArgumentTransformer.kt
@@ -2,6 +2,7 @@ package com.apurebase.kgraphql.schema.execution
 
 import com.apurebase.kgraphql.Context
 import com.apurebase.kgraphql.InvalidInputValueException
+import com.apurebase.kgraphql.helpers.singleConstructor
 import com.apurebase.kgraphql.request.Variables
 import com.apurebase.kgraphql.schema.introspection.TypeKind
 import com.apurebase.kgraphql.schema.model.FunctionWrapper
@@ -12,7 +13,6 @@ import com.apurebase.kgraphql.schema.scalar.deserializeScalar
 import com.apurebase.kgraphql.schema.structure.InputValue
 import com.apurebase.kgraphql.schema.structure.Type
 import kotlin.reflect.full.isSubclassOf
-import kotlin.reflect.full.primaryConstructor
 
 open class ArgumentTransformer {
 
@@ -96,8 +96,8 @@ open class ArgumentTransformer {
             }
 
             value is ObjectValueNode -> {
-                // SchemaCompilation ensures that input types have a primaryConstructor
-                val constructor = checkNotNull(type.unwrapped().kClass?.primaryConstructor)
+                // SchemaCompilation ensures that input types have a singleConstructor()
+                val constructor = checkNotNull(type.unwrapped().kClass?.singleConstructor())
                 val constructorParametersByName = constructor.parameters.associateBy { it.name }
                 val inputFieldsByName = type.unwrapped().inputFields.orEmpty().associateBy { it.name }
 

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/SchemaCompilation.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/SchemaCompilation.kt
@@ -6,6 +6,7 @@ import com.apurebase.kgraphql.Context
 import com.apurebase.kgraphql.configuration.SchemaConfiguration
 import com.apurebase.kgraphql.defaultKQLTypeName
 import com.apurebase.kgraphql.getIterableElementType
+import com.apurebase.kgraphql.helpers.singleConstructor
 import com.apurebase.kgraphql.isIterable
 import com.apurebase.kgraphql.request.isIntrospectionType
 import com.apurebase.kgraphql.schema.DefaultSchema
@@ -34,7 +35,6 @@ import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.full.isSuperclassOf
 import kotlin.reflect.full.memberProperties
-import kotlin.reflect.full.primaryConstructor
 import kotlin.reflect.jvm.jvmErasure
 
 @Suppress("UNCHECKED_CAST")
@@ -377,7 +377,7 @@ open class SchemaCompilation(
     protected suspend fun handleInputType(kClass: KClass<*>): Type {
         assertValidObjectType(kClass)
 
-        val primaryConstructor = kClass.primaryConstructor
+        val primaryConstructor = kClass.singleConstructor()
             ?: throw SchemaException("Java class '${kClass.simpleName}' as inputType is not supported")
 
         val inputObjectDef =

--- a/kgraphql/src/test/java/com/apurebase/kgraphql/schema/InvalidLatLng.java
+++ b/kgraphql/src/test/java/com/apurebase/kgraphql/schema/InvalidLatLng.java
@@ -1,0 +1,14 @@
+package com.apurebase.kgraphql.schema;
+
+// LatLng class with two constructors, which is not supported
+public class InvalidLatLng {
+    public double lat;
+    public double lng;
+
+    public InvalidLatLng() {}
+
+    public InvalidLatLng(double lat, double lng) {
+        this.lat = lat;
+        this.lng = lng;
+    }
+}


### PR DESCRIPTION
Java classes can be used as input objects if and only if they have a single accessible constructor. Proper argument names will only be present when available from the byte code (which they are by default not), and otherwise be resolved as `arg0`, `arg1`, etc.