### PR TITLE
fix: missing validation on input objects

### DIFF
--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/SchemaCompilation.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/SchemaCompilation.kt
@@ -360,7 +360,7 @@ open class SchemaCompilation(
         }
 
         if (declaredFields.isEmpty()) {
-            throw SchemaException("An Object type must define one or more fields. Found none on type ${objectDef.name}")
+            throw SchemaException("An object type must define one or more fields. Found none on type ${objectDef.name}")
         }
 
         declaredFields.forEach { validateName(it.name) }
@@ -429,6 +429,10 @@ open class SchemaCompilation(
             }
         } else {
             listOf()
+        }
+
+        if (fields.isEmpty()) {
+            throw SchemaException("An input type must define one or more fields. Found none on type ${inputObjectDef.name}")
         }
 
         fields.forEach { validateName(it.name) }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/ObjectsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/ObjectsSpecificationTest.kt
@@ -419,8 +419,8 @@ class ObjectsSpecificationTest {
     class Empty
 
     @Test
-    fun `an Object type must define one or more fields`() {
-        expect<SchemaException>("An Object type must define one or more fields. Found none on type Empty") {
+    fun `an object type must define one or more fields`() {
+        expect<SchemaException>("An object type must define one or more fields. Found none on type Empty") {
             schema { type<Empty>() }
         }
     }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/ScalarsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/ScalarsSpecificationTest.kt
@@ -49,7 +49,7 @@ class ScalarsSpecificationTest {
 
     @Test
     fun `extended scalars should not be available by default`() {
-        expect<SchemaException>("An Object type must define one or more fields. Found none on type Long") {
+        expect<SchemaException>("An object type must define one or more fields. Found none on type Long") {
             KGraphQL.schema {
                 query("long") {
                     resolver<Long> { 1L }
@@ -57,7 +57,7 @@ class ScalarsSpecificationTest {
             }
         }
 
-        expect<SchemaException>("An Object type must define one or more fields. Found none on type Short") {
+        expect<SchemaException>("An object type must define one or more fields. Found none on type Short") {
             KGraphQL.schema {
                 query("short") {
                     resolver<Short> { 2.toShort() }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/UnionsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/UnionsSpecificationTest.kt
@@ -178,7 +178,7 @@ class UnionsSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `A Union type must define one or more unique member types`() {
+    fun `a union type must define one or more unique member types`() {
         expect<SchemaException>("The union type 'invalid' has no possible types defined, requires at least one. Please refer to https://stuebingerb.github.io/KGraphQL/Reference/Type%20System/unions/") {
             KGraphQL.schema {
                 unionType("invalid") {}


### PR DESCRIPTION
According to the spec, input objects must define one or more input fields.