### PR TITLE
feat: handle enums automatically

### DIFF
--- a/docs/content/Reference/Type System/overview.md
+++ b/docs/content/Reference/Type System/overview.md
@@ -6,8 +6,8 @@ provided via DSL.
 ## Type System Creation
 
 KGraphQL is able to inspect operations and partially infer schema type system, so schema creator does not have to
-explicitly declare every type (but it may if needed). Unions, Enums and Scalars require explicit definition in Schema
-DSL. Inferred classes are interpreted as GraphQL Object or Interface type.
+explicitly declare every type (but it may if needed). Union and Scalars require explicit definition in Schema DSL.
+Inferred classes are interpreted as GraphQL Object or Interface type.
 
 ## Object or Interface?
 

--- a/docs/content/Tutorials/starwars.md
+++ b/docs/content/Tutorials/starwars.md
@@ -72,13 +72,12 @@ Then, we can create the schema:
         resolver{ -> listOf(luke, r2d2) }
       }
     
-      // 1kotlin classes need to be registered with "type" method 
+      // kotlin classes need to be registered with "type" method 
       // to be included in created schema type system
       // class Character is automatically included, 
       // as it is return type of both created queries  
       type<Droid>()
       type<Human>()
-      enum<Episode>()
     }
     ```
 

--- a/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/execution/StitchedSchemaExecutionTest.kt
+++ b/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/execution/StitchedSchemaExecutionTest.kt
@@ -55,7 +55,6 @@ class StitchedSchemaExecutionTest {
     }
 
     private fun SchemaBuilder.remoteSchema1WithEnum() = run {
-        enum<RemoteEnum>()
         query("remote1") {
             resolver { -> RemoteEnum.REMOTE1 }
         }
@@ -998,7 +997,6 @@ class StitchedSchemaExecutionTest {
             query("remote1") {
                 resolver { -> "dummy" }
             }
-            enum<RemoteEnum>()
             mutation("objectMutation") {
                 resolver { input: Remote1 -> input.copy(foo1 = "${input.foo1}-processed") }
             }
@@ -1189,7 +1187,6 @@ class StitchedSchemaExecutionTest {
         )
 
         fun SchemaBuilder.remoteSchema1WithVariables() = run {
-            enum<RemoteEnum>()
             query("getBoolean") {
                 resolver { toGet: Boolean -> toGet }
             }
@@ -1927,7 +1924,6 @@ class StitchedSchemaExecutionTest {
     @Test
     fun `schema with stitched enum extension properties from parent should work as expected`() = testApplication {
         fun SchemaBuilder.remote1Schema() = run {
-            enum<RemoteEnum>()
             query("remote1") {
                 resolver { enum: RemoteEnum -> enum }
             }
@@ -1936,7 +1932,6 @@ class StitchedSchemaExecutionTest {
         data class Remote2TypeWithEnum(val localEnum: RemoteEnum)
 
         fun SchemaBuilder.remote2Schema() = run {
-            enum<RemoteEnum>()
             query("remote2") {
                 resolver { enum: RemoteEnum -> Remote2TypeWithEnum(enum) }
             }

--- a/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/structure/StitchedSchemaTest.kt
+++ b/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/structure/StitchedSchemaTest.kt
@@ -136,7 +136,6 @@ class StitchedSchemaTest {
                     type<RemoteType2> {
                         description = "Second Remote Type"
                     }
-                    enum<RemoteEnum> {}
                 }
             }
         }

--- a/kgraphql-ktor/src/test/kotlin/com/apurebase/kgraphql/KtorFeatureTest.kt
+++ b/kgraphql-ktor/src/test/kotlin/com/apurebase/kgraphql/KtorFeatureTest.kt
@@ -115,7 +115,6 @@ class KtorFeatureTest : KtorTest() {
     @Test
     fun `Simple variables test`() {
         val server = withServer {
-            enum<MockEnum>()
             inputType<InputTwo>()
             query("test") { resolver { input: InputTwo -> "success: $input" } }
         }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/demo/StarWarsSchema.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/demo/StarWarsSchema.kt
@@ -58,8 +58,6 @@ suspend fun main() {
 
         type<Droid>()
         type<Human>()
-
-        enum<Episode>()
     }
 
     println(schema.execute("{hero(episode: JEDI){id, name, ... on Droid{primaryFunction} ... on Human{height}}}"))

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/EnumTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/EnumTest.kt
@@ -31,7 +31,6 @@ class EnumTest : BaseSchemaTest() {
             configure {
                 wrapErrors = false
             }
-            enum<FilmType>()
             query("search") {
                 description = "film categorized by type"
                 resolver { types: List<FilmType> ->

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaBuilderTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaBuilderTest.kt
@@ -280,7 +280,20 @@ class SchemaBuilderTest {
     }
 
     @Test
-    fun `custom type name`() {
+    fun `enums should be recognized automatically`() {
+        val schema = defaultSchema {
+            query("actor") {
+                resolver { type: FilmType -> Actor("Boguś Linda $type", 4343) }
+            }
+        }
+
+        val result =
+            deserialize(schema.executeBlocking("query(\$type: FilmType = FULL_LENGTH){actor(type: \$type){name}}"))
+        result.extract<String>("data/actor/name") shouldBe "Boguś Linda FULL_LENGTH"
+    }
+
+    @Test
+    fun `enums should support a custom type name`() {
         val schema = defaultSchema {
             query("actor") {
                 resolver { type: FilmType -> Actor("Boguś Linda $type", 4343) }
@@ -292,7 +305,7 @@ class SchemaBuilderTest {
         }
 
         val result =
-            deserialize(schema.executeBlocking("query(\$type : TYPE = FULL_LENGTH){actor(type: \$type){name}}"))
+            deserialize(schema.executeBlocking("query(\$type: TYPE = FULL_LENGTH){actor(type: \$type){name}}"))
         result.extract<String>("data/actor/name") shouldBe "Boguś Linda FULL_LENGTH"
     }
 

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaPrinterTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaPrinterTest.kt
@@ -428,8 +428,6 @@ class SchemaPrinterTest {
     @Test
     fun `schema with default values should be printed as expected`() {
         val schema = KGraphQL.schema {
-            enum<TestEnum>()
-
             query("getStringWithDefault") {
                 resolver { type: TestEnum, string: String -> type.name + string }.withArgs {
                     arg<TestEnum> { name = "type"; defaultValue = TestEnum.TYPE1 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/introspection/IntrospectionSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/introspection/IntrospectionSpecificationTest.kt
@@ -94,8 +94,6 @@ class IntrospectionSpecificationTest {
     @Test
     fun `__typename field cannot be used on enums`() {
         val schema = defaultSchema {
-            enum<SampleEnum>()
-
             query("sample") {
                 resolver { -> EnumData(SampleEnum.VALUE) }
             }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/InputValuesSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/InputValuesSpecificationTest.kt
@@ -25,7 +25,6 @@ class InputValuesSpecificationTest {
     data class FakeData(val number: Int = 0, val description: String = "", val list: List<String> = emptyList())
 
     val schema = defaultSchema {
-        enum<FakeEnum>()
         inputType<FakeData>()
 
         query("Int") { resolver { value: Int -> value } }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/InputObjectsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/InputObjectsSpecificationTest.kt
@@ -26,7 +26,6 @@ class InputObjectsSpecificationTest {
     private val objectMapper = jacksonObjectMapper()
 
     val schema = KGraphQL.schema {
-        enum<MockEnum>()
         inputType<InputTwo>()
         query("test") { resolver { input: InputTwo -> "success: $input" } }
     }


### PR DESCRIPTION
Previously, enums had to be manually added to a schema using `enum<Class>()`, e.g.

```
schema {
    enum<FilmType>()
    query("getEnum") {
        resolver { -> FilmType.FULL_LENGTH }
    }
}
```

This was a non-intuitive source of errors that especially new users were facing.

Now, enums are handled automatically, so the following definition is now valid:

```
schema {
    query("getEnum") {
        resolver { -> FilmType.FULL_LENGTH }
    }
}
```

Resolves #253