### PR TITLE
test: use `runTest` of coroutines.test instead of `runBlocking`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,3 +16,7 @@ end_of_line = crlf
 
 [*.{md,mdx}]
 trim_trailing_whitespace = false
+
+[*.{kt,kts}]
+ij_kotlin_name_count_to_use_star_import = 999
+ij_kotlin_name_count_to_use_star_import_for_members = 999

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,7 @@ ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
 ktor-server-auth = { module = "io.ktor:ktor-server-auth", version.ref = "ktor" }
 ktor-server-test-host = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor" }
 kotest = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
-junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit-jupiter" }
+junit-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-jupiter" }
+junit-jupiter-core = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit-jupiter" }
 kotlinx-benchmark-runtime = { module = "org.jetbrains.kotlinx:kotlinx-benchmark-runtime", version.ref = "kotlinx-benchmark" }

--- a/kgraphql-ktor-stitched/build.gradle.kts
+++ b/kgraphql-ktor-stitched/build.gradle.kts
@@ -15,8 +15,9 @@ dependencies {
     implementation(libs.ktor.client.cio)
     implementation(libs.kotlinx.serialization.json)
 
-    testImplementation(libs.junit.jupiter.api)
+    testImplementation(libs.junit.jupiter.core)
     testImplementation(libs.kotest)
     testImplementation(libs.ktor.server.test.host)
     testImplementation(testFixtures(project(":kgraphql")))
+    testRuntimeOnly(libs.junit.launcher)
 }

--- a/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/execution/StitchedSchemaExecutionTest.kt
+++ b/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/execution/StitchedSchemaExecutionTest.kt
@@ -2851,7 +2851,7 @@ class StitchedSchemaExecutionTest {
     }
 
     @Test
-    suspend fun `errors from remote execution should be propagated correctly`() = testApplication {
+    fun `errors from remote execution should be propagated correctly`() = testApplication {
         fun SchemaBuilder.remoteSchema() = run {
             query("failRemote") {
                 resolver<String> {

--- a/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/execution/StitchedSchemaExecutionTest.kt
+++ b/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/execution/StitchedSchemaExecutionTest.kt
@@ -2851,7 +2851,7 @@ class StitchedSchemaExecutionTest {
     }
 
     @Test
-    fun `errors from remote execution should be propagated correctly`() = testApplication {
+    suspend fun `errors from remote execution should be propagated correctly`() = testApplication {
         fun SchemaBuilder.remoteSchema() = run {
             query("failRemote") {
                 resolver<String> {

--- a/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/structure/IntrospectedSchemaTest.kt
+++ b/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/structure/IntrospectedSchemaTest.kt
@@ -4,6 +4,7 @@ import com.apurebase.kgraphql.KGraphQL
 import com.apurebase.kgraphql.request.Introspection
 import com.apurebase.kgraphql.schema.SchemaPrinter
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 class IntrospectedSchemaTest {
@@ -15,7 +16,7 @@ class IntrospectedSchemaTest {
     }
 
     @Test
-    suspend fun `introspected schema should result in the same SDL as the schema itself`() {
+    fun `introspected schema should result in the same SDL as the schema itself`() = runTest {
         val schema = KGraphQL.schema {
             extendedScalars()
 

--- a/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/structure/IntrospectedSchemaTest.kt
+++ b/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/structure/IntrospectedSchemaTest.kt
@@ -15,7 +15,7 @@ class IntrospectedSchemaTest {
     }
 
     @Test
-    fun `introspected schema should result in the same SDL as the schema itself`() {
+    suspend fun `introspected schema should result in the same SDL as the schema itself`() {
         val schema = KGraphQL.schema {
             extendedScalars()
 
@@ -32,7 +32,7 @@ class IntrospectedSchemaTest {
         }
 
         val schemaFromIntrospection = IntrospectedSchema.fromIntrospectionResponse(
-            schema.executeBlocking(Introspection.query())
+            schema.execute(Introspection.query())
         )
 
         SchemaPrinter().print(schemaFromIntrospection) shouldBe SchemaPrinter().print(schema)

--- a/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/structure/StitchedSchemaTest.kt
+++ b/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/structure/StitchedSchemaTest.kt
@@ -16,6 +16,7 @@ import com.apurebase.kgraphql.stitched.schema.configuration.StitchedSchemaConfig
 import com.apurebase.kgraphql.stitched.schema.execution.RemoteRequestExecutor
 import com.fasterxml.jackson.databind.JsonNode
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import java.util.Locale
 import java.util.UUID
@@ -77,7 +78,7 @@ class StitchedSchemaTest {
     }
 
     @Test
-    suspend fun `stitched schema should skip duplicate types by name and prefer local types`() {
+    fun `stitched schema should skip duplicate types by name and prefer local types`() = runTest {
         val schema = StitchedKGraphQL.stitchedSchema {
             configure {
                 remoteExecutor = DummyRemoteRequestExecutor
@@ -113,7 +114,7 @@ class StitchedSchemaTest {
     }
 
     @Test
-    suspend fun `stitched schema should include local and remote types with proper fields`() {
+    fun `stitched schema should include local and remote types with proper fields`() = runTest {
         val schema = StitchedKGraphQL.stitchedSchema {
             configure {
                 remoteExecutor = DummyRemoteRequestExecutor
@@ -174,7 +175,7 @@ class StitchedSchemaTest {
     }
 
     @Test
-    suspend fun `stitched schema should include union types with proper possible types`() {
+    fun `stitched schema should include union types with proper possible types`() = runTest {
         val schema = StitchedKGraphQL.stitchedSchema {
             configure {
                 remoteExecutor = DummyRemoteRequestExecutor
@@ -214,7 +215,7 @@ class StitchedSchemaTest {
     }
 
     @Test
-    suspend fun `stitched schema should include all local and remote queries`() {
+    fun `stitched schema should include all local and remote queries`() = runTest {
         val schema = StitchedKGraphQL.stitchedSchema {
             configure {
                 remoteExecutor = DummyRemoteRequestExecutor
@@ -283,7 +284,7 @@ class StitchedSchemaTest {
     }
 
     @Test
-    suspend fun `stitched schema should include all local and remote mutations`() {
+    fun `stitched schema should include all local and remote mutations`() = runTest {
         val schema = StitchedKGraphQL.stitchedSchema {
             configure {
                 remoteExecutor = DummyRemoteRequestExecutor
@@ -351,7 +352,7 @@ class StitchedSchemaTest {
     }
 
     @Test
-    suspend fun `schema with remote input types should be printed as expected`() {
+    fun `schema with remote input types should be printed as expected`() = runTest {
         data class TestObject(val name: String)
 
         val schema = StitchedKGraphQL.stitchedSchema {
@@ -394,7 +395,7 @@ class StitchedSchemaTest {
     }
 
     @Test
-    suspend fun `schema with remote extension properties should be printed as expected`() {
+    fun `schema with remote extension properties should be printed as expected`() = runTest {
         data class TestObject(val name: String)
 
         val schema = StitchedKGraphQL.stitchedSchema {
@@ -440,7 +441,7 @@ class StitchedSchemaTest {
     }
 
     @Test
-    suspend fun `schema with deprecated remote fields should be printed as expected`() {
+    fun `schema with deprecated remote fields should be printed as expected`() = runTest {
         data class TestObject(val name: String)
 
         val schema = StitchedKGraphQL.stitchedSchema {
@@ -489,7 +490,7 @@ class StitchedSchemaTest {
     class Face(override val value: String, override val value2: Boolean = false) : InterInter
 
     @Test
-    suspend fun `schema with remote interfaces should be printed as expected`() {
+    fun `schema with remote interfaces should be printed as expected`() = runTest {
         val schema = StitchedKGraphQL.stitchedSchema {
             configure {
                 remoteExecutor = DummyRemoteRequestExecutor
@@ -655,7 +656,7 @@ class StitchedSchemaTest {
 
     // TODO: make configurable? this doesn't seem like *always* intended
     @Test
-    suspend fun `stitched operations should include optional input arguments`() {
+    fun `stitched operations should include optional input arguments`() = runTest {
         data class SimpleClass(val existing: String)
 
         val schema = StitchedKGraphQL.stitchedSchema {

--- a/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/structure/StitchedSchemaTest.kt
+++ b/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/structure/StitchedSchemaTest.kt
@@ -41,13 +41,13 @@ class StitchedSchemaTest {
      * Executes the default introspection query against this [Schema] and returns it
      * as parsed [IntrospectedSchema]
      */
-    private fun Schema.introspected(): IntrospectedSchema {
-        val introspectionResponse = executeBlocking(Introspection.query())
+    private suspend fun Schema.introspected(): IntrospectedSchema {
+        val introspectionResponse = execute(Introspection.query())
         return IntrospectedSchema.fromIntrospectionResponse(introspectionResponse)
     }
 
     @Test
-    fun `stitched schema should allow to configure remote executor`() {
+    suspend fun `stitched schema should allow to configure remote executor`() {
         val customRemoteRequestExecutor = object : RemoteRequestExecutor {
             override suspend fun execute(node: Execution.Remote, ctx: Context): JsonNode? {
                 return null
@@ -77,7 +77,7 @@ class StitchedSchemaTest {
     }
 
     @Test
-    fun `stitched schema should skip duplicate types by name and prefer local types`() {
+    suspend fun `stitched schema should skip duplicate types by name and prefer local types`() {
         val schema = StitchedKGraphQL.stitchedSchema {
             configure {
                 remoteExecutor = DummyRemoteRequestExecutor
@@ -113,7 +113,7 @@ class StitchedSchemaTest {
     }
 
     @Test
-    fun `stitched schema should include local and remote types with proper fields`() {
+    suspend fun `stitched schema should include local and remote types with proper fields`() {
         val schema = StitchedKGraphQL.stitchedSchema {
             configure {
                 remoteExecutor = DummyRemoteRequestExecutor
@@ -174,7 +174,7 @@ class StitchedSchemaTest {
     }
 
     @Test
-    fun `stitched schema should include union types with proper possible types`() {
+    suspend fun `stitched schema should include union types with proper possible types`() {
         val schema = StitchedKGraphQL.stitchedSchema {
             configure {
                 remoteExecutor = DummyRemoteRequestExecutor
@@ -214,7 +214,7 @@ class StitchedSchemaTest {
     }
 
     @Test
-    fun `stitched schema should include all local and remote queries`() {
+    suspend fun `stitched schema should include all local and remote queries`() {
         val schema = StitchedKGraphQL.stitchedSchema {
             configure {
                 remoteExecutor = DummyRemoteRequestExecutor
@@ -283,7 +283,7 @@ class StitchedSchemaTest {
     }
 
     @Test
-    fun `stitched schema should include all local and remote mutations`() {
+    suspend fun `stitched schema should include all local and remote mutations`() {
         val schema = StitchedKGraphQL.stitchedSchema {
             configure {
                 remoteExecutor = DummyRemoteRequestExecutor
@@ -351,7 +351,7 @@ class StitchedSchemaTest {
     }
 
     @Test
-    fun `schema with remote input types should be printed as expected`() {
+    suspend fun `schema with remote input types should be printed as expected`() {
         data class TestObject(val name: String)
 
         val schema = StitchedKGraphQL.stitchedSchema {
@@ -394,7 +394,7 @@ class StitchedSchemaTest {
     }
 
     @Test
-    fun `schema with remote extension properties should be printed as expected`() {
+    suspend fun `schema with remote extension properties should be printed as expected`() {
         data class TestObject(val name: String)
 
         val schema = StitchedKGraphQL.stitchedSchema {
@@ -440,7 +440,7 @@ class StitchedSchemaTest {
     }
 
     @Test
-    fun `schema with deprecated remote fields should be printed as expected`() {
+    suspend fun `schema with deprecated remote fields should be printed as expected`() {
         data class TestObject(val name: String)
 
         val schema = StitchedKGraphQL.stitchedSchema {
@@ -489,7 +489,7 @@ class StitchedSchemaTest {
     class Face(override val value: String, override val value2: Boolean = false) : InterInter
 
     @Test
-    fun `schema with remote interfaces should be printed as expected`() {
+    suspend fun `schema with remote interfaces should be printed as expected`() {
         val schema = StitchedKGraphQL.stitchedSchema {
             configure {
                 remoteExecutor = DummyRemoteRequestExecutor
@@ -655,7 +655,7 @@ class StitchedSchemaTest {
 
     // TODO: make configurable? this doesn't seem like *always* intended
     @Test
-    fun `stitched operations should include optional input arguments`() {
+    suspend fun `stitched operations should include optional input arguments`() {
         data class SimpleClass(val existing: String)
 
         val schema = StitchedKGraphQL.stitchedSchema {
@@ -715,7 +715,7 @@ class StitchedSchemaTest {
         SchemaPrinter().print(schema) shouldBe expectedSDL
         SchemaPrinter().print(schema.introspected()) shouldBe expectedSDL
 
-        schema.executeBlocking(
+        schema.execute(
             """
             {
               __type(name: "SimpleClass") { name kind fields { name } }

--- a/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/structure/StitchedSchemaTest.kt
+++ b/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/structure/StitchedSchemaTest.kt
@@ -47,7 +47,7 @@ class StitchedSchemaTest {
     }
 
     @Test
-    suspend fun `stitched schema should allow to configure remote executor`() {
+    fun `stitched schema should allow to configure remote executor`() {
         val customRemoteRequestExecutor = object : RemoteRequestExecutor {
             override suspend fun execute(node: Execution.Remote, ctx: Context): JsonNode? {
                 return null

--- a/kgraphql-ktor/build.gradle.kts
+++ b/kgraphql-ktor/build.gradle.kts
@@ -10,8 +10,9 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.ktor.server.core)
 
-    testImplementation(libs.junit.jupiter.api)
+    testImplementation(libs.junit.jupiter.core)
     testImplementation(libs.kotest)
     testImplementation(libs.ktor.server.test.host)
     testImplementation(libs.ktor.server.auth)
+    testRuntimeOnly(libs.junit.launcher)
 }

--- a/kgraphql-ktor/build.gradle.kts
+++ b/kgraphql-ktor/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     implementation(libs.ktor.server.core)
 
     testImplementation(libs.junit.jupiter.core)
+    testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.kotest)
     testImplementation(libs.ktor.server.test.host)
     testImplementation(libs.ktor.server.auth)

--- a/kgraphql-ktor/src/test/kotlin/com/apurebase/kgraphql/KtorFeatureTest.kt
+++ b/kgraphql-ktor/src/test/kotlin/com/apurebase/kgraphql/KtorFeatureTest.kt
@@ -6,6 +6,7 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.server.application.ApplicationCall
+import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.add
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
@@ -17,7 +18,7 @@ class KtorFeatureTest : KtorTest() {
     data class User(val id: Int = -1, val name: String = "")
 
     @Test
-    suspend fun `Simple query test`() {
+    fun `Simple query test`() = runTest {
         val server = withServer {
             query("hello") {
                 resolver { -> "World!" }
@@ -33,7 +34,7 @@ class KtorFeatureTest : KtorTest() {
     }
 
     @Test
-    suspend fun `Simple mutation test`() {
+    fun `Simple mutation test`() = runTest {
         val server = withServer {
             query("dummy") {
                 resolver { -> "dummy" }
@@ -55,7 +56,7 @@ class KtorFeatureTest : KtorTest() {
     data class UserData(val username: String, val stuff: String)
 
     @Test
-    suspend fun `Simple context test`() {
+    fun `Simple context test`() = runTest {
         val georgeName = "George"
         val contextSetup: ContextBuilder.(ApplicationCall) -> Unit = { _ ->
             +UserData(georgeName, "STUFF")
@@ -106,7 +107,7 @@ class KtorFeatureTest : KtorTest() {
     data class InputTwo(val one: InputOne, val quantity: Int, val tokens: List<String>)
 
     @Test
-    suspend fun `Simple variables test`() {
+    fun `Simple variables test`() = runTest {
         val server = withServer {
             inputType<InputTwo>()
             query("test") { resolver { input: InputTwo -> "success: $input" } }
@@ -134,7 +135,7 @@ class KtorFeatureTest : KtorTest() {
     }
 
     @Test
-    suspend fun `Error response test`() {
+    fun `Error response test`() = runTest {
         val server = withServer {
             query("actor") {
                 resolver { -> Actor("George", 23) }

--- a/kgraphql/build.gradle.kts
+++ b/kgraphql/build.gradle.kts
@@ -39,10 +39,11 @@ dependencies {
     implementation(libs.aedile)
 
     testImplementation(libs.kotest)
-    testImplementation(libs.junit.jupiter.api)
+    testImplementation(libs.junit.jupiter.core)
     testImplementation(libs.junit.jupiter.params)
     testImplementation(libs.kotlinx.coroutines.debug)
     testImplementation(libs.kotlinx.coroutines.test)
+    testRuntimeOnly(libs.junit.launcher)
 
     testFixturesImplementation(libs.kotest)
 

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/TestUtils.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/TestUtils.kt
@@ -47,9 +47,9 @@ fun assertNoErrors(map: Map<*, *>) {
     if (map["data"] == null) throw AssertionError("Data is null")
 }
 
-fun executeEqualQueries(schema: Schema, expected: Map<*, *>, vararg queries: String) {
+suspend fun executeEqualQueries(schema: Schema, expected: Map<*, *>, vararg queries: String) {
     queries.map { request ->
-        schema.executeBlocking(request).deserialize()
+        schema.execute(request).deserialize()
     }.forAll { map ->
         map shouldBe expected
     }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/access/AccessRulesTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/access/AccessRulesTest.kt
@@ -38,32 +38,32 @@ class AccessRulesTest {
     }
 
     @Test
-    fun `allow when matching`() {
+    suspend fun `allow when matching`() {
         val kobe = deserialize(
-            schema.executeBlocking("{black_mamba{name}}", context = context { +"LAKERS" })
+            schema.execute("{black_mamba{name}}", context = context { +"LAKERS" })
         ).extract<String>("data/black_mamba/name")
 
         kobe shouldBe "KOBE"
     }
 
     @Test
-    fun `reject when not matching`() {
+    suspend fun `reject when not matching`() {
         expect<IllegalAccessException>("ILLEGAL ACCESS") {
             deserialize(
-                schema.executeBlocking("{ black_mamba {id} }", context = context { +"LAKERS" })
+                schema.execute("{ black_mamba {id} }", context = context { +"LAKERS" })
             ).extract<String>("data/black_mamba/id")
         }
     }
 
     @Test
-    fun `allow property resolver access rule`() {
-        deserialize(schema.executeBlocking("{white_mamba {item}}")).extract<String>("data/white_mamba/item") shouldBe "item"
+    suspend fun `allow property resolver access rule`() {
+        deserialize(schema.execute("{white_mamba {item}}")).extract<String>("data/white_mamba/item") shouldBe "item"
     }
 
     @Test
-    fun `reject property resolver access rule`() {
+    suspend fun `reject property resolver access rule`() {
         expect<IllegalAccessException>("ILLEGAL ACCESS") {
-            schema.executeBlocking("{black_mamba {item}}", context = context { +"LAKERS" }).also(::println)
+            schema.execute("{black_mamba {item}}", context = context { +"LAKERS" }).also(::println)
         }
     }
 

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/access/AccessRulesTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/access/AccessRulesTest.kt
@@ -7,6 +7,7 @@ import com.apurebase.kgraphql.deserialize
 import com.apurebase.kgraphql.expect
 import com.apurebase.kgraphql.extract
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 class AccessRulesTest {
@@ -38,7 +39,7 @@ class AccessRulesTest {
     }
 
     @Test
-    suspend fun `allow when matching`() {
+    fun `allow when matching`() = runTest {
         val kobe = deserialize(
             schema.execute("{black_mamba{name}}", context = context { +"LAKERS" })
         ).extract<String>("data/black_mamba/name")
@@ -47,7 +48,7 @@ class AccessRulesTest {
     }
 
     @Test
-    suspend fun `reject when not matching`() {
+    fun `reject when not matching`() = runTest {
         expect<IllegalAccessException>("ILLEGAL ACCESS") {
             deserialize(
                 schema.execute("{ black_mamba {id} }", context = context { +"LAKERS" })
@@ -56,12 +57,12 @@ class AccessRulesTest {
     }
 
     @Test
-    suspend fun `allow property resolver access rule`() {
+    fun `allow property resolver access rule`() = runTest {
         deserialize(schema.execute("{white_mamba {item}}")).extract<String>("data/white_mamba/item") shouldBe "item"
     }
 
     @Test
-    suspend fun `reject property resolver access rule`() {
+    fun `reject property resolver access rule`() = runTest {
         expect<IllegalAccessException>("ILLEGAL ACCESS") {
             schema.execute("{black_mamba {item}}", context = context { +"LAKERS" }).also(::println)
         }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/configuration/SchemaConfigurationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/configuration/SchemaConfigurationTest.kt
@@ -5,13 +5,14 @@ import com.apurebase.kgraphql.ValidationException
 import com.apurebase.kgraphql.defaultSchema
 import com.apurebase.kgraphql.expect
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
 class SchemaConfigurationTest {
     @ParameterizedTest
     @ValueSource(booleans = [true, false])
-    suspend fun `execution result should be the same with and without caching`(withCaching: Boolean) {
+    fun `execution result should be the same with and without caching`(withCaching: Boolean) = runTest {
         val schema = schema {
             configure {
                 useCachingDocumentParser = withCaching
@@ -28,7 +29,7 @@ class SchemaConfigurationTest {
 
     @ParameterizedTest
     @ValueSource(booleans = [true, false])
-    suspend fun `execution result should use pretty printing if configured`(withPrettyPrinter: Boolean) {
+    fun `execution result should use pretty printing if configured`(withPrettyPrinter: Boolean) = runTest {
         val schema = schema {
             configure {
                 useDefaultPrettyPrinter = withPrettyPrinter
@@ -57,7 +58,7 @@ class SchemaConfigurationTest {
 
     @ParameterizedTest
     @ValueSource(booleans = [true, false])
-    suspend fun `introspections should be allowed depending on configuration`(introspectionAllowed: Boolean) {
+    fun `introspections should be allowed depending on configuration`(introspectionAllowed: Boolean) = runTest {
         val schema = defaultSchema {
             configure {
                 introspection = introspectionAllowed

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/configuration/SchemaConfigurationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/configuration/SchemaConfigurationTest.kt
@@ -11,7 +11,7 @@ import org.junit.jupiter.params.provider.ValueSource
 class SchemaConfigurationTest {
     @ParameterizedTest
     @ValueSource(booleans = [true, false])
-    fun `execution result should be the same with and without caching`(withCaching: Boolean) {
+    suspend fun `execution result should be the same with and without caching`(withCaching: Boolean) {
         val schema = schema {
             configure {
                 useCachingDocumentParser = withCaching
@@ -21,14 +21,14 @@ class SchemaConfigurationTest {
             }
         }
 
-        schema.executeBlocking("{ hello }") shouldBe """
+        schema.execute("{ hello }") shouldBe """
             {"data":{"hello":"world"}}
         """.trimIndent()
     }
 
     @ParameterizedTest
     @ValueSource(booleans = [true, false])
-    fun `execution result should use pretty printing if configured`(withPrettyPrinter: Boolean) {
+    suspend fun `execution result should use pretty printing if configured`(withPrettyPrinter: Boolean) {
         val schema = schema {
             configure {
                 useDefaultPrettyPrinter = withPrettyPrinter
@@ -52,12 +52,12 @@ class SchemaConfigurationTest {
             """.trimIndent()
         }
 
-        schema.executeBlocking("{ hello }") shouldBe expected
+        schema.execute("{ hello }") shouldBe expected
     }
 
     @ParameterizedTest
     @ValueSource(booleans = [true, false])
-    fun `introspections should be allowed depending on configuration`(introspectionAllowed: Boolean) {
+    suspend fun `introspections should be allowed depending on configuration`(introspectionAllowed: Boolean) {
         val schema = defaultSchema {
             configure {
                 introspection = introspectionAllowed
@@ -68,12 +68,12 @@ class SchemaConfigurationTest {
         }
 
         if (introspectionAllowed) {
-            schema.executeBlocking("{ __schema { queryType { name } } }") shouldBe """
+            schema.execute("{ __schema { queryType { name } } }") shouldBe """
                 {"data":{"__schema":{"queryType":{"name":"Query"}}}}
             """.trimIndent()
         } else {
             expect<ValidationException>("GraphQL introspection is not allowed") {
-                schema.executeBlocking("{ __schema { queryType { name } } }")
+                schema.execute("{ __schema { queryType { name } } }")
             }
         }
     }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/BaseSchemaTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/BaseSchemaTest.kt
@@ -293,12 +293,12 @@ abstract class BaseSchemaTest {
     @AfterEach
     fun cleanup() = createdActors.clear()
 
-    fun execute(
+    suspend fun execute(
         query: String,
         variables: String? = null,
         context: Context = Context(emptyMap()),
         operationName: String? = null,
     ) = testedSchema
-        .executeBlocking(query, variables, context, operationName)
+        .execute(query, variables, context, operationName)
         .deserialize()
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/DataLoaderExecutionTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/DataLoaderExecutionTest.kt
@@ -69,9 +69,9 @@ class DataLoaderExecutionTest {
     }
 
     @Test
-    fun `stress test with dataloaders and custom supervisor jobs`() {
+    suspend fun `stress test with dataloaders and custom supervisor jobs`() {
         val result = deserialize(
-            schema.executeBlocking(
+            schema.execute(
                 """
                  {
                      data1: items(amount: 250) { ...Fields }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/DataLoaderExecutionTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/DataLoaderExecutionTest.kt
@@ -6,6 +6,7 @@ import com.apurebase.kgraphql.extract
 import io.kotest.matchers.collections.shouldHaveSize
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
 import nidomiro.kdataloader.ExecutionResult
 import org.junit.jupiter.api.Test
 import kotlin.random.Random
@@ -69,7 +70,7 @@ class DataLoaderExecutionTest {
     }
 
     @Test
-    suspend fun `stress test with dataloaders and custom supervisor jobs`() {
+    fun `stress test with dataloaders and custom supervisor jobs`() = runTest {
         val result = deserialize(
             schema.execute(
                 """

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/EnumTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/EnumTest.kt
@@ -11,14 +11,14 @@ import org.junit.jupiter.api.Test
 class EnumTest : BaseSchemaTest() {
 
     @Test
-    fun `query with enum field`() {
+    suspend fun `query with enum field`() {
         val map = execute("{film{type}}")
         assertNoErrors(map)
         map.extract<String>("data/film/type") shouldBe "FULL_LENGTH"
     }
 
     @Test
-    fun `query with enum argument`() {
+    suspend fun `query with enum argument`() {
         val map = execute("{ films: filmsByType(type: FULL_LENGTH){title, type}}")
         assertNoErrors(map)
         map.extract<String>("data/films[0]/type") shouldBe "FULL_LENGTH"
@@ -26,7 +26,7 @@ class EnumTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `query with enum array variables`() {
+    suspend fun `query with enum array variables`() {
         val schema = defaultSchema {
             configure {
                 wrapErrors = false
@@ -39,7 +39,7 @@ class EnumTest : BaseSchemaTest() {
             }
         }
 
-        val map = schema.executeBlocking(
+        val map = schema.execute(
             request = "query Search(${'$'}types: [FilmType!]!) { search(types: ${'$'}types)}",
             variables = "{\"types\":[\"FULL_LENGTH\"]}"
         ).deserialize()

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/EnumTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/EnumTest.kt
@@ -6,19 +6,20 @@ import com.apurebase.kgraphql.defaultSchema
 import com.apurebase.kgraphql.deserialize
 import com.apurebase.kgraphql.extract
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 class EnumTest : BaseSchemaTest() {
 
     @Test
-    suspend fun `query with enum field`() {
+    fun `query with enum field`() = runTest {
         val map = execute("{film{type}}")
         assertNoErrors(map)
         map.extract<String>("data/film/type") shouldBe "FULL_LENGTH"
     }
 
     @Test
-    suspend fun `query with enum argument`() {
+    fun `query with enum argument`() = runTest {
         val map = execute("{ films: filmsByType(type: FULL_LENGTH){title, type}}")
         assertNoErrors(map)
         map.extract<String>("data/films[0]/type") shouldBe "FULL_LENGTH"
@@ -26,7 +27,7 @@ class EnumTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `query with enum array variables`() {
+    fun `query with enum array variables`() = runTest {
         val schema = defaultSchema {
             configure {
                 wrapErrors = false

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/FakeComplicatedDataLoad.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/FakeComplicatedDataLoad.kt
@@ -28,5 +28,4 @@ class FakeComplicatedDataLoad : CoroutineScope {
             "${cache1.get(delay to returnValue)}:${cache2.get(delay to returnValue)}"
         }.await()
     }
-
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/InputObjectTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/InputObjectTest.kt
@@ -4,13 +4,14 @@ import com.apurebase.kgraphql.KGraphQL
 import com.apurebase.kgraphql.expect
 import com.apurebase.kgraphql.schema.SchemaException
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 class InputObjectTest {
     data class Person(val name: String, val age: Int)
 
     @Test
-    suspend fun `property name should default to Kotlin name`() {
+    fun `property name should default to Kotlin name`() = runTest {
         val schema = KGraphQL.schema {
             query("getPerson") {
                 resolver { name: String -> Person(name = name, age = 42) }
@@ -79,7 +80,7 @@ class InputObjectTest {
     }
 
     @Test
-    suspend fun `property name should be configurable`() {
+    fun `property name should be configurable`() = runTest {
         val schema = KGraphQL.schema {
             inputType<Person> {
                 name = "PersonInput"

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/InputObjectTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/InputObjectTest.kt
@@ -10,7 +10,7 @@ class InputObjectTest {
     data class Person(val name: String, val age: Int)
 
     @Test
-    fun `property name should default to Kotlin name`() {
+    suspend fun `property name should default to Kotlin name`() {
         val schema = KGraphQL.schema {
             query("getPerson") {
                 resolver { name: String -> Person(name = name, age = 42) }
@@ -43,7 +43,7 @@ class InputObjectTest {
             
         """.trimIndent()
 
-        schema.executeBlocking(
+        schema.execute(
             """
             query {
               getPerson(name: "foo") { name age }
@@ -53,7 +53,7 @@ class InputObjectTest {
             {"data":{"getPerson":{"name":"foo","age":42}}}
         """.trimIndent()
 
-        schema.executeBlocking(
+        schema.execute(
             """
             mutation {
               addPerson(person: { name: "bar", age: 20 }) { name age }
@@ -66,7 +66,7 @@ class InputObjectTest {
         val variables = """
             { "person": { "name": "foobar", "age": 60 } }
         """.trimIndent()
-        schema.executeBlocking(
+        schema.execute(
             """
             mutation(${'$'}person: PersonInput!) {
               addPerson(person: ${'$'}person) { name age }
@@ -79,7 +79,7 @@ class InputObjectTest {
     }
 
     @Test
-    fun `property name should be configurable`() {
+    suspend fun `property name should be configurable`() {
         val schema = KGraphQL.schema {
             inputType<Person> {
                 name = "PersonInput"
@@ -122,7 +122,7 @@ class InputObjectTest {
             
         """.trimIndent()
 
-        schema.executeBlocking(
+        schema.execute(
             """
             query {
               getPerson(name: "foo") { name age }
@@ -132,7 +132,7 @@ class InputObjectTest {
             {"data":{"getPerson":{"name":"foo","age":42}}}
         """.trimIndent()
 
-        schema.executeBlocking(
+        schema.execute(
             """
             mutation {
               addPerson(person: { inputName: "bar", inputAge: 20 }) { name age }
@@ -145,7 +145,7 @@ class InputObjectTest {
         val variables = """
             { "person": { "inputName": "foobar", "inputAge": 60 } }
         """.trimIndent()
-        schema.executeBlocking(
+        schema.execute(
             """
             mutation(${'$'}person: PersonInput!) {
               addPerson(person: ${'$'}person) { name age }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/LongScalarTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/LongScalarTest.kt
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test
 class LongScalarTest {
 
     @Test
-    fun testLongField() {
+    suspend fun testLongField() {
         val schema = defaultSchema {
             extendedScalars()
             query("long") {
@@ -18,13 +18,13 @@ class LongScalarTest {
             }
         }
 
-        val response = schema.executeBlocking("{ long }")
+        val response = schema.execute("{ long }")
         val long = deserialize(response).extract<Long>("data/long")
         long shouldBe Long.MAX_VALUE
     }
 
     @Test
-    fun testLongArgument() {
+    suspend fun testLongArgument() {
         val schema = defaultSchema {
             extendedScalars()
             query("isLong") {
@@ -39,7 +39,7 @@ class LongScalarTest {
         }
 
         val isLong = deserialize(
-            schema.executeBlocking("{ isLong(long: ${Int.MAX_VALUE.toLong() + 1}) }")
+            schema.execute("{ isLong(long: ${Int.MAX_VALUE.toLong() + 1}) }")
         ).extract<String>("data/isLong")
         isLong shouldBe "YES"
     }
@@ -47,7 +47,7 @@ class LongScalarTest {
     data class VeryLong(val long: Long)
 
     @Test
-    fun `Schema may declare custom long scalar type`() {
+    suspend fun `Schema may declare custom long scalar type`() {
         val schema = KGraphQL.schema {
             longScalar<VeryLong> {
                 deserialize = ::VeryLong
@@ -60,7 +60,7 @@ class LongScalarTest {
         }
 
         val value = Int.MAX_VALUE.toLong() + 2
-        val response = deserialize(schema.executeBlocking("{ number(number: $value) }"))
+        val response = deserialize(schema.execute("{ number(number: $value) }"))
         response.extract<Long>("data/number") shouldBe value
     }
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/LongScalarTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/LongScalarTest.kt
@@ -5,12 +5,13 @@ import com.apurebase.kgraphql.defaultSchema
 import com.apurebase.kgraphql.deserialize
 import com.apurebase.kgraphql.extract
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 class LongScalarTest {
 
     @Test
-    suspend fun testLongField() {
+    fun testLongField() = runTest {
         val schema = defaultSchema {
             extendedScalars()
             query("long") {
@@ -24,7 +25,7 @@ class LongScalarTest {
     }
 
     @Test
-    suspend fun testLongArgument() {
+    fun testLongArgument() = runTest {
         val schema = defaultSchema {
             extendedScalars()
             query("isLong") {
@@ -47,7 +48,7 @@ class LongScalarTest {
     data class VeryLong(val long: Long)
 
     @Test
-    suspend fun `Schema may declare custom long scalar type`() {
+    fun `Schema may declare custom long scalar type`() = runTest {
         val schema = KGraphQL.schema {
             longScalar<VeryLong> {
                 deserialize = ::VeryLong

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/MutationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/MutationTest.kt
@@ -14,7 +14,7 @@ class MutationTest : BaseSchemaTest() {
     private val testActor = Actor("Michael Caine", 72)
 
     @Test
-    fun `simple mutation multiple fields`() {
+    suspend fun `simple mutation multiple fields`() {
         val map = execute("mutation {createActor(name: \"${testActor.name}\", age: ${testActor.age}){name, age}}")
         assertNoErrors(map)
         map.extract<Map<String, Any>>("data/createActor") shouldBe mapOf(
@@ -24,63 +24,63 @@ class MutationTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `simple mutation single field`() {
+    suspend fun `simple mutation single field`() {
         val map = execute("mutation {createActor(name: \"${testActor.name}\", age: ${testActor.age}){name}}")
         assertNoErrors(map)
         map.extract<Map<String, Any>>("data/createActor") shouldBe mapOf<String, Any>("name" to testActor.name)
     }
 
     @Test
-    fun `simple mutation single field 2`() {
+    suspend fun `simple mutation single field 2`() {
         val map = execute("mutation {createActor(name: \"${testActor.name}\", age: ${testActor.age}){age}}")
         assertNoErrors(map)
         map.extract<Map<String, Any>>("data/createActor") shouldBe mapOf<String, Any>("age" to testActor.age)
     }
 
     @Test
-    fun `invalid mutation name`() {
+    suspend fun `invalid mutation name`() {
         expect<ValidationException>("Property createBanana on Mutation does not exist") {
             execute("mutation {createBanana(name: \"${testActor.name}\", age: ${testActor.age}){age}}")
         }
     }
 
     @Test
-    fun `invalid argument type`() {
+    suspend fun `invalid argument type`() {
         expect<InvalidInputValueException>("Cannot coerce \"fwfwf\" to numeric constant") {
             execute("mutation {createActor(name: \"${testActor.name}\", age: \"fwfwf\"){age}}")
         }
     }
 
     @Test
-    fun `invalid arguments number`() {
+    suspend fun `invalid arguments number`() {
         expect<ValidationException>("createActor does support arguments [name, age]. Found arguments [name, age, bananan]") {
             execute("mutation {createActor(name: \"${testActor.name}\", age: ${testActor.age}, bananan: \"fwfwf\"){age}}")
         }
     }
 
     @Test
-    fun `invalid arguments number with NotIntrospected class`() {
+    suspend fun `invalid arguments number with NotIntrospected class`() {
         expect<ValidationException>("createActorWithContext does support arguments [name, age]. Found arguments [name, age, bananan]") {
             execute("mutation {createActorWithContext(name: \"${testActor.name}\", age: ${testActor.age}, bananan: \"fwfwf\"){age}}")
         }
     }
 
     @Test
-    fun `mutation with alias`() {
+    suspend fun `mutation with alias`() {
         val map = execute("mutation {caine : createActor(name: \"${testActor.name}\", age: ${testActor.age}){age}}")
         assertNoErrors(map)
         map.extract<Map<String, Any>>("data/caine") shouldBe mapOf<String, Any>("age" to testActor.age)
     }
 
     @Test
-    fun `mutation with field alias`() {
+    suspend fun `mutation with field alias`() {
         val map = execute("mutation {createActor(name: \"${testActor.name}\", age: ${testActor.age}){howOld: age}}")
         assertNoErrors(map)
         map.extract<Map<String, Any>>("data/createActor") shouldBe mapOf<String, Any>("howOld" to testActor.age)
     }
 
     @Test
-    fun `simple mutation with aliased input type`() {
+    suspend fun `simple mutation with aliased input type`() {
         val map = execute(
             "mutation(\$newActor: ActorInput!) { createActorWithAliasedInputType(newActor: \$newActor) {name}}",
             variables = "{\"newActor\": {\"name\": \"${testActor.name}\", \"age\": ${testActor.age}}}"

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/MutationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/MutationTest.kt
@@ -7,6 +7,7 @@ import com.apurebase.kgraphql.assertNoErrors
 import com.apurebase.kgraphql.expect
 import com.apurebase.kgraphql.extract
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 class MutationTest : BaseSchemaTest() {
@@ -14,7 +15,7 @@ class MutationTest : BaseSchemaTest() {
     private val testActor = Actor("Michael Caine", 72)
 
     @Test
-    suspend fun `simple mutation multiple fields`() {
+    fun `simple mutation multiple fields`() = runTest {
         val map = execute("mutation {createActor(name: \"${testActor.name}\", age: ${testActor.age}){name, age}}")
         assertNoErrors(map)
         map.extract<Map<String, Any>>("data/createActor") shouldBe mapOf(
@@ -24,63 +25,63 @@ class MutationTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `simple mutation single field`() {
+    fun `simple mutation single field`() = runTest {
         val map = execute("mutation {createActor(name: \"${testActor.name}\", age: ${testActor.age}){name}}")
         assertNoErrors(map)
         map.extract<Map<String, Any>>("data/createActor") shouldBe mapOf<String, Any>("name" to testActor.name)
     }
 
     @Test
-    suspend fun `simple mutation single field 2`() {
+    fun `simple mutation single field 2`() = runTest {
         val map = execute("mutation {createActor(name: \"${testActor.name}\", age: ${testActor.age}){age}}")
         assertNoErrors(map)
         map.extract<Map<String, Any>>("data/createActor") shouldBe mapOf<String, Any>("age" to testActor.age)
     }
 
     @Test
-    suspend fun `invalid mutation name`() {
+    fun `invalid mutation name`() = runTest {
         expect<ValidationException>("Property createBanana on Mutation does not exist") {
             execute("mutation {createBanana(name: \"${testActor.name}\", age: ${testActor.age}){age}}")
         }
     }
 
     @Test
-    suspend fun `invalid argument type`() {
+    fun `invalid argument type`() = runTest {
         expect<InvalidInputValueException>("Cannot coerce \"fwfwf\" to numeric constant") {
             execute("mutation {createActor(name: \"${testActor.name}\", age: \"fwfwf\"){age}}")
         }
     }
 
     @Test
-    suspend fun `invalid arguments number`() {
+    fun `invalid arguments number`() = runTest {
         expect<ValidationException>("createActor does support arguments [name, age]. Found arguments [name, age, bananan]") {
             execute("mutation {createActor(name: \"${testActor.name}\", age: ${testActor.age}, bananan: \"fwfwf\"){age}}")
         }
     }
 
     @Test
-    suspend fun `invalid arguments number with NotIntrospected class`() {
+    fun `invalid arguments number with NotIntrospected class`() = runTest {
         expect<ValidationException>("createActorWithContext does support arguments [name, age]. Found arguments [name, age, bananan]") {
             execute("mutation {createActorWithContext(name: \"${testActor.name}\", age: ${testActor.age}, bananan: \"fwfwf\"){age}}")
         }
     }
 
     @Test
-    suspend fun `mutation with alias`() {
+     fun `mutation with alias`() = runTest {
         val map = execute("mutation {caine : createActor(name: \"${testActor.name}\", age: ${testActor.age}){age}}")
         assertNoErrors(map)
         map.extract<Map<String, Any>>("data/caine") shouldBe mapOf<String, Any>("age" to testActor.age)
     }
 
     @Test
-    suspend fun `mutation with field alias`() {
+    fun `mutation with field alias`() = runTest {
         val map = execute("mutation {createActor(name: \"${testActor.name}\", age: ${testActor.age}){howOld: age}}")
         assertNoErrors(map)
         map.extract<Map<String, Any>>("data/createActor") shouldBe mapOf<String, Any>("howOld" to testActor.age)
     }
 
     @Test
-    suspend fun `simple mutation with aliased input type`() {
+    fun `simple mutation with aliased input type`() = runTest {
         val map = execute(
             "mutation(\$newActor: ActorInput!) { createActorWithAliasedInputType(newActor: \$newActor) {name}}",
             variables = "{\"newActor\": {\"name\": \"${testActor.name}\", \"age\": ${testActor.age}}}"

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/ObjectTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/ObjectTest.kt
@@ -10,7 +10,7 @@ class ObjectTest {
     data class Person(val name: String, val age: Int)
 
     @Test
-    fun `property name should default to Kotlin name`() {
+    suspend fun `property name should default to Kotlin name`() {
         val schema = KGraphQL.schema {
             query("getPerson") {
                 resolver { name: String -> Person(name = name, age = 42) }
@@ -30,7 +30,7 @@ class ObjectTest {
             
         """.trimIndent()
 
-        schema.executeBlocking(
+        schema.execute(
             """
             query {
               getPerson(name: "foo") { name age }
@@ -42,7 +42,7 @@ class ObjectTest {
     }
 
     @Test
-    fun `property name should be configurable`() {
+    suspend fun `property name should be configurable`() {
         val schema = KGraphQL.schema {
             type<Person> {
                 property(Person::age) {
@@ -71,7 +71,7 @@ class ObjectTest {
             
         """.trimIndent()
 
-        schema.executeBlocking(
+        schema.execute(
             """
             query {
               getPerson(name: "foo") { newName newAge }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/ObjectTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/ObjectTest.kt
@@ -4,13 +4,14 @@ import com.apurebase.kgraphql.KGraphQL
 import com.apurebase.kgraphql.expect
 import com.apurebase.kgraphql.schema.SchemaException
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 class ObjectTest {
     data class Person(val name: String, val age: Int)
 
     @Test
-    suspend fun `property name should default to Kotlin name`() {
+    fun `property name should default to Kotlin name`() = runTest {
         val schema = KGraphQL.schema {
             query("getPerson") {
                 resolver { name: String -> Person(name = name, age = 42) }
@@ -42,7 +43,7 @@ class ObjectTest {
     }
 
     @Test
-    suspend fun `property name should be configurable`() {
+    fun `property name should be configurable`() = runTest {
         val schema = KGraphQL.schema {
             type<Person> {
                 property(Person::age) {

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/ParallelExecutionTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/ParallelExecutionTest.kt
@@ -3,16 +3,32 @@ package com.apurebase.kgraphql.integration
 import com.apurebase.kgraphql.KGraphQL
 import com.apurebase.kgraphql.deserialize
 import com.apurebase.kgraphql.extract
-import io.kotest.matchers.longs.shouldBeLessThan
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.currentTime
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import kotlin.random.Random
-import kotlin.system.measureTimeMillis
 
 class ParallelExecutionTest {
 
     data class AType(val id: Int)
+
+    private fun suspendResolversSchema(dispatcher: CoroutineDispatcher) = KGraphQL.schema {
+        configure {
+            coroutineDispatcher = dispatcher
+        }
+        repeat(1000) {
+            query("automated_$it") {
+                resolver { ->
+                    delay(3)
+                    "$it"
+                }
+            }
+        }
+    }
 
     private val syncResolversSchema = KGraphQL.schema {
         repeat(1000) {
@@ -25,18 +41,10 @@ class ParallelExecutionTest {
         }
     }
 
-    private val suspendResolverSchema = KGraphQL.schema {
-        repeat(1000) {
-            query("automated_$it") {
-                resolver { ->
-                    delay(3)
-                    "$it"
-                }
-            }
+    private fun suspendPropertySchema(dispatcher: CoroutineDispatcher) = KGraphQL.schema {
+        configure {
+            coroutineDispatcher = dispatcher
         }
-    }
-
-    private val suspendPropertySchema = KGraphQL.schema {
         query("getAll") {
             resolver { -> (0..999).map { AType(it) } }
         }
@@ -55,9 +63,10 @@ class ParallelExecutionTest {
     private val query = "{\n" + (0..999).joinToString("") { "automated_${it}\n" } + " }"
 
     @Test
-    suspend fun `suspendable property resolvers`() {
+    fun `suspendable property resolvers`() = runTest {
         val query = "{getAll{id,children{id}}}"
-        val map = deserialize(suspendPropertySchema.execute(query))
+        val schema = suspendPropertySchema(this@runTest.coroutineContext[CoroutineDispatcher]!!)
+        val map = deserialize(schema.execute(query))
 
         map.extract<Int>("data/getAll[0]/id") shouldBe 0
         map.extract<Int>("data/getAll[500]/id") shouldBe 500
@@ -69,7 +78,7 @@ class ParallelExecutionTest {
     }
 
     @Test
-    suspend fun `1000 synchronous resolvers sleeping with Thread sleep`() {
+    fun `1000 synchronous resolvers sleeping with Thread sleep`() = runTest {
         val map = deserialize(syncResolversSchema.execute(query))
         map.extract<String>("data/automated_0") shouldBe "0"
         map.extract<String>("data/automated_271") shouldBe "271"
@@ -79,8 +88,9 @@ class ParallelExecutionTest {
     }
 
     @Test
-    suspend fun `1000 suspending resolvers sleeping with suspending delay`() {
-        val map = deserialize(suspendResolverSchema.execute(query))
+    fun `1000 suspending resolvers sleeping with suspending delay`() = runTest {
+        val schema = suspendResolversSchema(this@runTest.coroutineContext[CoroutineDispatcher]!!)
+        val map = deserialize(schema.execute(query))
         map.extract<String>("data/automated_0") shouldBe "0"
         map.extract<String>("data/automated_271") shouldBe "271"
         map.extract<String>("data/automated_314") shouldBe "314"
@@ -88,13 +98,11 @@ class ParallelExecutionTest {
         map.extract<String>("data/automated_999") shouldBe "999"
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
-    suspend fun `execution should run in parallel`() {
-        val duration = measureTimeMillis {
-            deserialize(syncResolversSchema.execute(query))
-        }
-        // syncResolversSchema has 1000 resolvers, each waiting for 3ms. Usually, execution
-        // takes about 300ms so if it takes 3s, we apparently ran sequentially.
-        duration shouldBeLessThan 3000
+    fun `execution should run in parallel`() = runTest {
+        val schema = suspendResolversSchema(this@runTest.coroutineContext[CoroutineDispatcher]!!)
+        deserialize(schema.execute(query))
+        currentTime shouldBe 3
     }
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/ParallelExecutionTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/ParallelExecutionTest.kt
@@ -55,9 +55,9 @@ class ParallelExecutionTest {
     private val query = "{\n" + (0..999).joinToString("") { "automated_${it}\n" } + " }"
 
     @Test
-    fun `suspendable property resolvers`() {
+    suspend fun `suspendable property resolvers`() {
         val query = "{getAll{id,children{id}}}"
-        val map = deserialize(suspendPropertySchema.executeBlocking(query))
+        val map = deserialize(suspendPropertySchema.execute(query))
 
         map.extract<Int>("data/getAll[0]/id") shouldBe 0
         map.extract<Int>("data/getAll[500]/id") shouldBe 500
@@ -69,8 +69,8 @@ class ParallelExecutionTest {
     }
 
     @Test
-    fun `1000 synchronous resolvers sleeping with Thread sleep`() {
-        val map = deserialize(syncResolversSchema.executeBlocking(query))
+    suspend fun `1000 synchronous resolvers sleeping with Thread sleep`() {
+        val map = deserialize(syncResolversSchema.execute(query))
         map.extract<String>("data/automated_0") shouldBe "0"
         map.extract<String>("data/automated_271") shouldBe "271"
         map.extract<String>("data/automated_314") shouldBe "314"
@@ -79,8 +79,8 @@ class ParallelExecutionTest {
     }
 
     @Test
-    fun `1000 suspending resolvers sleeping with suspending delay`() {
-        val map = deserialize(suspendResolverSchema.executeBlocking(query))
+    suspend fun `1000 suspending resolvers sleeping with suspending delay`() {
+        val map = deserialize(suspendResolverSchema.execute(query))
         map.extract<String>("data/automated_0") shouldBe "0"
         map.extract<String>("data/automated_271") shouldBe "271"
         map.extract<String>("data/automated_314") shouldBe "314"
@@ -89,9 +89,9 @@ class ParallelExecutionTest {
     }
 
     @Test
-    fun `execution should run in parallel`() {
+    suspend fun `execution should run in parallel`() {
         val duration = measureTimeMillis {
-            deserialize(syncResolversSchema.executeBlocking(query))
+            deserialize(syncResolversSchema.execute(query))
         }
         // syncResolversSchema has 1000 resolvers, each waiting for 3ms. Usually, execution
         // takes about 300ms so if it takes 3s, we apparently ran sequentially.

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/QueryTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/QueryTest.kt
@@ -11,11 +11,12 @@ import com.apurebase.kgraphql.schema.execution.Execution
 import io.kotest.assertions.throwables.shouldThrowExactly
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.throwable.shouldHaveMessage
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 class QueryTest : BaseSchemaTest() {
     @Test
-    suspend fun `query nested selection set`() {
+    fun `query nested selection set`() = runTest {
         val map = execute("{film{title, director{name, age}}}")
         assertNoErrors(map)
         map.extract<String>("data/film/title") shouldBe prestige.title
@@ -24,7 +25,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `query collection field`() {
+    fun `query collection field`() = runTest {
         val map = execute("{film{title, director{favActors{name, age}}}}")
         assertNoErrors(map)
         map.extract<Map<String, String>>("data/film/director/favActors[0]") shouldBe
@@ -35,28 +36,28 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `query scalar field`() {
+    fun `query scalar field`() = runTest {
         val map = execute("{film{id}}")
         assertNoErrors(map)
         map.extract<String>("data/film/id") shouldBe "${prestige.id.literal}:${prestige.id.numeric}"
     }
 
     @Test
-    suspend fun `query with selection set on collection`() {
+    fun `query with selection set on collection`() = runTest {
         val map = execute("{film{title, director{favActors{name}}}}")
         assertNoErrors(map)
         map.extract<Map<String, String>>("data/film/director/favActors[0]") shouldBe mapOf("name" to prestige.director.favActors[0].name)
     }
 
     @Test
-    suspend fun `query with selection set on collection 2`() {
+    fun `query with selection set on collection 2`() = runTest {
         val map = execute("{film{title, director{favActors{age}}}}")
         assertNoErrors(map)
         map.extract<Map<String, Int>>("data/film/director/favActors[0]") shouldBe mapOf("age" to prestige.director.favActors[0].age)
     }
 
     @Test
-    suspend fun `query with invalid field name`() {
+    fun `query with invalid field name`() = runTest {
         val exception = shouldThrowExactly<ValidationException> {
             execute("{film{title, director{name, favDish}}}")
         }
@@ -67,35 +68,35 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `query with argument`() {
+    fun `query with argument`() = runTest {
         val map = execute("{filmByRank(rank: 1){title}}")
         assertNoErrors(map)
         map.extract<String>("data/filmByRank/title") shouldBe "Prestige"
     }
 
     @Test
-    suspend fun `query with argument 2`() {
+    fun `query with argument 2`() = runTest {
         val map = execute("{filmByRank(rank: 2){title}}")
         assertNoErrors(map)
         map.extract<String>("data/filmByRank/title") shouldBe "Se7en"
     }
 
     @Test
-    suspend fun `query with alias`() {
+    fun `query with alias`() = runTest {
         val map = execute("{bestFilm: filmByRank(rank: 1){title}}")
         assertNoErrors(map)
         map.extract<String>("data/bestFilm/title") shouldBe "Prestige"
     }
 
     @Test
-    suspend fun `query with field alias`() {
+    fun `query with field alias`() = runTest {
         val map = execute("{filmByRank(rank: 2){fullTitle: title}}")
         assertNoErrors(map)
         map.extract<String>("data/filmByRank/fullTitle") shouldBe "Se7en"
     }
 
     @Test
-    suspend fun `query with multiple aliases`() {
+    fun `query with multiple aliases`() = runTest {
         val map = execute("{bestFilm: filmByRank(rank: 1){title}, secondBestFilm: filmByRank(rank: 2){title}}")
         assertNoErrors(map)
         map.extract<String>("data/bestFilm/title") shouldBe "Prestige"
@@ -103,7 +104,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `query with ignored property`() {
+    fun `query with ignored property`() = runTest {
         val exception = shouldThrowExactly<ValidationException> {
             execute("{scenario{author, content}}")
         }
@@ -114,7 +115,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `query with interface`() {
+    fun `query with interface`() = runTest {
         val map = execute("{randomPerson{name \n age}}")
         map.extract<Map<String, String>>("data/randomPerson") shouldBe
             mapOf(
@@ -124,7 +125,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `query with collection elements interface`() {
+    fun `query with collection elements interface`() = runTest {
         val map = execute("{people{name, age}}")
         map.extract<Map<String, String>>("data/people[0]") shouldBe
             mapOf(
@@ -134,7 +135,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `query extension property`() {
+    fun `query extension property`() = runTest {
         val map = execute("{actors{name, age, isOld}}")
         for (i in 0..4) {
             val isOld = map.extract<Boolean>("data/actors[$i]/isOld")
@@ -144,7 +145,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `query extension property with arguments`() {
+    fun `query extension property with arguments`() = runTest {
         val map = execute("{actors{name, picture(big: true)}}")
         for (i in 0..4) {
             val name = map.extract<String>("data/actors[$i]/name").replace(' ', '_')
@@ -153,7 +154,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `query extension property with optional argument`() {
+    fun `query extension property with optional argument`() = runTest {
         val map = execute("{actors{name, picture}}")
         for (i in 0..4) {
             val name = map.extract<String>("data/actors[$i]/name").replace(' ', '_')
@@ -162,7 +163,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `query extension property with optional annotated argument`() {
+    fun `query extension property with optional annotated argument`() = runTest {
         val map = execute("{actors{name, pictureWithArgs}}")
         for (i in 0..4) {
             val name = map.extract<String>("data/actors[$i]/name").replace(' ', '_')
@@ -171,25 +172,25 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `query with mandatory generic input type`() {
+    fun `query with mandatory generic input type`() = runTest {
         val map = execute("""{actorsByTags(tags: ["1", "2", "3"]){name}}""")
         assertNoErrors(map)
     }
 
     @Test
-    suspend fun `query with optional generic input type`() {
+    fun `query with optional generic input type`() = runTest {
         val map = execute("{actorsByTagsOptional{name}}")
         assertNoErrors(map)
     }
 
     @Test
-    suspend fun `query with nullable generic input type`() {
+    fun `query with nullable generic input type`() = runTest {
         val map = execute("{actorsByTagsNullable{name}}")
         assertNoErrors(map)
     }
 
     @Test
-    suspend fun `query with transformed property`() {
+    fun `query with transformed property`() = runTest {
         val map = execute("{scenario{id, content(uppercase: false)}}")
         map.extract<String>("data/scenario/content") shouldBe "Very long scenario"
 
@@ -198,7 +199,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `query with invalid field arguments`() {
+    fun `query with invalid field arguments`() = runTest {
         val exception = shouldThrowExactly<ValidationException> {
             execute("{scenario{id(uppercase: true), content}}")
         }
@@ -209,7 +210,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `query with external fragment`() {
+    fun `query with external fragment`() = runTest {
         val map = execute("{film{title, ...dir }} fragment dir on Film {director{name, age}}")
         assertNoErrors(map)
         map.extract<String>("data/film/title") shouldBe prestige.title
@@ -218,7 +219,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `query with nested external fragment`() {
+    fun `query with nested external fragment`() = runTest {
         val map = execute(
             """
             {
@@ -253,7 +254,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `query with two nested external fragments`() {
+    fun `query with two nested external fragments`() = runTest {
         val map = execute(
             """
             {
@@ -292,7 +293,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `query with two fragments`() {
+    fun `query with two fragments`() = runTest {
         val map = execute(
             """
             {
@@ -321,7 +322,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `query with two inline fragments`() {
+    fun `query with two inline fragments`() = runTest {
         val map = execute(
             """
             {
@@ -339,7 +340,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `query with typename and other property`() {
+    fun `query with typename and other property`() = runTest {
         data class FooChild(val barChild: String)
         data class Foo(val bar: String, val child: FooChild?)
 
@@ -411,7 +412,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `query with mixed selections`() {
+    fun `query with mixed selections`() = runTest {
         val map = execute(
             """
             {
@@ -436,7 +437,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `query with missing fragment type`() {
+    fun `query with missing fragment type`() = runTest {
         val exception = shouldThrowExactly<ValidationException> {
             execute(
                 """
@@ -457,7 +458,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `query with missing named fragment type`() {
+    fun `query with missing named fragment type`() = runTest {
         val exception = shouldThrowExactly<ValidationException> {
             execute(
                 """
@@ -476,7 +477,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `query with missing selection set`() {
+    fun `query with missing selection set`() = runTest {
         val exception = shouldThrowExactly<ValidationException> {
             execute("{film}")
         }
@@ -489,7 +490,7 @@ class QueryTest : BaseSchemaTest() {
     data class SampleNode(val id: Int, val name: String, val fields: List<String>? = null)
 
     @Test
-    suspend fun `access to execution node`() {
+    fun `access to execution node`() = runTest {
         val result = defaultSchema {
             query("root") {
                 resolver { node: Execution.Node ->
@@ -532,7 +533,7 @@ class QueryTest : BaseSchemaTest() {
 
     // cf. https://spec.graphql.org/October2021/#example-77852
     @Test
-    suspend fun `multiple selection sets for the same object should be merged on top level`() {
+    fun `multiple selection sets for the same object should be merged on top level`() = runTest {
         data class Person(val firstName: String, val lastName: String)
 
         val response = defaultSchema {
@@ -557,7 +558,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `multiple selection sets for the same object should be merged on object level`() {
+    fun `multiple selection sets for the same object should be merged on object level`() = runTest {
         data class Person(val firstName: String, val lastName: String)
         data class PersonWrapper(val person: Person)
 
@@ -585,13 +586,20 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `multiple complex selection sets for the same object should be merged on top level`() {
+    fun `multiple complex selection sets for the same object should be merged on top level`() = runTest {
         data class Address(val zipCode: String, val street: String, val city: String, val country: String)
         data class Person(val firstName: String, val lastName: String, val birthDate: String, val address: Address)
 
         val response = defaultSchema {
             query("me") {
-                resolver { -> Person("John", "Doe", "1.1.1970", Address("12345", "Main Street", "SomeCity", "SomeCountry")) }
+                resolver { ->
+                    Person(
+                        "John",
+                        "Doe",
+                        "1.1.1970",
+                        Address("12345", "Main Street", "SomeCity", "SomeCountry")
+                    )
+                }
             }
         }.execute(
             """

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/QueryTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/QueryTest.kt
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test
 
 class QueryTest : BaseSchemaTest() {
     @Test
-    fun `query nested selection set`() {
+    suspend fun `query nested selection set`() {
         val map = execute("{film{title, director{name, age}}}")
         assertNoErrors(map)
         map.extract<String>("data/film/title") shouldBe prestige.title
@@ -24,7 +24,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `query collection field`() {
+    suspend fun `query collection field`() {
         val map = execute("{film{title, director{favActors{name, age}}}}")
         assertNoErrors(map)
         map.extract<Map<String, String>>("data/film/director/favActors[0]") shouldBe
@@ -35,28 +35,28 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `query scalar field`() {
+    suspend fun `query scalar field`() {
         val map = execute("{film{id}}")
         assertNoErrors(map)
         map.extract<String>("data/film/id") shouldBe "${prestige.id.literal}:${prestige.id.numeric}"
     }
 
     @Test
-    fun `query with selection set on collection`() {
+    suspend fun `query with selection set on collection`() {
         val map = execute("{film{title, director{favActors{name}}}}")
         assertNoErrors(map)
         map.extract<Map<String, String>>("data/film/director/favActors[0]") shouldBe mapOf("name" to prestige.director.favActors[0].name)
     }
 
     @Test
-    fun `query with selection set on collection 2`() {
+    suspend fun `query with selection set on collection 2`() {
         val map = execute("{film{title, director{favActors{age}}}}")
         assertNoErrors(map)
         map.extract<Map<String, Int>>("data/film/director/favActors[0]") shouldBe mapOf("age" to prestige.director.favActors[0].age)
     }
 
     @Test
-    fun `query with invalid field name`() {
+    suspend fun `query with invalid field name`() {
         val exception = shouldThrowExactly<ValidationException> {
             execute("{film{title, director{name, favDish}}}")
         }
@@ -67,35 +67,35 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `query with argument`() {
+    suspend fun `query with argument`() {
         val map = execute("{filmByRank(rank: 1){title}}")
         assertNoErrors(map)
         map.extract<String>("data/filmByRank/title") shouldBe "Prestige"
     }
 
     @Test
-    fun `query with argument 2`() {
+    suspend fun `query with argument 2`() {
         val map = execute("{filmByRank(rank: 2){title}}")
         assertNoErrors(map)
         map.extract<String>("data/filmByRank/title") shouldBe "Se7en"
     }
 
     @Test
-    fun `query with alias`() {
+    suspend fun `query with alias`() {
         val map = execute("{bestFilm: filmByRank(rank: 1){title}}")
         assertNoErrors(map)
         map.extract<String>("data/bestFilm/title") shouldBe "Prestige"
     }
 
     @Test
-    fun `query with field alias`() {
+    suspend fun `query with field alias`() {
         val map = execute("{filmByRank(rank: 2){fullTitle: title}}")
         assertNoErrors(map)
         map.extract<String>("data/filmByRank/fullTitle") shouldBe "Se7en"
     }
 
     @Test
-    fun `query with multiple aliases`() {
+    suspend fun `query with multiple aliases`() {
         val map = execute("{bestFilm: filmByRank(rank: 1){title}, secondBestFilm: filmByRank(rank: 2){title}}")
         assertNoErrors(map)
         map.extract<String>("data/bestFilm/title") shouldBe "Prestige"
@@ -103,7 +103,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `query with ignored property`() {
+    suspend fun `query with ignored property`() {
         val exception = shouldThrowExactly<ValidationException> {
             execute("{scenario{author, content}}")
         }
@@ -114,7 +114,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `query with interface`() {
+    suspend fun `query with interface`() {
         val map = execute("{randomPerson{name \n age}}")
         map.extract<Map<String, String>>("data/randomPerson") shouldBe
             mapOf(
@@ -124,7 +124,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `query with collection elements interface`() {
+    suspend fun `query with collection elements interface`() {
         val map = execute("{people{name, age}}")
         map.extract<Map<String, String>>("data/people[0]") shouldBe
             mapOf(
@@ -134,7 +134,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `query extension property`() {
+    suspend fun `query extension property`() {
         val map = execute("{actors{name, age, isOld}}")
         for (i in 0..4) {
             val isOld = map.extract<Boolean>("data/actors[$i]/isOld")
@@ -144,7 +144,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `query extension property with arguments`() {
+    suspend fun `query extension property with arguments`() {
         val map = execute("{actors{name, picture(big: true)}}")
         for (i in 0..4) {
             val name = map.extract<String>("data/actors[$i]/name").replace(' ', '_')
@@ -153,7 +153,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `query extension property with optional argument`() {
+    suspend fun `query extension property with optional argument`() {
         val map = execute("{actors{name, picture}}")
         for (i in 0..4) {
             val name = map.extract<String>("data/actors[$i]/name").replace(' ', '_')
@@ -162,7 +162,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `query extension property with optional annotated argument`() {
+    suspend fun `query extension property with optional annotated argument`() {
         val map = execute("{actors{name, pictureWithArgs}}")
         for (i in 0..4) {
             val name = map.extract<String>("data/actors[$i]/name").replace(' ', '_')
@@ -171,25 +171,25 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `query with mandatory generic input type`() {
+    suspend fun `query with mandatory generic input type`() {
         val map = execute("""{actorsByTags(tags: ["1", "2", "3"]){name}}""")
         assertNoErrors(map)
     }
 
     @Test
-    fun `query with optional generic input type`() {
+    suspend fun `query with optional generic input type`() {
         val map = execute("{actorsByTagsOptional{name}}")
         assertNoErrors(map)
     }
 
     @Test
-    fun `query with nullable generic input type`() {
+    suspend fun `query with nullable generic input type`() {
         val map = execute("{actorsByTagsNullable{name}}")
         assertNoErrors(map)
     }
 
     @Test
-    fun `query with transformed property`() {
+    suspend fun `query with transformed property`() {
         val map = execute("{scenario{id, content(uppercase: false)}}")
         map.extract<String>("data/scenario/content") shouldBe "Very long scenario"
 
@@ -198,7 +198,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `query with invalid field arguments`() {
+    suspend fun `query with invalid field arguments`() {
         val exception = shouldThrowExactly<ValidationException> {
             execute("{scenario{id(uppercase: true), content}}")
         }
@@ -209,7 +209,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `query with external fragment`() {
+    suspend fun `query with external fragment`() {
         val map = execute("{film{title, ...dir }} fragment dir on Film {director{name, age}}")
         assertNoErrors(map)
         map.extract<String>("data/film/title") shouldBe prestige.title
@@ -218,7 +218,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `query with nested external fragment`() {
+    suspend fun `query with nested external fragment`() {
         val map = execute(
             """
             {
@@ -253,7 +253,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `query with two nested external fragments`() {
+    suspend fun `query with two nested external fragments`() {
         val map = execute(
             """
             {
@@ -292,7 +292,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `query with two fragments`() {
+    suspend fun `query with two fragments`() {
         val map = execute(
             """
             {
@@ -321,7 +321,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `query with two inline fragments`() {
+    suspend fun `query with two inline fragments`() {
         val map = execute(
             """
             {
@@ -339,7 +339,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `query with typename and other property`() {
+    suspend fun `query with typename and other property`() {
         data class FooChild(val barChild: String)
         data class Foo(val bar: String, val child: FooChild?)
 
@@ -349,7 +349,7 @@ class QueryTest : BaseSchemaTest() {
             }
         }
 
-        schema.executeBlocking(
+        schema.execute(
             """
             {
                 foo { bar __typename }
@@ -359,7 +359,7 @@ class QueryTest : BaseSchemaTest() {
             {"data":{"foo":{"bar":"bar","__typename":"Foo"}}}
         """.trimIndent()
 
-        schema.executeBlocking(
+        schema.execute(
             """
             {
                 foo { __typename bar }
@@ -369,7 +369,7 @@ class QueryTest : BaseSchemaTest() {
             {"data":{"foo":{"__typename":"Foo","bar":"bar"}}}
         """.trimIndent()
 
-        schema.executeBlocking(
+        schema.execute(
             """
             {
                 foo { child { __typename barChild } }
@@ -379,7 +379,7 @@ class QueryTest : BaseSchemaTest() {
             {"data":{"foo":{"child":{"__typename":"FooChild","barChild":"barChild"}}}}
         """.trimIndent()
 
-        schema.executeBlocking(
+        schema.execute(
             """
             {
                 foo { child { barChild __typename } }
@@ -389,7 +389,7 @@ class QueryTest : BaseSchemaTest() {
             {"data":{"foo":{"child":{"barChild":"barChild","__typename":"FooChild"}}}}
         """.trimIndent()
 
-        schema.executeBlocking(
+        schema.execute(
             """
             {
                 foo { __typename child { barChild __typename } }
@@ -399,7 +399,7 @@ class QueryTest : BaseSchemaTest() {
             {"data":{"foo":{"__typename":"Foo","child":{"barChild":"barChild","__typename":"FooChild"}}}}
         """.trimIndent()
 
-        schema.executeBlocking(
+        schema.execute(
             """
             {
                 foo { child { barChild } __typename }
@@ -411,7 +411,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `query with mixed selections`() {
+    suspend fun `query with mixed selections`() {
         val map = execute(
             """
             {
@@ -436,7 +436,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `query with missing fragment type`() {
+    suspend fun `query with missing fragment type`() {
         val exception = shouldThrowExactly<ValidationException> {
             execute(
                 """
@@ -457,7 +457,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `query with missing named fragment type`() {
+    suspend fun `query with missing named fragment type`() {
         val exception = shouldThrowExactly<ValidationException> {
             execute(
                 """
@@ -476,7 +476,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `query with missing selection set`() {
+    suspend fun `query with missing selection set`() {
         val exception = shouldThrowExactly<ValidationException> {
             execute("{film}")
         }
@@ -489,7 +489,7 @@ class QueryTest : BaseSchemaTest() {
     data class SampleNode(val id: Int, val name: String, val fields: List<String>? = null)
 
     @Test
-    fun `access to execution node`() {
+    suspend fun `access to execution node`() {
         val result = defaultSchema {
             query("root") {
                 resolver { node: Execution.Node ->
@@ -505,7 +505,7 @@ class QueryTest : BaseSchemaTest() {
                     }
                 }
             }
-        }.executeBlocking(
+        }.execute(
             """
             {
                 root {
@@ -532,14 +532,14 @@ class QueryTest : BaseSchemaTest() {
 
     // cf. https://spec.graphql.org/October2021/#example-77852
     @Test
-    fun `multiple selection sets for the same object should be merged on top level`() {
+    suspend fun `multiple selection sets for the same object should be merged on top level`() {
         data class Person(val firstName: String, val lastName: String)
 
         val response = defaultSchema {
             query("me") {
                 resolver { -> Person("John", "Doe") }
             }
-        }.executeBlocking(
+        }.execute(
             """
             {
                 me {
@@ -557,7 +557,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `multiple selection sets for the same object should be merged on object level`() {
+    suspend fun `multiple selection sets for the same object should be merged on object level`() {
         data class Person(val firstName: String, val lastName: String)
         data class PersonWrapper(val person: Person)
 
@@ -565,7 +565,7 @@ class QueryTest : BaseSchemaTest() {
             query("me") {
                 resolver { -> PersonWrapper(Person("John", "Doe")) }
             }
-        }.executeBlocking(
+        }.execute(
             """
             {
                 me {
@@ -585,7 +585,7 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `multiple complex selection sets for the same object should be merged on top level`() {
+    suspend fun `multiple complex selection sets for the same object should be merged on top level`() {
         data class Address(val zipCode: String, val street: String, val city: String, val country: String)
         data class Person(val firstName: String, val lastName: String, val birthDate: String, val address: Address)
 
@@ -593,7 +593,7 @@ class QueryTest : BaseSchemaTest() {
             query("me") {
                 resolver { -> Person("John", "Doe", "1.1.1970", Address("12345", "Main Street", "SomeCity", "SomeCountry")) }
             }
-        }.executeBlocking(
+        }.execute(
             """
             {
                 me {

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/RealWorldSchemaTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/RealWorldSchemaTest.kt
@@ -2,6 +2,7 @@ package com.apurebase.kgraphql.integration
 
 import com.apurebase.kgraphql.KGraphQL
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 class RealWorldSchemaTest {
@@ -43,7 +44,7 @@ class RealWorldSchemaTest {
 
     // https://github.com/apureBase/KGraphQL/issues/75
     @Test
-    suspend fun `issue-75 object is not of declaring class - full sample`() {
+    fun `issue-75 object is not of declaring class - full sample`() = runTest {
         val schema = KGraphQL.schema {
             configure {
                 useDefaultPrettyPrinter = true

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/RealWorldSchemaTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/RealWorldSchemaTest.kt
@@ -43,7 +43,7 @@ class RealWorldSchemaTest {
 
     // https://github.com/apureBase/KGraphQL/issues/75
     @Test
-    fun `issue-75 object is not of declaring class - full sample`() {
+    suspend fun `issue-75 object is not of declaring class - full sample`() {
         val schema = KGraphQL.schema {
             configure {
                 useDefaultPrettyPrinter = true
@@ -118,7 +118,7 @@ class RealWorldSchemaTest {
             }
         }
 
-        val result = schema.executeBlocking(
+        val result = schema.execute(
             """
             query findTrace(${'$'}traceID: String!) {
               findTrace(traceID: ${'$'}traceID) {

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/github/GitHubIssue139.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/github/GitHubIssue139.kt
@@ -3,6 +3,7 @@ package com.apurebase.kgraphql.integration.github
 import com.apurebase.kgraphql.KGraphQL
 import com.apurebase.kgraphql.deserialize
 import com.apurebase.kgraphql.schema.dsl.SchemaBuilder
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
@@ -63,7 +64,7 @@ class GitHubIssue139 {
     }
 
     @Test
-    suspend fun `custom factory definitions`() {
+    fun `custom factory definitions`() = runTest {
         KGraphQL.schema {
             connection("item", Repo1)
             connection("element", Repo2)

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/github/GitHubIssue139.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/github/GitHubIssue139.kt
@@ -63,12 +63,12 @@ class GitHubIssue139 {
     }
 
     @Test
-    fun `custom factory definitions`() {
+    suspend fun `custom factory definitions`() {
         KGraphQL.schema {
             connection("item", Repo1)
             connection("element", Repo2)
             connection("thing", Repo3)
-        }.executeBlocking(
+        }.execute(
             """
             {
                 itemsCount

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/merge/MapMergeTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/merge/MapMergeTest.kt
@@ -7,89 +7,78 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 
 class MapMergeTest {
     private val jsonNodeFactory = JsonNodeFactory.instance
 
     @Test
-    fun `merge should add property`() {
-        runBlocking {
-            val existing = createMap("param1" to CompletableDeferred(jsonNodeFactory.textNode("value1")))
-            val update = CompletableDeferred(jsonNodeFactory.textNode("value2"))
+    suspend fun `merge should add property`() {
+        val existing = createMap("param1" to CompletableDeferred(jsonNodeFactory.textNode("value1")))
+        val update = CompletableDeferred(jsonNodeFactory.textNode("value2"))
 
-            existing.merge("param2", update)
+        existing.merge("param2", update)
 
-            existing["param2"] shouldBe update
-        }
+        existing["param2"] shouldBe update
     }
 
     @Test
-    fun `merge should add nested property`() {
-        runBlocking {
-            val existing = createMap("param1" to CompletableDeferred(jsonNodeFactory.textNode("value1")))
-            val update = CompletableDeferred(jsonNodeFactory.objectNode().put("param2", "value2"))
+    suspend fun `merge should add nested property`() {
+        val existing = createMap("param1" to CompletableDeferred(jsonNodeFactory.textNode("value1")))
+        val update = CompletableDeferred(jsonNodeFactory.objectNode().put("param2", "value2"))
 
-            existing.merge("sub", update)
+        existing.merge("sub", update)
 
-            existing["sub"] shouldBe update
-        }
+        existing["sub"] shouldBe update
     }
 
     @Test
-    fun `merge should not change simple node`() {
-        runBlocking {
-            val existingValue = CompletableDeferred(jsonNodeFactory.textNode("value1"))
-            val existing = createMap("param" to existingValue)
-            val update = CompletableDeferred(jsonNodeFactory.textNode("value2"))
+    suspend fun `merge should not change simple node`() {
+        val existingValue = CompletableDeferred(jsonNodeFactory.textNode("value1"))
+        val existing = createMap("param" to existingValue)
+        val update = CompletableDeferred(jsonNodeFactory.textNode("value2"))
 
-            expect<IllegalStateException>("trying to merge different simple nodes for param") {
-                existing.merge(
-                    "param",
-                    update
-                )
-            }
-
-            existing["param"] shouldBe existingValue
+        expect<IllegalStateException>("trying to merge different simple nodes for param") {
+            existing.merge(
+                "param",
+                update
+            )
         }
+
+        existing["param"] shouldBe existingValue
     }
 
     @Test
-    fun `merge should not merge simple node with object node`() {
-        runBlocking {
-            val existingValue = CompletableDeferred(jsonNodeFactory.textNode("value1"))
-            val existing = createMap("param" to existingValue)
-            val update = CompletableDeferred(jsonNodeFactory.objectNode())
+    suspend fun `merge should not merge simple node with object node`() {
+        val existingValue = CompletableDeferred(jsonNodeFactory.textNode("value1"))
+        val existing = createMap("param" to existingValue)
+        val update = CompletableDeferred(jsonNodeFactory.objectNode())
 
-            expect<IllegalStateException>("trying to merge object with simple node for param") {
-                existing.merge(
-                    "param",
-                    update
-                )
-            }
-
-            val expected: JsonNode? = jsonNodeFactory.textNode("value1")
-            existing["param"]?.await() shouldBe expected
+        expect<IllegalStateException>("trying to merge object with simple node for param") {
+            existing.merge(
+                "param",
+                update
+            )
         }
+
+        val expected: JsonNode? = jsonNodeFactory.textNode("value1")
+        existing["param"]?.await() shouldBe expected
     }
 
     @Test
-    fun `merge should not merge object node with simple node`() {
-        runBlocking {
-            val existingObj = CompletableDeferred(jsonNodeFactory.objectNode().put("other", "value1"))
-            val existing = createMap("param" to existingObj)
-            val update = CompletableDeferred(jsonNodeFactory.textNode("value2"))
+    suspend fun `merge should not merge object node with simple node`() {
+        val existingObj = CompletableDeferred(jsonNodeFactory.objectNode().put("other", "value1"))
+        val existing = createMap("param" to existingObj)
+        val update = CompletableDeferred(jsonNodeFactory.textNode("value2"))
 
-            expect<IllegalStateException>("trying to merge simple node with object node for param") {
-                existing.merge(
-                    "param",
-                    update
-                )
-            }
-
-            existing["param"] shouldBe existingObj
+        expect<IllegalStateException>("trying to merge simple node with object node for param") {
+            existing.merge(
+                "param",
+                update
+            )
         }
+
+        existing["param"] shouldBe existingObj
     }
 
     private fun createMap(vararg pairs: Pair<String, Deferred<JsonNode?>>) = mutableMapOf(*pairs)

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/merge/MapMergeTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/merge/MapMergeTest.kt
@@ -7,13 +7,14 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 class MapMergeTest {
     private val jsonNodeFactory = JsonNodeFactory.instance
 
     @Test
-    suspend fun `merge should add property`() {
+    fun `merge should add property`() = runTest {
         val existing = createMap("param1" to CompletableDeferred(jsonNodeFactory.textNode("value1")))
         val update = CompletableDeferred(jsonNodeFactory.textNode("value2"))
 
@@ -23,7 +24,7 @@ class MapMergeTest {
     }
 
     @Test
-    suspend fun `merge should add nested property`() {
+    fun `merge should add nested property`() = runTest {
         val existing = createMap("param1" to CompletableDeferred(jsonNodeFactory.textNode("value1")))
         val update = CompletableDeferred(jsonNodeFactory.objectNode().put("param2", "value2"))
 
@@ -33,7 +34,7 @@ class MapMergeTest {
     }
 
     @Test
-    suspend fun `merge should not change simple node`() {
+    fun `merge should not change simple node`() = runTest {
         val existingValue = CompletableDeferred(jsonNodeFactory.textNode("value1"))
         val existing = createMap("param" to existingValue)
         val update = CompletableDeferred(jsonNodeFactory.textNode("value2"))
@@ -49,7 +50,7 @@ class MapMergeTest {
     }
 
     @Test
-    suspend fun `merge should not merge simple node with object node`() {
+    fun `merge should not merge simple node with object node`() = runTest {
         val existingValue = CompletableDeferred(jsonNodeFactory.textNode("value1"))
         val existing = createMap("param" to existingValue)
         val update = CompletableDeferred(jsonNodeFactory.objectNode())
@@ -66,7 +67,7 @@ class MapMergeTest {
     }
 
     @Test
-    suspend fun `merge should not merge object node with simple node`() {
+    fun `merge should not merge object node with simple node`() = runTest {
         val existingObj = CompletableDeferred(jsonNodeFactory.objectNode().put("other", "value1"))
         val existing = createMap("param" to existingObj)
         val update = CompletableDeferred(jsonNodeFactory.textNode("value2"))

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaBuilderTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaBuilderTest.kt
@@ -99,7 +99,7 @@ class SchemaBuilderTest {
 
     // https://github.com/stuebingerb/KGraphQL/issues/321
     @Test
-    fun `transformations should change the return type`() {
+    suspend fun `transformations should change the return type`() {
         data class Foo(val id: Int, val name: String?, val nameWithDefault: String?, val transformedId: Int)
 
         val numbers = mapOf(1 to "one", 2 to "two")
@@ -117,13 +117,13 @@ class SchemaBuilderTest {
             }
         }
 
-        testedSchema.executeBlocking(
+        testedSchema.execute(
             "{ foo(id: 1) { id name nameWithDefault transformedId } }"
         ) shouldBe """
             {"data":{"foo":{"id":1,"name":"one","nameWithDefault":"one","transformedId":"1"}}}
         """.trimIndent()
 
-        testedSchema.executeBlocking(
+        testedSchema.execute(
             "{ foo(id: 3) { id name nameWithDefault transformedId } }"
         ) shouldBe """
             {"data":{"foo":{"id":3,"name":null,"nameWithDefault":"(no name)","transformedId":"3"}}}
@@ -224,7 +224,7 @@ class SchemaBuilderTest {
     }
 
     @Test
-    fun `KFunction resolver`() {
+    suspend fun `KFunction resolver`() {
         val actorService = object {
             fun getMainActor() = Actor("Little John", 44)
             fun getActor(id: Int) = when (id) {
@@ -256,12 +256,12 @@ class SchemaBuilderTest {
         property shouldNotBe null
         property.returnType.unwrapped().name shouldBe "Actor"
 
-        deserialize(tested.executeBlocking("{mainActor{name}}"))
-        deserialize(tested.executeBlocking("{actorById(id: 1){name}}"))
+        deserialize(tested.execute("{mainActor{name}}"))
+        deserialize(tested.execute("{actorById(id: 1){name}}"))
     }
 
     @Test
-    fun `_ should be allowed as receiver argument name`() {
+    suspend fun `_ should be allowed as receiver argument name`() {
         val schema = defaultSchema {
             query("actor") {
                 resolver { -> Actor("Boguś Linda", 4343) }
@@ -276,11 +276,11 @@ class SchemaBuilderTest {
             }
         }
 
-        schema.executeBlocking("{actor{favDishes(size: 2)}}").also(::println).deserialize()
+        schema.execute("{actor{favDishes(size: 2)}}").also(::println).deserialize()
     }
 
     @Test
-    fun `enums should be recognized automatically`() {
+    suspend fun `enums should be recognized automatically`() {
         val schema = defaultSchema {
             query("actor") {
                 resolver { type: FilmType -> Actor("Boguś Linda $type", 4343) }
@@ -288,12 +288,12 @@ class SchemaBuilderTest {
         }
 
         val result =
-            deserialize(schema.executeBlocking("query(\$type: FilmType = FULL_LENGTH){actor(type: \$type){name}}"))
+            deserialize(schema.execute("query(\$type: FilmType = FULL_LENGTH){actor(type: \$type){name}}"))
         result.extract<String>("data/actor/name") shouldBe "Boguś Linda FULL_LENGTH"
     }
 
     @Test
-    fun `enums should support a custom type name`() {
+    suspend fun `enums should support a custom type name`() {
         val schema = defaultSchema {
             query("actor") {
                 resolver { type: FilmType -> Actor("Boguś Linda $type", 4343) }
@@ -305,12 +305,12 @@ class SchemaBuilderTest {
         }
 
         val result =
-            deserialize(schema.executeBlocking("query(\$type: TYPE = FULL_LENGTH){actor(type: \$type){name}}"))
+            deserialize(schema.execute("query(\$type: TYPE = FULL_LENGTH){actor(type: \$type){name}}"))
         result.extract<String>("data/actor/name") shouldBe "Boguś Linda FULL_LENGTH"
     }
 
     @Test
-    fun `java arrays should be supported`() {
+    suspend fun `java arrays should be supported`() {
         schema {
             query("actors") {
                 resolver { ->
@@ -320,7 +320,7 @@ class SchemaBuilderTest {
                     )
                 }
             }
-        }.executeBlocking("{actors { name } }").let(::println)
+        }.execute("{actors { name } }").let(::println)
     }
 
     class InputOne(val string: String)
@@ -366,7 +366,7 @@ class SchemaBuilderTest {
     }
 
     @Test
-    fun `client code can declare custom generic type resolver`() {
+    suspend fun `client code can declare custom generic type resolver`() {
         val typeResolver = object : DefaultGenericTypeResolver() {
             override fun unbox(obj: Any) = if (obj is Maybe<*>) obj.get() else super.unbox(obj)
             override fun resolveMonad(type: KType): KType {
@@ -391,7 +391,7 @@ class SchemaBuilderTest {
             query("undefinedValue") { resolver<Maybe<String>> { Maybe.Undefined } }
         }
 
-        deserialize(schema.executeBlocking("{__schema{queryType{fields{ type { ofType { kind name fields { type {ofType {kind name}}}}}}}}}")).let {
+        deserialize(schema.execute("{__schema{queryType{fields{ type { ofType { kind name fields { type {ofType {kind name}}}}}}}}}")).let {
             it.extract<String>("data/__schema/queryType/fields[0]/type/ofType/kind") shouldBe "OBJECT"
             it.extract<String>("data/__schema/queryType/fields[0]/type/ofType/name") shouldBe "SomeWithGenericType"
             it.extract<String>("data/__schema/queryType/fields[0]/type/ofType/fields[0]/type/ofType/kind") shouldBe "SCALAR"
@@ -409,25 +409,25 @@ class SchemaBuilderTest {
             it.extract<String>("data/__schema/queryType/fields[3]/type/ofType/name") shouldBe "String"
         }
 
-        deserialize(schema.executeBlocking("{definedValueProp {value}}")).extract<Int>("data/definedValueProp/value") shouldBe 33
-        deserialize(schema.executeBlocking("{undefinedValueProp {anotherValue}}")).let {
+        deserialize(schema.execute("{definedValueProp {value}}")).extract<Int>("data/definedValueProp/value") shouldBe 33
+        deserialize(schema.execute("{undefinedValueProp {anotherValue}}")).let {
             it.extract<String>("data/undefinedValueProp/anotherValue") shouldBe "foo"
         }
-        deserialize(schema.executeBlocking("{definedValue}")).let {
+        deserialize(schema.execute("{definedValue}")).let {
             it.extract<String>("data/definedValue") shouldBe "good!"
         }
         expect<IllegalArgumentException>("Requested value is not defined!") {
-            deserialize(schema.executeBlocking("{undefinedValue}"))
+            deserialize(schema.execute("{undefinedValue}"))
         }
         expect<IllegalArgumentException>("Requested value is not defined!") {
-            deserialize(schema.executeBlocking("{undefinedValueProp {value}}"))
+            deserialize(schema.execute("{undefinedValueProp {value}}"))
         }
     }
 
     data class LambdaWrapper(val lambda: () -> Int)
 
     @Test
-    fun `function properties can be handled by providing generic type resolver`() {
+    suspend fun `function properties can be handled by providing generic type resolver`() {
         val typeResolver = object : DefaultGenericTypeResolver() {
             override fun unbox(obj: Any) = if (obj is Function0<*>) obj() else super.unbox(obj)
             override fun resolveMonad(type: KType): KType {
@@ -449,18 +449,18 @@ class SchemaBuilderTest {
             }
         }
 
-        deserialize(schema.executeBlocking("{__schema{queryType{fields{ type { ofType { kind name fields { type {ofType {kind name}}}}}}}}}")).let {
+        deserialize(schema.execute("{__schema{queryType{fields{ type { ofType { kind name fields { type {ofType {kind name}}}}}}}}}")).let {
             it.extract<String>("data/__schema/queryType/fields[0]/type/ofType/kind") shouldBe "OBJECT"
             it.extract<String>("data/__schema/queryType/fields[0]/type/ofType/name") shouldBe "LambdaWrapper"
             it.extract<String>("data/__schema/queryType/fields[0]/type/ofType/fields[0]/type/ofType/kind") shouldBe "SCALAR"
             it.extract<String>("data/__schema/queryType/fields[0]/type/ofType/fields[0]/type/ofType/name") shouldBe "Int"
         }
 
-        deserialize(schema.executeBlocking("{lambda {lambda}}")).extract<Int>("data/lambda/lambda") shouldBe 1
+        deserialize(schema.execute("{lambda {lambda}}")).extract<Int>("data/lambda/lambda") shouldBe 1
     }
 
     @Test
-    fun `input value default value and description can be specified`() {
+    suspend fun `input value default value and description can be specified`() {
         val expectedDescription = "Int Argument"
         val expectedDefaultValue = 33
         val schema = defaultSchema {
@@ -475,11 +475,11 @@ class SchemaBuilderTest {
         intArg?.defaultValue shouldBe expectedDefaultValue.toString()
         intArg?.description shouldBe expectedDescription
 
-        val response = deserialize(schema.executeBlocking("{data}"))
+        val response = deserialize(schema.execute("{data}"))
         response.extract<Int>("data/data") shouldBe 33
 
         val introspection =
-            deserialize(schema.executeBlocking("{__schema{queryType{fields{name, args{name, description, defaultValue}}}}}"))
+            deserialize(schema.execute("{__schema{queryType{fields{name, args{name, description, defaultValue}}}}}"))
         introspection.extract<String>("data/__schema/queryType/fields[0]/args[0]/description") shouldBe expectedDescription
     }
 
@@ -513,7 +513,7 @@ class SchemaBuilderTest {
     data class UserData(val username: String, val stuff: String)
 
     @Test
-    fun `client code can declare custom context class and use it in query resolver`() {
+    suspend fun `client code can declare custom context class and use it in query resolver`() {
         val schema = schema {
             query("name") {
                 resolver { ctx: Context -> ctx.get<UserData>()?.username }
@@ -522,12 +522,12 @@ class SchemaBuilderTest {
 
         val georgeName = "George"
         val response =
-            deserialize(schema.executeBlocking("{name}", context = context { +UserData(georgeName, "STUFF") }))
+            deserialize(schema.execute("{name}", context = context { +UserData(georgeName, "STUFF") }))
         response.extract<String>("data/name") shouldBe georgeName
     }
 
     @Test
-    fun `client code can use context class in property resolver`() {
+    suspend fun `client code can use context class in property resolver`() {
         val georgeName = "George"
         val schema = schema {
             query("actor") {
@@ -554,7 +554,7 @@ class SchemaBuilderTest {
             inject("ADA")
         }
         val response =
-            deserialize(schema.executeBlocking("{actor{ nickname, name(addStuff: true) }}", context = context))
+            deserialize(schema.execute("{actor{ nickname, name(addStuff: true) }}", context = context))
         response.extract<String>("data/actor/name") shouldBe "${georgeName}STUFF"
         response.extract<String>("data/actor/nickname") shouldBe "Hodor and $georgeName"
     }
@@ -592,9 +592,9 @@ class SchemaBuilderTest {
         val val9: Int = 9
     )
 
-    private fun checkNineValuesSchema(schema: Schema) {
+    private suspend fun checkNineValuesSchema(schema: Schema) {
         val response = deserialize(
-            schema.executeBlocking(
+            schema.execute(
                 "{" +
                     "queryWith1Param(val1: 2) { val1 }" +
                     "queryWith2Params(val1: 2, val2: \"3\") { val1, val2 }" +
@@ -664,7 +664,7 @@ class SchemaBuilderTest {
     }
 
     @Test
-    fun `schema can contain resolvers with up to 9 parameters`() {
+    suspend fun `schema can contain resolvers with up to 9 parameters`() {
         val schema = schema {
             query("queryWith1Param") {
                 resolver { val1: Int ->
@@ -725,7 +725,7 @@ class SchemaBuilderTest {
     }
 
     @Test
-    fun `schema can contain suspend resolvers`() {
+    suspend fun `schema can contain suspend resolvers`() {
         val schema = schema {
             query("queryWith1Param") {
                 resolver { val1: Int ->
@@ -808,7 +808,7 @@ class SchemaBuilderTest {
     }
 
     @Test
-    fun `schema can have same type and input type with different names`() {
+    suspend fun `schema can have same type and input type with different names`() {
         val schema = defaultSchema {
             query("createType") {
                 resolver { input: InputOne -> input }
@@ -824,7 +824,7 @@ class SchemaBuilderTest {
         schema.typeByKClass(InputOne::class) shouldNotBe null
         schema.inputTypeByKClass(InputOne::class) shouldNotBe null
 
-        val introspection = deserialize(schema.executeBlocking("{__schema{types{name}}}"))
+        val introspection = deserialize(schema.execute("{__schema{types{name}}}"))
         val types = introspection.extract<List<Map<String, String>>>("data/__schema/types")
         val names = types.map { it["name"] }
         names shouldContain "TypeAsInput"
@@ -832,7 +832,7 @@ class SchemaBuilderTest {
     }
 
     @Test
-    fun `Short int types are mapped to Short Scalar`() {
+    suspend fun `Short int types are mapped to Short Scalar`() {
         val schema = defaultSchema {
             extendedScalars()
             query("shortQuery") {
@@ -840,13 +840,13 @@ class SchemaBuilderTest {
             }
         }
 
-        val typesIntrospection = deserialize(schema.executeBlocking("{__schema{types{name}}}"))
+        val typesIntrospection = deserialize(schema.execute("{__schema{types{name}}}"))
         val types = typesIntrospection.extract<List<Map<String, String>>>("data/__schema/types")
         val names = types.map { it["name"] }
         names shouldContain "Short"
 
         val response =
-            deserialize(schema.executeBlocking("{__schema{queryType{fields{ type { ofType { kind name }}}}}}"))
+            deserialize(schema.execute("{__schema{queryType{fields{ type { ofType { kind name }}}}}}"))
         response.extract<String>("data/__schema/queryType/fields[0]/type/ofType/kind") shouldBe "SCALAR"
         response.extract<String>("data/__schema/queryType/fields[0]/type/ofType/name") shouldBe "Short"
     }
@@ -893,11 +893,11 @@ class SchemaBuilderTest {
     }
 
     @Test
-    fun `specifying return type explicitly allows generic query creation that returns List of T`() {
+    suspend fun `specifying return type explicitly allows generic query creation that returns List of T`() {
         val schema = defaultSchema {
             createGenericQuery(listOf("generic"))
         }
-        val result = deserialize(schema.executeBlocking("{data}"))
+        val result = deserialize(schema.execute("{data}"))
         result.extract<List<String>>("data/data") shouldBe listOf("generic")
     }
 

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaBuilderTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaBuilderTest.kt
@@ -23,6 +23,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import kotlin.reflect.KType
 import kotlin.reflect.full.isSupertypeOf
@@ -99,7 +100,7 @@ class SchemaBuilderTest {
 
     // https://github.com/stuebingerb/KGraphQL/issues/321
     @Test
-    suspend fun `transformations should change the return type`() {
+    fun `transformations should change the return type`() = runTest {
         data class Foo(val id: Int, val name: String?, val nameWithDefault: String?, val transformedId: Int)
 
         val numbers = mapOf(1 to "one", 2 to "two")
@@ -224,7 +225,7 @@ class SchemaBuilderTest {
     }
 
     @Test
-    suspend fun `KFunction resolver`() {
+    fun `KFunction resolver`() = runTest {
         val actorService = object {
             fun getMainActor() = Actor("Little John", 44)
             fun getActor(id: Int) = when (id) {
@@ -261,7 +262,7 @@ class SchemaBuilderTest {
     }
 
     @Test
-    suspend fun `_ should be allowed as receiver argument name`() {
+    fun `_ should be allowed as receiver argument name`() = runTest {
         val schema = defaultSchema {
             query("actor") {
                 resolver { -> Actor("Boguś Linda", 4343) }
@@ -280,7 +281,7 @@ class SchemaBuilderTest {
     }
 
     @Test
-    suspend fun `enums should be recognized automatically`() {
+    fun `enums should be recognized automatically`() = runTest {
         val schema = defaultSchema {
             query("actor") {
                 resolver { type: FilmType -> Actor("Boguś Linda $type", 4343) }
@@ -293,7 +294,7 @@ class SchemaBuilderTest {
     }
 
     @Test
-    suspend fun `enums should support a custom type name`() {
+    fun `enums should support a custom type name`() = runTest {
         val schema = defaultSchema {
             query("actor") {
                 resolver { type: FilmType -> Actor("Boguś Linda $type", 4343) }
@@ -310,7 +311,7 @@ class SchemaBuilderTest {
     }
 
     @Test
-    suspend fun `java arrays should be supported`() {
+    fun `java arrays should be supported`() = runTest {
         schema {
             query("actors") {
                 resolver { ->
@@ -366,7 +367,7 @@ class SchemaBuilderTest {
     }
 
     @Test
-    suspend fun `client code can declare custom generic type resolver`() {
+    fun `client code can declare custom generic type resolver`() = runTest {
         val typeResolver = object : DefaultGenericTypeResolver() {
             override fun unbox(obj: Any) = if (obj is Maybe<*>) obj.get() else super.unbox(obj)
             override fun resolveMonad(type: KType): KType {
@@ -427,7 +428,7 @@ class SchemaBuilderTest {
     data class LambdaWrapper(val lambda: () -> Int)
 
     @Test
-    suspend fun `function properties can be handled by providing generic type resolver`() {
+    fun `function properties can be handled by providing generic type resolver`() = runTest {
         val typeResolver = object : DefaultGenericTypeResolver() {
             override fun unbox(obj: Any) = if (obj is Function0<*>) obj() else super.unbox(obj)
             override fun resolveMonad(type: KType): KType {
@@ -460,7 +461,7 @@ class SchemaBuilderTest {
     }
 
     @Test
-    suspend fun `input value default value and description can be specified`() {
+    fun `input value default value and description can be specified`() = runTest {
         val expectedDescription = "Int Argument"
         val expectedDefaultValue = 33
         val schema = defaultSchema {
@@ -513,7 +514,7 @@ class SchemaBuilderTest {
     data class UserData(val username: String, val stuff: String)
 
     @Test
-    suspend fun `client code can declare custom context class and use it in query resolver`() {
+    fun `client code can declare custom context class and use it in query resolver`() = runTest {
         val schema = schema {
             query("name") {
                 resolver { ctx: Context -> ctx.get<UserData>()?.username }
@@ -527,7 +528,7 @@ class SchemaBuilderTest {
     }
 
     @Test
-    suspend fun `client code can use context class in property resolver`() {
+    fun `client code can use context class in property resolver`() = runTest {
         val georgeName = "George"
         val schema = schema {
             query("actor") {
@@ -664,7 +665,7 @@ class SchemaBuilderTest {
     }
 
     @Test
-    suspend fun `schema can contain resolvers with up to 9 parameters`() {
+    fun `schema can contain resolvers with up to 9 parameters`() = runTest {
         val schema = schema {
             query("queryWith1Param") {
                 resolver { val1: Int ->
@@ -725,7 +726,7 @@ class SchemaBuilderTest {
     }
 
     @Test
-    suspend fun `schema can contain suspend resolvers`() {
+    fun `schema can contain suspend resolvers`() = runTest {
         val schema = schema {
             query("queryWith1Param") {
                 resolver { val1: Int ->
@@ -808,7 +809,7 @@ class SchemaBuilderTest {
     }
 
     @Test
-    suspend fun `schema can have same type and input type with different names`() {
+    fun `schema can have same type and input type with different names`() = runTest {
         val schema = defaultSchema {
             query("createType") {
                 resolver { input: InputOne -> input }
@@ -832,7 +833,7 @@ class SchemaBuilderTest {
     }
 
     @Test
-    suspend fun `Short int types are mapped to Short Scalar`() {
+    fun `Short int types are mapped to Short Scalar`() = runTest {
         val schema = defaultSchema {
             extendedScalars()
             query("shortQuery") {
@@ -893,7 +894,7 @@ class SchemaBuilderTest {
     }
 
     @Test
-    suspend fun `specifying return type explicitly allows generic query creation that returns List of T`() {
+    fun `specifying return type explicitly allows generic query creation that returns List of T`() = runTest {
         val schema = defaultSchema {
             createGenericQuery(listOf("generic"))
         }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaInheritanceTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaInheritanceTest.kt
@@ -4,6 +4,7 @@ import com.apurebase.kgraphql.KGraphQL
 import com.apurebase.kgraphql.ValidationException
 import com.apurebase.kgraphql.deserialize
 import com.apurebase.kgraphql.expect
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import java.util.UUID
 
@@ -18,7 +19,7 @@ class SchemaInheritanceTest {
     class C(override var name: String, override var age: Int, var pesel: String = "") : A(name, age)
 
     @Test
-    suspend fun `call to ignore property should cascade to subclasses`() {
+    fun `call to ignore property should cascade to subclasses`() = runTest {
         val name = "PELE"
         val age = 20
 

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaInheritanceTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaInheritanceTest.kt
@@ -18,7 +18,7 @@ class SchemaInheritanceTest {
     class C(override var name: String, override var age: Int, var pesel: String = "") : A(name, age)
 
     @Test
-    fun `call to ignore property should cascade to subclasses`() {
+    suspend fun `call to ignore property should cascade to subclasses`() {
         val name = "PELE"
         val age = 20
 
@@ -32,11 +32,11 @@ class SchemaInheritanceTest {
         }
 
         expect<ValidationException>("Property id on B does not exist") {
-            deserialize(schema.executeBlocking("{b{id, name, age}}"))
+            deserialize(schema.execute("{b{id, name, age}}"))
         }
 
         expect<ValidationException>("Property id on C does not exist") {
-            deserialize(schema.executeBlocking("{c{id, name, age}}"))
+            deserialize(schema.execute("{c{id, name, age}}"))
         }
     }
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/dsl/DataLoaderPropertyDSLTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/dsl/DataLoaderPropertyDSLTest.kt
@@ -15,7 +15,7 @@ import kotlin.reflect.typeOf
 class DataLoaderPropertyDSLTest {
 
     @Test
-    fun `prepare() should support multiple arguments`() {
+    suspend fun `prepare() should support multiple arguments`() {
         val schema = defaultSchema {
             query("parent") {
                 resolver { -> Parent() }
@@ -31,7 +31,7 @@ class DataLoaderPropertyDSLTest {
                 }
             }
         }
-        val results = schema.executeBlocking(
+        val results = schema.execute(
             """
             {
                 parent {

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/dsl/DataLoaderPropertyDSLTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/dsl/DataLoaderPropertyDSLTest.kt
@@ -7,15 +7,15 @@ import com.apurebase.kgraphql.extract
 import com.apurebase.kgraphql.schema.SchemaBuilderTest
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import kotlinx.coroutines.test.runTest
 import nidomiro.kdataloader.ExecutionResult
 import org.junit.jupiter.api.Test
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
 
 class DataLoaderPropertyDSLTest {
-
     @Test
-    suspend fun `prepare() should support multiple arguments`() {
+    fun `prepare() should support multiple arguments`() = runTest {
         val schema = defaultSchema {
             query("parent") {
                 resolver { -> Parent() }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/introspection/ContextSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/introspection/ContextSpecificationTest.kt
@@ -5,13 +5,14 @@ import com.apurebase.kgraphql.defaultSchema
 import com.apurebase.kgraphql.deserialize
 import com.apurebase.kgraphql.extract
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 class ContextSpecificationTest {
 
     @Test
     @Suppress("UNUSED_ANONYMOUS_PARAMETER")
-    suspend fun `query resolver should not return context param`() {
+    fun `query resolver should not return context param`() = runTest {
         val schema = defaultSchema {
             query("sample") {
                 resolver { ctx: Context, limit: Int -> "SAMPLE" }
@@ -24,7 +25,7 @@ class ContextSpecificationTest {
 
     @Test
     @Suppress("UNUSED_ANONYMOUS_PARAMETER")
-    suspend fun `mutation resolver should not return context param`() {
+    fun `mutation resolver should not return context param`() = runTest {
         val schema = defaultSchema {
             query("sample") {
                 resolver { -> "dummy" }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/introspection/ContextSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/introspection/ContextSpecificationTest.kt
@@ -11,20 +11,20 @@ class ContextSpecificationTest {
 
     @Test
     @Suppress("UNUSED_ANONYMOUS_PARAMETER")
-    fun `query resolver should not return context param`() {
+    suspend fun `query resolver should not return context param`() {
         val schema = defaultSchema {
             query("sample") {
                 resolver { ctx: Context, limit: Int -> "SAMPLE" }
             }
         }
 
-        val response = deserialize(schema.executeBlocking("{__schema{queryType{fields{args{name}}}}}"))
+        val response = deserialize(schema.execute("{__schema{queryType{fields{args{name}}}}}"))
         response.extract<String>("data/__schema/queryType/fields[0]/args[0]/name") shouldBe "limit"
     }
 
     @Test
     @Suppress("UNUSED_ANONYMOUS_PARAMETER")
-    fun `mutation resolver should not return context param`() {
+    suspend fun `mutation resolver should not return context param`() {
         val schema = defaultSchema {
             query("sample") {
                 resolver { -> "dummy" }
@@ -34,7 +34,7 @@ class ContextSpecificationTest {
             }
         }
 
-        val response = deserialize(schema.executeBlocking("{__schema{mutationType{fields{args{name}}}}}"))
+        val response = deserialize(schema.execute("{__schema{mutationType{fields{args{name}}}}}"))
         response.extract<String>("data/__schema/mutationType/fields[0]/args[0]/name") shouldBe "input"
     }
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/introspection/DeprecationSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/introspection/DeprecationSpecificationTest.kt
@@ -7,13 +7,14 @@ import com.apurebase.kgraphql.extract
 import com.apurebase.kgraphql.schema.SchemaException
 import io.kotest.matchers.maps.shouldContainAll
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import kotlin.reflect.typeOf
 
 class DeprecationSpecificationTest {
 
     @Test
-    suspend fun `queries may be deprecated`() {
+    fun `queries may be deprecated`() = runTest {
         val expected = "sample query"
         val schema = defaultSchema {
             query("sample") {
@@ -31,7 +32,7 @@ class DeprecationSpecificationTest {
     }
 
     @Test
-    suspend fun `mutations may be deprecated`() {
+    fun `mutations may be deprecated`() = runTest {
         val expected = "sample mutation"
         val schema = defaultSchema {
             query("dummy") {
@@ -54,7 +55,7 @@ class DeprecationSpecificationTest {
     data class Sample(val content: String)
 
     @Test
-    suspend fun `kotlin field may be deprecated`() {
+    fun `kotlin field may be deprecated`() = runTest {
         val expected = "sample type"
         val schema = defaultSchema {
             query("sample") {
@@ -77,7 +78,7 @@ class DeprecationSpecificationTest {
     }
 
     @Test
-    suspend fun `extension field may be deprecated`() {
+    fun `extension field may be deprecated`() = runTest {
         val expected = "sample type"
         val schema = defaultSchema {
             query("sample") {
@@ -104,7 +105,7 @@ class DeprecationSpecificationTest {
     enum class SampleEnum { ONE, TWO, THREE }
 
     @Test
-    suspend fun `enum value may be deprecated`() {
+    fun `enum value may be deprecated`() = runTest {
         val expected = "some enum value"
         val schema = defaultSchema {
             query("sample") {
@@ -128,7 +129,7 @@ class DeprecationSpecificationTest {
     }
 
     @Test
-    suspend fun `optional input value may be deprecated`() {
+    fun `optional input value may be deprecated`() = runTest {
         data class InputType(val oldOptional: String?, val new: String)
 
         val expected = "deprecated input value"
@@ -173,7 +174,7 @@ class DeprecationSpecificationTest {
     }
 
     @Test
-    suspend fun `deprecated input values should not be returned by default`() {
+    fun `deprecated input values should not be returned by default`() = runTest {
         data class InputType(val oldOptional: String?, val new: String)
 
         val expected = "deprecated input value"
@@ -200,7 +201,7 @@ class DeprecationSpecificationTest {
     }
 
     @Test
-    suspend fun `optional field args may be deprecated`() {
+    fun `optional field args may be deprecated`() = runTest {
         val expected = "deprecated field arg"
 
         @Suppress("UNUSED_ANONYMOUS_PARAMETER")
@@ -243,7 +244,7 @@ class DeprecationSpecificationTest {
     }
 
     @Test
-    suspend fun `deprecated field args should not be returned by default`() {
+    fun `deprecated field args should not be returned by default`() = runTest {
         val expected = "deprecated input value"
 
         @Suppress("UNUSED_ANONYMOUS_PARAMETER")

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/introspection/DeprecationSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/introspection/DeprecationSpecificationTest.kt
@@ -13,7 +13,7 @@ import kotlin.reflect.typeOf
 class DeprecationSpecificationTest {
 
     @Test
-    fun `queries may be deprecated`() {
+    suspend fun `queries may be deprecated`() {
         val expected = "sample query"
         val schema = defaultSchema {
             query("sample") {
@@ -23,7 +23,7 @@ class DeprecationSpecificationTest {
         }
 
         val response =
-            deserialize(schema.executeBlocking("{__schema{queryType{fields(includeDeprecated: true){name, deprecationReason, isDeprecated}}}}"))
+            deserialize(schema.execute("{__schema{queryType{fields(includeDeprecated: true){name, deprecationReason, isDeprecated}}}}"))
         response.extract<Map<String, Any?>>("data/__schema/queryType/fields[0]") shouldContainAll mapOf(
             "deprecationReason" to expected,
             "isDeprecated" to true
@@ -31,7 +31,7 @@ class DeprecationSpecificationTest {
     }
 
     @Test
-    fun `mutations may be deprecated`() {
+    suspend fun `mutations may be deprecated`() {
         val expected = "sample mutation"
         val schema = defaultSchema {
             query("dummy") {
@@ -44,7 +44,7 @@ class DeprecationSpecificationTest {
         }
 
         val response =
-            deserialize(schema.executeBlocking("{__schema{mutationType{fields(includeDeprecated: true){name, deprecationReason, isDeprecated}}}}"))
+            deserialize(schema.execute("{__schema{mutationType{fields(includeDeprecated: true){name, deprecationReason, isDeprecated}}}}"))
         response.extract<Map<String, Any?>>("data/__schema/mutationType/fields[0]") shouldContainAll mapOf(
             "deprecationReason" to expected,
             "isDeprecated" to true
@@ -54,7 +54,7 @@ class DeprecationSpecificationTest {
     data class Sample(val content: String)
 
     @Test
-    fun `kotlin field may be deprecated`() {
+    suspend fun `kotlin field may be deprecated`() {
         val expected = "sample type"
         val schema = defaultSchema {
             query("sample") {
@@ -69,7 +69,7 @@ class DeprecationSpecificationTest {
         }
 
         val response =
-            deserialize(schema.executeBlocking("{__type(name: \"Sample\"){fields(includeDeprecated: true){isDeprecated, deprecationReason}}}"))
+            deserialize(schema.execute("{__type(name: \"Sample\"){fields(includeDeprecated: true){isDeprecated, deprecationReason}}}"))
         response.extract<Map<String, Any?>>("data/__type/fields[0]") shouldContainAll mapOf(
             "deprecationReason" to expected,
             "isDeprecated" to true
@@ -77,7 +77,7 @@ class DeprecationSpecificationTest {
     }
 
     @Test
-    fun `extension field may be deprecated`() {
+    suspend fun `extension field may be deprecated`() {
         val expected = "sample type"
         val schema = defaultSchema {
             query("sample") {
@@ -93,7 +93,7 @@ class DeprecationSpecificationTest {
         }
 
         val response =
-            deserialize(schema.executeBlocking("{__type(name: \"Sample\"){fields(includeDeprecated: true){name, isDeprecated, deprecationReason}}}"))
+            deserialize(schema.execute("{__type(name: \"Sample\"){fields(includeDeprecated: true){name, isDeprecated, deprecationReason}}}"))
         response.extract<Map<String, Any?>>("data/__type/fields[1]") shouldContainAll mapOf(
             "deprecationReason" to expected,
             "isDeprecated" to true
@@ -104,7 +104,7 @@ class DeprecationSpecificationTest {
     enum class SampleEnum { ONE, TWO, THREE }
 
     @Test
-    fun `enum value may be deprecated`() {
+    suspend fun `enum value may be deprecated`() {
         val expected = "some enum value"
         val schema = defaultSchema {
             query("sample") {
@@ -119,7 +119,7 @@ class DeprecationSpecificationTest {
         }
 
         val response =
-            deserialize(schema.executeBlocking("{__type(name: \"SampleEnum\"){enumValues(includeDeprecated: true){name, isDeprecated, deprecationReason}}}"))
+            deserialize(schema.execute("{__type(name: \"SampleEnum\"){enumValues(includeDeprecated: true){name, isDeprecated, deprecationReason}}}"))
         response.extract<Map<String, Any?>>("data/__type/enumValues[0]") shouldContainAll mapOf(
             "name" to SampleEnum.ONE.name,
             "deprecationReason" to expected,
@@ -128,7 +128,7 @@ class DeprecationSpecificationTest {
     }
 
     @Test
-    fun `optional input value may be deprecated`() {
+    suspend fun `optional input value may be deprecated`() {
         data class InputType(val oldOptional: String?, val new: String)
 
         val expected = "deprecated input value"
@@ -144,7 +144,7 @@ class DeprecationSpecificationTest {
         }
 
         val response =
-            deserialize(schema.executeBlocking("{__type(name: \"InputType\"){inputFields(includeDeprecated: true){name, deprecationReason, isDeprecated}}}"))
+            deserialize(schema.execute("{__type(name: \"InputType\"){inputFields(includeDeprecated: true){name, deprecationReason, isDeprecated}}}"))
         response.extract<Map<String, Any?>>("data/__type/inputFields[0]") shouldContainAll mapOf(
             "name" to "new",
             "deprecationReason" to null,
@@ -173,7 +173,7 @@ class DeprecationSpecificationTest {
     }
 
     @Test
-    fun `deprecated input values should not be returned by default`() {
+    suspend fun `deprecated input values should not be returned by default`() {
         data class InputType(val oldOptional: String?, val new: String)
 
         val expected = "deprecated input value"
@@ -189,7 +189,7 @@ class DeprecationSpecificationTest {
         }
 
         val response =
-            deserialize(schema.executeBlocking("{__type(name: \"InputType\"){inputFields{name, deprecationReason, isDeprecated}}}"))
+            deserialize(schema.execute("{__type(name: \"InputType\"){inputFields{name, deprecationReason, isDeprecated}}}"))
         response.extract<Map<String, Any?>>("data/__type/inputFields[0]") shouldContainAll mapOf(
             "name" to "new",
             "deprecationReason" to null,
@@ -200,7 +200,7 @@ class DeprecationSpecificationTest {
     }
 
     @Test
-    fun `optional field args may be deprecated`() {
+    suspend fun `optional field args may be deprecated`() {
         val expected = "deprecated field arg"
 
         @Suppress("UNUSED_ANONYMOUS_PARAMETER")
@@ -214,7 +214,7 @@ class DeprecationSpecificationTest {
         }
 
         val response =
-            deserialize(schema.executeBlocking("{__schema{queryType{fields{name, args(includeDeprecated: true){name deprecationReason isDeprecated}}}}}"))
+            deserialize(schema.execute("{__schema{queryType{fields{name, args(includeDeprecated: true){name deprecationReason isDeprecated}}}}}"))
         response.extract<Map<String, Any?>>("data/__schema/queryType/fields[0]/args[0]") shouldContainAll mapOf(
             "name" to "oldOptional",
             "deprecationReason" to expected,
@@ -243,7 +243,7 @@ class DeprecationSpecificationTest {
     }
 
     @Test
-    fun `deprecated field args should not be returned by default`() {
+    suspend fun `deprecated field args should not be returned by default`() {
         val expected = "deprecated input value"
 
         @Suppress("UNUSED_ANONYMOUS_PARAMETER")
@@ -257,7 +257,7 @@ class DeprecationSpecificationTest {
         }
 
         val response =
-            deserialize(schema.executeBlocking("{__schema{queryType{fields{name, args{name deprecationReason isDeprecated}}}}}"))
+            deserialize(schema.execute("{__schema{queryType{fields{name, args{name deprecationReason isDeprecated}}}}}"))
         response.extract<Map<String, Any?>>("data/__schema/queryType/fields[0]/args[0]") shouldContainAll mapOf(
             "name" to "new",
             "deprecationReason" to null,

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/introspection/DocumentationSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/introspection/DocumentationSpecificationTest.kt
@@ -5,12 +5,13 @@ import com.apurebase.kgraphql.deserialize
 import com.apurebase.kgraphql.extract
 import io.kotest.matchers.maps.shouldContainAll
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 class DocumentationSpecificationTest {
 
     @Test
-    suspend fun `queries may be documented`() {
+    fun `queries may be documented`() = runTest {
         val expected = "sample query"
         val schema = defaultSchema {
             query("sample") {
@@ -24,7 +25,7 @@ class DocumentationSpecificationTest {
     }
 
     @Test
-    suspend fun `mutations may be documented`() {
+    fun `mutations may be documented`() = runTest {
         val expected = "sample mutation"
         val schema = defaultSchema {
             query("dummy") {
@@ -43,7 +44,7 @@ class DocumentationSpecificationTest {
     data class Sample(val content: String)
 
     @Test
-    suspend fun `object type may be documented`() {
+    fun `object type may be documented`() = runTest {
         val expected = "sample type"
         val schema = defaultSchema {
             query("sample") {
@@ -59,7 +60,7 @@ class DocumentationSpecificationTest {
     }
 
     @Test
-    suspend fun `input type may be documented`() {
+    fun `input type may be documented`() = runTest {
         val expected = "sample type"
         val schema = defaultSchema {
             query("sample") {
@@ -76,7 +77,7 @@ class DocumentationSpecificationTest {
     }
 
     @Test
-    suspend fun `kotlin field may be documented`() {
+    fun `kotlin field may be documented`() = runTest {
         val expected = "sample type"
         val schema = defaultSchema {
             query("sample") {
@@ -95,7 +96,7 @@ class DocumentationSpecificationTest {
     }
 
     @Test
-    suspend fun `extension field may be documented`() {
+    fun `extension field may be documented`() = runTest {
         val expected = "sample type"
         val schema = defaultSchema {
             query("sample") {
@@ -120,7 +121,7 @@ class DocumentationSpecificationTest {
     enum class SampleEnum { ONE, TWO, THREE }
 
     @Test
-    suspend fun `enum value may be documented`() {
+    fun `enum value may be documented`() = runTest {
         val expected = "some enum value"
         val schema = defaultSchema {
             query("sample") {
@@ -145,7 +146,7 @@ class DocumentationSpecificationTest {
     data class Documented(val id: Int)
 
     @Test
-    suspend fun `type may be documented`() {
+    fun `type may be documented`() = runTest {
         val expected = "very documented type"
         val schema = defaultSchema {
             query("documented") {

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/introspection/DocumentationSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/introspection/DocumentationSpecificationTest.kt
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test
 class DocumentationSpecificationTest {
 
     @Test
-    fun `queries may be documented`() {
+    suspend fun `queries may be documented`() {
         val expected = "sample query"
         val schema = defaultSchema {
             query("sample") {
@@ -19,12 +19,12 @@ class DocumentationSpecificationTest {
             }
         }
 
-        val response = deserialize(schema.executeBlocking("{__schema{queryType{fields{name, description}}}}"))
+        val response = deserialize(schema.execute("{__schema{queryType{fields{name, description}}}}"))
         response.extract<String>("data/__schema/queryType/fields[0]/description") shouldBe expected
     }
 
     @Test
-    fun `mutations may be documented`() {
+    suspend fun `mutations may be documented`() {
         val expected = "sample mutation"
         val schema = defaultSchema {
             query("dummy") {
@@ -36,14 +36,14 @@ class DocumentationSpecificationTest {
             }
         }
 
-        val response = deserialize(schema.executeBlocking("{__schema{mutationType{fields{name, description}}}}"))
+        val response = deserialize(schema.execute("{__schema{mutationType{fields{name, description}}}}"))
         response.extract<String>("data/__schema/mutationType/fields[0]/description") shouldBe expected
     }
 
     data class Sample(val content: String)
 
     @Test
-    fun `object type may be documented`() {
+    suspend fun `object type may be documented`() {
         val expected = "sample type"
         val schema = defaultSchema {
             query("sample") {
@@ -54,12 +54,12 @@ class DocumentationSpecificationTest {
             }
         }
 
-        val response = deserialize(schema.executeBlocking("{__type(name: \"Sample\"){description}}"))
+        val response = deserialize(schema.execute("{__type(name: \"Sample\"){description}}"))
         response.extract<String>("data/__type/description/") shouldBe expected
     }
 
     @Test
-    fun `input type may be documented`() {
+    suspend fun `input type may be documented`() {
         val expected = "sample type"
         val schema = defaultSchema {
             query("sample") {
@@ -71,12 +71,12 @@ class DocumentationSpecificationTest {
             }
         }
 
-        val response = deserialize(schema.executeBlocking("{__type(name: \"Sample\"){description}}"))
+        val response = deserialize(schema.execute("{__type(name: \"Sample\"){description}}"))
         response.extract<String>("data/__type/description/") shouldBe expected
     }
 
     @Test
-    fun `kotlin field may be documented`() {
+    suspend fun `kotlin field may be documented`() {
         val expected = "sample type"
         val schema = defaultSchema {
             query("sample") {
@@ -90,12 +90,12 @@ class DocumentationSpecificationTest {
             }
         }
 
-        val response = deserialize(schema.executeBlocking("{__type(name: \"Sample\"){fields{description}}}"))
+        val response = deserialize(schema.execute("{__type(name: \"Sample\"){fields{description}}}"))
         response.extract<String>("data/__type/fields[0]/description/") shouldBe expected
     }
 
     @Test
-    fun `extension field may be documented`() {
+    suspend fun `extension field may be documented`() {
         val expected = "sample type"
         val schema = defaultSchema {
             query("sample") {
@@ -110,7 +110,7 @@ class DocumentationSpecificationTest {
             }
         }
 
-        val response = deserialize(schema.executeBlocking("{__type(name: \"Sample\"){fields{name, description}}}"))
+        val response = deserialize(schema.execute("{__type(name: \"Sample\"){fields{name, description}}}"))
         response.extract<Map<String, Any?>>("data/__type/fields[1]") shouldContainAll mapOf(
             "name" to "add",
             "description" to expected
@@ -120,7 +120,7 @@ class DocumentationSpecificationTest {
     enum class SampleEnum { ONE, TWO, THREE }
 
     @Test
-    fun `enum value may be documented`() {
+    suspend fun `enum value may be documented`() {
         val expected = "some enum value"
         val schema = defaultSchema {
             query("sample") {
@@ -135,7 +135,7 @@ class DocumentationSpecificationTest {
         }
 
         val response =
-            deserialize(schema.executeBlocking("{__type(name: \"SampleEnum\"){enumValues{name, description}}}"))
+            deserialize(schema.execute("{__type(name: \"SampleEnum\"){enumValues{name, description}}}"))
         response.extract<Map<String, Any?>>("data/__type/enumValues[0]") shouldContainAll mapOf(
             "name" to SampleEnum.ONE.name,
             "description" to expected
@@ -145,7 +145,7 @@ class DocumentationSpecificationTest {
     data class Documented(val id: Int)
 
     @Test
-    fun `type may be documented`() {
+    suspend fun `type may be documented`() {
         val expected = "very documented type"
         val schema = defaultSchema {
             query("documented") {
@@ -158,7 +158,7 @@ class DocumentationSpecificationTest {
         }
 
         val response =
-            deserialize(schema.executeBlocking("query { __type(name: \"Documented\") {  name, kind, description } }"))
+            deserialize(schema.execute("query { __type(name: \"Documented\") {  name, kind, description } }"))
         response.extract<String>("data/__type/description") shouldBe expected
     }
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/introspection/IntrospectionSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/introspection/IntrospectionSpecificationTest.kt
@@ -16,6 +16,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldNotContain
 import io.kotest.matchers.string.shouldNotStartWith
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 class IntrospectionSpecificationTest {
@@ -34,7 +35,7 @@ class IntrospectionSpecificationTest {
     data class Data(val string: String)
 
     @Test
-    suspend fun `__typename field can be used to obtain type of object`() {
+    fun `__typename field can be used to obtain type of object`() = runTest {
         val schema = defaultSchema {
             query("sample") {
                 resolver { -> Data("Ronaldingo") }
@@ -46,7 +47,7 @@ class IntrospectionSpecificationTest {
     }
 
     @Test
-    suspend fun `__typename field can be used to obtain type of query`() {
+    fun `__typename field can be used to obtain type of query`() = runTest {
         val schema = defaultSchema {
             query("dummy") {
                 resolver { -> "dummy" }
@@ -58,7 +59,7 @@ class IntrospectionSpecificationTest {
     }
 
     @Test
-    suspend fun `__typename field can be used to obtain type of mutation`() {
+    fun `__typename field can be used to obtain type of mutation`() = runTest {
         val schema = defaultSchema {
             query("dummy") {
                 resolver { -> "dummy" }
@@ -73,7 +74,7 @@ class IntrospectionSpecificationTest {
     }
 
     @Test
-    suspend fun `__typename field cannot be used on scalars`() {
+    fun `__typename field cannot be used on scalars`() = runTest {
         val schema = defaultSchema {
             query("sample") {
                 resolver { -> Data("Ronaldingo") }
@@ -92,7 +93,7 @@ class IntrospectionSpecificationTest {
     data class EnumData(val enum: SampleEnum)
 
     @Test
-    suspend fun `__typename field cannot be used on enums`() {
+    fun `__typename field cannot be used on enums`() = runTest {
         val schema = defaultSchema {
             query("sample") {
                 resolver { -> EnumData(SampleEnum.VALUE) }
@@ -109,7 +110,7 @@ class IntrospectionSpecificationTest {
     data class Union2(val two: String)
 
     @Test
-    suspend fun `__typename field can be used to obtain type of union member in runtime`() {
+    fun `__typename field can be used to obtain type of union member in runtime`() = runTest {
         val schema = defaultSchema {
             type<Data> {
                 unionProperty("union") {
@@ -167,7 +168,7 @@ class IntrospectionSpecificationTest {
     }
 
     @Test
-    suspend fun `field __schema is accessible from the type of the root of a query operation`() {
+    fun `field __schema is accessible from the type of the root of a query operation`() = runTest {
         val schema = defaultSchema {
             query("data") {
                 resolver<String> { "DADA" }
@@ -179,7 +180,7 @@ class IntrospectionSpecificationTest {
     }
 
     @Test
-    suspend fun `field __types is accessible from the type of the root of a query operation`() {
+    fun `field __types is accessible from the type of the root of a query operation`() = runTest {
         val schema = defaultSchema {
             query("data") {
                 resolver<String> { "DADA" }
@@ -238,7 +239,7 @@ class IntrospectionSpecificationTest {
     class Face(override val value: String, override val value2: Boolean = false) : InterInter
 
     @Test
-    suspend fun `__typename returns actual type of object`() {
+    fun `__typename returns actual type of object`() = runTest {
         val schema = defaultSchema {
             query("interface") {
                 resolver { ->
@@ -320,7 +321,7 @@ class IntrospectionSpecificationTest {
     }
 
     @Test
-    suspend fun `introspection field __typename must not leak into schema introspection`() {
+    fun `introspection field __typename must not leak into schema introspection`() = runTest {
         val schema = defaultSchema {
             query("interface") {
                 resolver { -> Face("~~MOCK~~") }
@@ -336,7 +337,7 @@ class IntrospectionSpecificationTest {
     }
 
     @Test
-    suspend fun `introspection types should not contain duplicated float type for kotlin Double and Float`() {
+    fun `introspection types should not contain duplicated float type for kotlin Double and Float`() = runTest {
         val schema = defaultSchema {
             query("interface") {
                 resolver { -> Face("~~MOCK~~") }
@@ -351,7 +352,7 @@ class IntrospectionSpecificationTest {
     }
 
     @Test
-    suspend fun `introspection shouldn't contain LookupSchema nor SchemaProxy`() {
+    fun `introspection shouldn't contain LookupSchema nor SchemaProxy`() = runTest {
         unionSchema.execute(Introspection.query()).run {
             this shouldNotContain "LookupSchema"
             this shouldNotContain "SchemaProxy"
@@ -359,7 +360,7 @@ class IntrospectionSpecificationTest {
     }
 
     @Test
-    suspend fun `__Directive introspection should return all built-in directives as expected`() {
+    fun `__Directive introspection should return all built-in directives as expected`() = runTest {
         val schema = defaultSchema {
             query("interface") {
                 resolver { -> Face("~~MOCK~~") }
@@ -402,7 +403,7 @@ class IntrospectionSpecificationTest {
      * Not part of spec, but assumption of many graphql tools
      */
     @Test
-    suspend fun `query type should have non null, empty interface list`() {
+    fun `query type should have non null, empty interface list`() = runTest {
         val schema = defaultSchema {
             query("interface") {
                 resolver { -> Face("~~MOCK~~") }
@@ -417,7 +418,7 @@ class IntrospectionSpecificationTest {
      * Not part of spec, but assumption of many graphql tools
      */
     @Test
-    suspend fun `__Directive introspection type should have onField, onFragment, onOperation fields`() {
+    fun `__Directive introspection type should have onField, onFragment, onOperation fields`() = runTest {
         val schema = defaultSchema {
             query("interface") {
                 resolver { -> Face("~~MOCK~~") }
@@ -435,7 +436,7 @@ class IntrospectionSpecificationTest {
     }
 
     @Test
-    suspend fun `all available SpecLevels of the introspection query should return without errors`() {
+    fun `all available SpecLevels of the introspection query should return without errors`() = runTest {
         Introspection.SpecLevel.entries.forEach { _ ->
             val schema = defaultSchema {
                 query("sample") {

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/ArgumentsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/ArgumentsSpecificationTest.kt
@@ -7,6 +7,7 @@ import com.apurebase.kgraphql.defaultSchema
 import com.apurebase.kgraphql.deserialize
 import com.apurebase.kgraphql.executeEqualQueries
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
@@ -59,7 +60,7 @@ class ArgumentsSpecificationTest {
     }
 
     @Test
-    suspend fun `arguments are unordered`() {
+    fun `arguments are unordered`() = runTest {
         executeEqualQueries(
             schema,
             mapOf("data" to mapOf("actor" to mapOf("favDishes" to listOf("burger", "bread")))),
@@ -69,7 +70,7 @@ class ArgumentsSpecificationTest {
     }
 
     @Test
-    suspend fun `many arguments can exist on given field`() {
+    fun `many arguments can exist on given field`() = runTest {
         val response = deserialize(schema.execute("{actor{favDishes(size: 2, prefix: \"b\")}}"))
         response shouldBe mapOf<String, Any>(
             "data" to mapOf(
@@ -84,7 +85,7 @@ class ArgumentsSpecificationTest {
     }
 
     @Test
-    suspend fun `all arguments to suspendResolvers`() {
+    fun `all arguments to suspendResolvers`() = runTest {
         val request = """
             {
                 actor {
@@ -114,7 +115,7 @@ class ArgumentsSpecificationTest {
     }
 
     @Test
-    suspend fun `property arguments should accept default values`() {
+    fun `property arguments should accept default values`() = runTest {
         val schema = defaultSchema {
             query("actor") {
                 resolver {
@@ -165,7 +166,7 @@ class ArgumentsSpecificationTest {
 
     // https://github.com/aPureBase/KGraphQL/issues/144
     @Test
-    suspend fun `arguments with lists should preserve generic type`() {
+    fun `arguments with lists should preserve generic type`() = runTest {
         val schema = schema {
             stringScalar<LocalDate> {
                 serialize = { date -> date.toString() }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/ArgumentsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/ArgumentsSpecificationTest.kt
@@ -59,7 +59,7 @@ class ArgumentsSpecificationTest {
     }
 
     @Test
-    fun `arguments are unordered`() {
+    suspend fun `arguments are unordered`() {
         executeEqualQueries(
             schema,
             mapOf("data" to mapOf("actor" to mapOf("favDishes" to listOf("burger", "bread")))),
@@ -69,8 +69,8 @@ class ArgumentsSpecificationTest {
     }
 
     @Test
-    fun `many arguments can exist on given field`() {
-        val response = deserialize(schema.executeBlocking("{actor{favDishes(size: 2, prefix: \"b\")}}"))
+    suspend fun `many arguments can exist on given field`() {
+        val response = deserialize(schema.execute("{actor{favDishes(size: 2, prefix: \"b\")}}"))
         response shouldBe mapOf<String, Any>(
             "data" to mapOf(
                 "actor" to mapOf(
@@ -84,7 +84,7 @@ class ArgumentsSpecificationTest {
     }
 
     @Test
-    fun `all arguments to suspendResolvers`() {
+    suspend fun `all arguments to suspendResolvers`() {
         val request = """
             {
                 actor {
@@ -97,7 +97,7 @@ class ArgumentsSpecificationTest {
                 }
             }
         """.trimIndent()
-        val response = deserialize(schema.executeBlocking(request))
+        val response = deserialize(schema.execute(request))
         response shouldBe
             mapOf<String, Any>(
                 "data" to mapOf(
@@ -114,7 +114,7 @@ class ArgumentsSpecificationTest {
     }
 
     @Test
-    fun `property arguments should accept default values`() {
+    suspend fun `property arguments should accept default values`() {
         val schema = defaultSchema {
             query("actor") {
                 resolver {
@@ -142,7 +142,7 @@ class ArgumentsSpecificationTest {
             }
         """.trimIndent()
 
-        val response = deserialize(schema.executeBlocking(request))
+        val response = deserialize(schema.execute(request))
         response shouldBe
             mapOf<String, Any>(
                 "data" to mapOf<String, Any>(
@@ -165,7 +165,7 @@ class ArgumentsSpecificationTest {
 
     // https://github.com/aPureBase/KGraphQL/issues/144
     @Test
-    fun `arguments with lists should preserve generic type`() {
+    suspend fun `arguments with lists should preserve generic type`() {
         val schema = schema {
             stringScalar<LocalDate> {
                 serialize = { date -> date.toString() }
@@ -182,7 +182,7 @@ class ArgumentsSpecificationTest {
             }
         }
 
-        val result = schema.executeBlocking(
+        val result = schema.execute(
             """
             {
                 slots {

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/FieldAliasSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/FieldAliasSpecificationTest.kt
@@ -6,6 +6,7 @@ import com.apurebase.kgraphql.defaultSchema
 import com.apurebase.kgraphql.deserialize
 import com.apurebase.kgraphql.extract
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 @Specification("2.7 Field Alias")
@@ -28,7 +29,7 @@ class FieldAliasSpecificationTest {
     }
 
     @Test
-    suspend fun `can define response object field name`() {
+    fun `can define response object field name`() = runTest {
         val map =
             deserialize(schema.execute("{actor{ageMonths: age(inMonths : true) ageYears: age(inMonths : false)}}"))
         map.extract<Int>("data/actor/ageMonths") shouldBe age * 12
@@ -36,7 +37,7 @@ class FieldAliasSpecificationTest {
     }
 
     @Test
-    suspend fun `top level of a query can be given alias`() {
+    fun `top level of a query can be given alias`() = runTest {
         val map = deserialize(schema.execute("{ bogus : actor{name}}"))
         map.extract<String>("data/bogus/name") shouldBe actorName
     }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/FieldAliasSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/FieldAliasSpecificationTest.kt
@@ -28,16 +28,16 @@ class FieldAliasSpecificationTest {
     }
 
     @Test
-    fun `can define response object field name`() {
+    suspend fun `can define response object field name`() {
         val map =
-            deserialize(schema.executeBlocking("{actor{ageMonths: age(inMonths : true) ageYears: age(inMonths : false)}}"))
+            deserialize(schema.execute("{actor{ageMonths: age(inMonths : true) ageYears: age(inMonths : false)}}"))
         map.extract<Int>("data/actor/ageMonths") shouldBe age * 12
         map.extract<Int>("data/actor/ageYears") shouldBe age
     }
 
     @Test
-    fun `top level of a query can be given alias`() {
-        val map = deserialize(schema.executeBlocking("{ bogus : actor{name}}"))
+    suspend fun `top level of a query can be given alias`() {
+        val map = deserialize(schema.execute("{ bogus : actor{name}}"))
         map.extract<String>("data/bogus/name") shouldBe actorName
     }
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/FieldsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/FieldsSpecificationTest.kt
@@ -22,8 +22,8 @@ class FieldsSpecificationTest {
     }
 
     @Test
-    fun `field may itself contain a selection set`() {
-        val response = deserialize(schema.executeBlocking("{actor{id, actualActor{name, age}}}"))
+    suspend fun `field may itself contain a selection set`() {
+        val response = deserialize(schema.execute("{actor{id, actualActor{name, age}}}"))
         val map = response.extract<Map<String, Any>>("data/actor/actualActor")
         map shouldBe mapOf("name" to "Boguś Linda", "age" to age)
     }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/FieldsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/FieldsSpecificationTest.kt
@@ -6,6 +6,7 @@ import com.apurebase.kgraphql.defaultSchema
 import com.apurebase.kgraphql.deserialize
 import com.apurebase.kgraphql.extract
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 @Specification("2.5 Fields")
@@ -22,7 +23,7 @@ class FieldsSpecificationTest {
     }
 
     @Test
-    suspend fun `field may itself contain a selection set`() {
+    fun `field may itself contain a selection set`() = runTest {
         val response = deserialize(schema.execute("{actor{id, actualActor{name, age}}}"))
         val map = response.extract<Map<String, Any>>("data/actor/actualActor")
         map shouldBe mapOf("name" to "Boguś Linda", "age" to age)

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/FragmentsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/FragmentsSpecificationTest.kt
@@ -38,7 +38,7 @@ class FragmentsSpecificationTest {
     private val baseTestSchema = object : BaseSchemaTest() {}
 
     @Test
-    fun `fragment's fields are added to the query at the same level as the fragment invocation`() {
+    suspend fun `fragment's fields are added to the query at the same level as the fragment invocation`() {
         val expected = mapOf(
             "data" to mapOf(
                 "actor" to mapOf(
@@ -56,7 +56,7 @@ class FragmentsSpecificationTest {
     }
 
     @Test
-    fun `fragments can be nested`() {
+    suspend fun `fragments can be nested`() {
         val expected = mapOf(
             "data" to mapOf(
                 "actor" to mapOf(
@@ -74,9 +74,9 @@ class FragmentsSpecificationTest {
     }
 
     @Test
-    fun `inline fragments may also be used to apply a directive to a group of fields`() {
+    suspend fun `inline fragments may also be used to apply a directive to a group of fields`() {
         val response = deserialize(
-            schema.executeBlocking(
+            schema.execute(
                 "query (\$expandedInfo : Boolean!){actor{actualActor{name ... @include(if: \$expandedInfo){ age }}}}",
                 "{\"expandedInfo\":false}"
             )
@@ -87,7 +87,7 @@ class FragmentsSpecificationTest {
     }
 
     @Test
-    fun `query with inline fragment with type condition`() {
+    suspend fun `query with inline fragment with type condition`() {
         val map = baseTestSchema.execute("{people{name, age, ... on Actor {isOld} ... on Director {favActors{name}}}}")
         assertNoErrors(map)
         for (i in map.extract<List<*>>("data/people").indices) {
@@ -107,7 +107,7 @@ class FragmentsSpecificationTest {
     }
 
     @Test
-    fun `query with external fragment with type condition`() {
+    suspend fun `query with external fragment with type condition`() {
         val map =
             baseTestSchema.execute("{people{name, age ...act ...dir}} fragment act on Actor {isOld} fragment dir on Director {favActors{name}}")
         assertNoErrors(map)
@@ -128,7 +128,7 @@ class FragmentsSpecificationTest {
     }
 
     @Test
-    fun `multiple nested fragments are handled`() {
+    suspend fun `multiple nested fragments are handled`() {
         val map = baseTestSchema.execute(Introspection.query())
         val fields = map.extract<List<Map<String, *>>>("data/__schema/types[0]/fields")
 
@@ -138,7 +138,7 @@ class FragmentsSpecificationTest {
     }
 
     @Test
-    fun `queries with recursive fragments are denied`() {
+    suspend fun `queries with recursive fragments are denied`() {
         expect<ValidationException>("Fragment spread circular references are not allowed") {
             baseTestSchema.execute(
                 """
@@ -164,7 +164,7 @@ class FragmentsSpecificationTest {
     }
 
     @Test
-    fun `queries with duplicated fragments are denied`() {
+    suspend fun `queries with duplicated fragments are denied`() {
         expect<ValidationException>("There can be only one fragment named film_title.") {
             baseTestSchema.execute(
                 """
@@ -197,7 +197,7 @@ class FragmentsSpecificationTest {
     // https://github.com/aPureBase/KGraphQL/issues/141
     // https://github.com/stuebingerb/KGraphQL/issues/130
     @Test
-    fun `fragments on union types should work`() {
+    suspend fun `fragments on union types should work`() {
         val schema = KGraphQL.schema {
             unionType<TopUnion>()
 
@@ -212,7 +212,7 @@ class FragmentsSpecificationTest {
             }
         }
 
-        val nameResult = schema.executeBlocking(
+        val nameResult = schema.execute(
             """
             {
                 unions(isOne: true) {
@@ -228,7 +228,7 @@ class FragmentsSpecificationTest {
         ).deserialize()
         nameResult.extract<List<String>>("data/unions/names") shouldBe listOf("name1", "name2")
 
-        val numberResult = schema.executeBlocking(
+        val numberResult = schema.execute(
             """
             {
                 unions(isOne: false) {
@@ -267,8 +267,8 @@ class FragmentsSpecificationTest {
 
     // https://github.com/aPureBase/KGraphQL/issues/197
     @Test
-    fun `executor should merge fragment declaration and field declaration`() {
-        val response = testedSchema.executeBlocking(
+    suspend fun `executor should merge fragment declaration and field declaration`() {
+        val response = testedSchema.execute(
             """
             { 
                 outer { 
@@ -306,8 +306,8 @@ class FragmentsSpecificationTest {
 
     // https://github.com/aPureBase/KGraphQL/issues/197
     @Test
-    fun `executor should merge several fragment declarations and field declaration`() {
-        val response = testedSchema.executeBlocking(
+    suspend fun `executor should merge several fragment declarations and field declaration`() {
+        val response = testedSchema.execute(
             """
             { 
                 outer { 
@@ -348,7 +348,7 @@ class FragmentsSpecificationTest {
 
     // https://github.com/aPureBase/KGraphQL/issues/189
     @Test
-    fun `queries with missing fragments should return proper error message`() {
+    suspend fun `queries with missing fragments should return proper error message`() {
         expect<ValidationException>("Fragment film_title_misspelled not found") {
             baseTestSchema.execute(
                 """

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/FragmentsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/FragmentsSpecificationTest.kt
@@ -16,6 +16,7 @@ import io.kotest.assertions.throwables.shouldThrowExactly
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 @Specification("2.8 Fragments")
@@ -38,7 +39,7 @@ class FragmentsSpecificationTest {
     private val baseTestSchema = object : BaseSchemaTest() {}
 
     @Test
-    suspend fun `fragment's fields are added to the query at the same level as the fragment invocation`() {
+    fun `fragment's fields are added to the query at the same level as the fragment invocation`() = runTest {
         val expected = mapOf(
             "data" to mapOf(
                 "actor" to mapOf(
@@ -56,7 +57,7 @@ class FragmentsSpecificationTest {
     }
 
     @Test
-    suspend fun `fragments can be nested`() {
+    fun `fragments can be nested`() = runTest {
         val expected = mapOf(
             "data" to mapOf(
                 "actor" to mapOf(
@@ -74,7 +75,7 @@ class FragmentsSpecificationTest {
     }
 
     @Test
-    suspend fun `inline fragments may also be used to apply a directive to a group of fields`() {
+    fun `inline fragments may also be used to apply a directive to a group of fields`() = runTest {
         val response = deserialize(
             schema.execute(
                 "query (\$expandedInfo : Boolean!){actor{actualActor{name ... @include(if: \$expandedInfo){ age }}}}",
@@ -87,7 +88,7 @@ class FragmentsSpecificationTest {
     }
 
     @Test
-    suspend fun `query with inline fragment with type condition`() {
+    fun `query with inline fragment with type condition`() = runTest {
         val map = baseTestSchema.execute("{people{name, age, ... on Actor {isOld} ... on Director {favActors{name}}}}")
         assertNoErrors(map)
         for (i in map.extract<List<*>>("data/people").indices) {
@@ -107,7 +108,7 @@ class FragmentsSpecificationTest {
     }
 
     @Test
-    suspend fun `query with external fragment with type condition`() {
+    fun `query with external fragment with type condition`() = runTest {
         val map =
             baseTestSchema.execute("{people{name, age ...act ...dir}} fragment act on Actor {isOld} fragment dir on Director {favActors{name}}")
         assertNoErrors(map)
@@ -128,7 +129,7 @@ class FragmentsSpecificationTest {
     }
 
     @Test
-    suspend fun `multiple nested fragments are handled`() {
+    fun `multiple nested fragments are handled`() = runTest {
         val map = baseTestSchema.execute(Introspection.query())
         val fields = map.extract<List<Map<String, *>>>("data/__schema/types[0]/fields")
 
@@ -138,7 +139,7 @@ class FragmentsSpecificationTest {
     }
 
     @Test
-    suspend fun `queries with recursive fragments are denied`() {
+    fun `queries with recursive fragments are denied`() = runTest {
         expect<ValidationException>("Fragment spread circular references are not allowed") {
             baseTestSchema.execute(
                 """
@@ -164,7 +165,7 @@ class FragmentsSpecificationTest {
     }
 
     @Test
-    suspend fun `queries with duplicated fragments are denied`() {
+    fun `queries with duplicated fragments are denied`() = runTest {
         expect<ValidationException>("There can be only one fragment named film_title.") {
             baseTestSchema.execute(
                 """
@@ -197,7 +198,7 @@ class FragmentsSpecificationTest {
     // https://github.com/aPureBase/KGraphQL/issues/141
     // https://github.com/stuebingerb/KGraphQL/issues/130
     @Test
-    suspend fun `fragments on union types should work`() {
+    fun `fragments on union types should work`() = runTest {
         val schema = KGraphQL.schema {
             unionType<TopUnion>()
 
@@ -267,7 +268,7 @@ class FragmentsSpecificationTest {
 
     // https://github.com/aPureBase/KGraphQL/issues/197
     @Test
-    suspend fun `executor should merge fragment declaration and field declaration`() {
+    fun `executor should merge fragment declaration and field declaration`() = runTest {
         val response = testedSchema.execute(
             """
             { 
@@ -306,7 +307,7 @@ class FragmentsSpecificationTest {
 
     // https://github.com/aPureBase/KGraphQL/issues/197
     @Test
-    suspend fun `executor should merge several fragment declarations and field declaration`() {
+    fun `executor should merge several fragment declarations and field declaration`() = runTest {
         val response = testedSchema.execute(
             """
             { 
@@ -348,7 +349,7 @@ class FragmentsSpecificationTest {
 
     // https://github.com/aPureBase/KGraphQL/issues/189
     @Test
-    suspend fun `queries with missing fragments should return proper error message`() {
+    fun `queries with missing fragments should return proper error message`() = runTest {
         expect<ValidationException>("Fragment film_title_misspelled not found") {
             baseTestSchema.execute(
                 """

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/InputValuesSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/InputValuesSpecificationTest.kt
@@ -41,18 +41,18 @@ class InputValuesSpecificationTest {
 
     @Test
     @Specification("2.9.1 Int Value")
-    fun `Int input value`() {
+    suspend fun `Int input value`() {
         val input = 4356
-        val response = deserialize(schema.executeBlocking("{ Int(value: $input) }"))
+        val response = deserialize(schema.execute("{ Int(value: $input) }"))
         response.extract<Int>("data/Int") shouldBe input
     }
 
     @ParameterizedTest
     @ValueSource(strings = ["42.0", "\"foo\"", "bar"])
     @Specification("2.9.1 Int Value")
-    fun `Invalid Int input value`(value: String) {
+    suspend fun `Invalid Int input value`(value: String) {
         val exception = shouldThrowExactly<InvalidInputValueException> {
-            deserialize(schema.executeBlocking("{ Int(value: $value) }"))
+            deserialize(schema.execute("{ Int(value: $value) }"))
         }
         exception shouldHaveMessage "Cannot coerce $value to numeric constant"
         exception.extensions shouldBe mapOf(
@@ -62,26 +62,26 @@ class InputValuesSpecificationTest {
 
     @Test
     @Specification("2.9.2 Float Value")
-    fun `Float input value`() {
+    suspend fun `Float input value`() {
         val input = 4356.34
-        val response = deserialize(schema.executeBlocking("{ Float(value: $input) }"))
+        val response = deserialize(schema.execute("{ Float(value: $input) }"))
         response.extract<Double>("data/Float") shouldBe input
     }
 
     @Test
     @Specification("2.9.2 Float Value")
-    fun `Double input value`() {
+    suspend fun `Double input value`() {
         // GraphQL Float is Kotlin Double
         val input = 4356.34
-        val response = deserialize(schema.executeBlocking("{ Double(value: $input) }"))
+        val response = deserialize(schema.execute("{ Double(value: $input) }"))
         response.extract<Double>("data/Double") shouldBe input
     }
 
     @Test
     @Specification("2.9.2 Float Value")
-    fun `Double with exponential input value`() {
+    suspend fun `Double with exponential input value`() {
         val input = 4356.34e2
-        val response = deserialize(schema.executeBlocking("{ Double(value: $input) }"))
+        val response = deserialize(schema.execute("{ Double(value: $input) }"))
         response.extract<Double>("data/Double") shouldBe input
     }
 
@@ -102,17 +102,17 @@ class InputValuesSpecificationTest {
         ]
     )
     @Specification("2.9.3 Boolean Value")
-    fun `Boolean input value`(input: String, expected: Boolean) {
-        val response = deserialize(schema.executeBlocking("{ Boolean(value: $input) }"))
+    suspend fun `Boolean input value`(input: String, expected: Boolean) {
+        val response = deserialize(schema.execute("{ Boolean(value: $input) }"))
         response.extract<Boolean>("data/Boolean") shouldBe expected
     }
 
     @ParameterizedTest
     @ValueSource(strings = ["null", "42", "\"foo\"", "[\"foo\", \"bar\"]"])
     @Specification("2.9.3 Boolean Value")
-    fun `Invalid Boolean input value`(value: String) {
+    suspend fun `Invalid Boolean input value`(value: String) {
         val exception = shouldThrowExactly<InvalidInputValueException> {
-            deserialize(schema.executeBlocking("{ Boolean(value: $value) }"))
+            deserialize(schema.execute("{ Boolean(value: $value) }"))
         }
         exception shouldHaveMessage "argument '$value' is not valid value of type Boolean"
         exception.extensions shouldBe mapOf(
@@ -122,28 +122,28 @@ class InputValuesSpecificationTest {
 
     @Test
     @Specification("2.9.4 String Value")
-    fun `String input value`() {
+    suspend fun `String input value`() {
         val input = "\\\\Ala ma kota \\n\\\\kot ma Alę"
         val expected = "\\Ala ma kota \n\\kot ma Alę"
-        val response = deserialize(schema.executeBlocking("{ String(value: \"$input\") }"))
+        val response = deserialize(schema.execute("{ String(value: \"$input\") }"))
         response.extract<String>("data/String") shouldBe expected
     }
 
     @Test
     @Specification("2.9.4 String Value")
-    fun `String block input value`() {
+    suspend fun `String block input value`() {
         val input = "\\Ala ma kota \n\\kot ma Alę"
         val expected = "\\Ala ma kota \n\\kot ma Alę"
-        val response = deserialize(schema.executeBlocking("{ String(value: \"\"\"$input\"\"\") }"))
+        val response = deserialize(schema.execute("{ String(value: \"\"\"$input\"\"\") }"))
         response.extract<String>("data/String") shouldBe expected
     }
 
     @ParameterizedTest
     @ValueSource(strings = ["null", "true", "42", "[\"foo\", \"bar\"]"])
     @Specification("2.9.4 String Value")
-    fun `Invalid String input value`(value: String) {
+    suspend fun `Invalid String input value`(value: String) {
         val exception = shouldThrowExactly<InvalidInputValueException> {
-            deserialize(schema.executeBlocking("{ String(value: $value) }"))
+            deserialize(schema.execute("{ String(value: $value) }"))
         }
         exception shouldHaveMessage "argument '$value' is not valid value of type String"
         exception.extensions shouldBe mapOf(
@@ -153,24 +153,24 @@ class InputValuesSpecificationTest {
 
     @Test
     @Specification("2.9.5 Null Value")
-    fun `Null input value`() {
-        val response = deserialize(schema.executeBlocking("{ Null(value: null) }"))
+    suspend fun `Null input value`() {
+        val response = deserialize(schema.execute("{ Null(value: null) }"))
         response.extract<Nothing?>("data/Null") shouldBe null
     }
 
     @Test
     @Specification("2.9.6 Enum Value")
-    fun `Enum input value`() {
-        val response = deserialize(schema.executeBlocking("{ Enum(value: ENUM1) }"))
+    suspend fun `Enum input value`() {
+        val response = deserialize(schema.execute("{ Enum(value: ENUM1) }"))
         response.extract<String>("data/Enum") shouldBe FakeEnum.ENUM1.toString()
     }
 
     @ParameterizedTest
     @ValueSource(strings = ["ENUM3"])
     @Specification("2.9.6 Enum Value")
-    fun `Invalid Enum input value`(value: String) {
+    suspend fun `Invalid Enum input value`(value: String) {
         val exception = shouldThrowExactly<InvalidInputValueException> {
-            deserialize(schema.executeBlocking("{ Enum(value: $value) }"))
+            deserialize(schema.execute("{ Enum(value: $value) }"))
         }
         exception shouldHaveMessage "Invalid enum ${FakeEnum::class.simpleName} value. Expected one of [ENUM1, ENUM2]"
         exception.extensions shouldBe mapOf(
@@ -180,17 +180,17 @@ class InputValuesSpecificationTest {
 
     @Test
     @Specification("2.9.7 List Value")
-    fun `List input value`() {
-        val response = deserialize(schema.executeBlocking("{ List(value: [23, 3, 23]) }"))
+    suspend fun `List input value`() {
+        val response = deserialize(schema.execute("{ List(value: [23, 3, 23]) }"))
         response.extract<List<Int>>("data/List") shouldBe listOf(23, 3, 23)
     }
 
     @ParameterizedTest
     @ValueSource(strings = ["true", "\"foo\""])
     @Specification("2.9.7 List Value")
-    fun `Invalid List input value`(value: String) {
+    suspend fun `Invalid List input value`(value: String) {
         val exception = shouldThrowExactly<InvalidInputValueException> {
-            deserialize(schema.executeBlocking("{ List(value: $value) }"))
+            deserialize(schema.execute("{ List(value: $value) }"))
         }
         exception shouldHaveMessage "Cannot coerce $value to numeric constant"
         exception.extensions shouldBe mapOf(
@@ -200,9 +200,9 @@ class InputValuesSpecificationTest {
 
     @Test
     @Specification("2.9.8 Object Value")
-    fun `Literal object input value`() {
+    suspend fun `Literal object input value`() {
         val response = deserialize(
-            schema.executeBlocking("{ Object(value: { number: 232, description: \"little number\" }) }")
+            schema.execute("{ Object(value: { number: 232, description: \"little number\" }) }")
         )
         response.extract<Int>("data/Object") shouldBe 232
     }
@@ -210,9 +210,9 @@ class InputValuesSpecificationTest {
     @ParameterizedTest
     @ValueSource(strings = ["null", "true", "42"])
     @Specification("2.9.8 Object Value")
-    fun `Invalid Literal object input value`(value: String) {
+    suspend fun `Invalid Literal object input value`(value: String) {
         val exception = shouldThrowExactly<InvalidInputValueException> {
-            schema.executeBlocking("{ Object(value: { number: 232, description: \"little number\", list: $value }) }")
+            schema.execute("{ Object(value: { number: 232, description: \"little number\", list: $value }) }")
         }
         exception shouldHaveMessage "argument '$value' is not valid value of type String"
         exception.extensions shouldBe mapOf(
@@ -222,9 +222,9 @@ class InputValuesSpecificationTest {
 
     @Test
     @Specification("2.9.8 Object Value")
-    fun `Invalid Literal object input value - null`() {
+    suspend fun `Invalid Literal object input value - null`() {
         val exception = shouldThrowExactly<InvalidInputValueException> {
-            schema.executeBlocking("{ Object(value: null) }")
+            schema.execute("{ Object(value: null) }")
         }
         exception shouldHaveMessage "argument 'null' is not valid value of type FakeData"
         exception.extensions shouldBe mapOf(
@@ -234,9 +234,9 @@ class InputValuesSpecificationTest {
 
     @Test
     @Specification("2.9.8 Object Value")
-    fun `Literal object input value with list field`() {
+    suspend fun `Literal object input value with list field`() {
         val response = deserialize(
-            schema.executeBlocking(
+            schema.execute(
                 """
                 {
                     ObjectList(
@@ -255,9 +255,9 @@ class InputValuesSpecificationTest {
 
     @Test
     @Specification("2.9.8 Object Value")
-    fun `Object input value`() {
+    suspend fun `Object input value`() {
         val response = deserialize(
-            schema.executeBlocking(
+            schema.execute(
                 request = "query(\$object: FakeData!) { Object(value: \$object) }",
                 variables = "{ \"object\": { \"number\": 232, \"description\": \"little number\" } }"
             )
@@ -267,9 +267,9 @@ class InputValuesSpecificationTest {
 
     @Test
     @Specification("2.9.8 Object Value")
-    fun `Object input value with list field`() {
+    suspend fun `Object input value with list field`() {
         val response = deserialize(
-            schema.executeBlocking(
+            schema.execute(
                 request = "query(\$object: FakeData!){ ObjectList(value: \$object) }",
                 variables = "{ \"object\": { \"number\": 232, \"description\": \"little number\", \"list\": [\"number\", \"description\", \"little number\"] } }"
             )
@@ -279,8 +279,8 @@ class InputValuesSpecificationTest {
 
     @Test
     @Specification("2.9.8 Object Value")
-    fun `Input object value mixed with variables`() {
-        val response = schema.executeBlocking(
+    suspend fun `Input object value mixed with variables`() {
+        val response = schema.execute(
             """
             query ObjectVariablesMixed(${'$'}description: String!, ${'$'}number: Int! = 25) {
                 ObjectList(value: {
@@ -301,9 +301,9 @@ class InputValuesSpecificationTest {
 
     @Test
     @Specification("2.9.8 Object Value")
-    fun `Unknown object input value type`() {
+    suspend fun `Unknown object input value type`() {
         val exception = shouldThrowExactly<InvalidInputValueException> {
-            schema.executeBlocking("query(\$object: FakeDate) { Object(value: \$object) }")
+            schema.execute("query(\$object: FakeDate) { Object(value: \$object) }")
         }
         exception shouldHaveMessage "Invalid variable \$object argument type FakeDate, expected FakeData!"
         exception.extensions shouldBe mapOf(
@@ -322,7 +322,7 @@ class InputValuesSpecificationTest {
 
     // https://github.com/aPureBase/KGraphQL/issues/199
     @Test
-    fun `input object value with interface`() {
+    suspend fun `input object value with interface`() {
         val schema = KGraphQL.schema {
             inputType<Dessert> {
                 name = "DessertInput"
@@ -336,7 +336,7 @@ class InputValuesSpecificationTest {
             }
         }
 
-        schema.executeBlocking("""
+        schema.execute("""
             query {
                 dessert { id name }
             }
@@ -344,7 +344,7 @@ class InputValuesSpecificationTest {
             {"data":{"dessert":{"id":"id-1","name":"name-1"}}}
         """.trimIndent()
 
-        schema.executeBlocking("""
+        schema.execute("""
             mutation {
                 updateDessert(dessert: {id: "id-2", name: "name-2"}) { id name }
             }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/InputValuesSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/InputValuesSpecificationTest.kt
@@ -9,6 +9,7 @@ import com.apurebase.kgraphql.extract
 import io.kotest.assertions.throwables.shouldThrowExactly
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.throwable.shouldHaveMessage
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
@@ -41,7 +42,7 @@ class InputValuesSpecificationTest {
 
     @Test
     @Specification("2.9.1 Int Value")
-    suspend fun `Int input value`() {
+    fun `Int input value`() = runTest {
         val input = 4356
         val response = deserialize(schema.execute("{ Int(value: $input) }"))
         response.extract<Int>("data/Int") shouldBe input
@@ -50,7 +51,7 @@ class InputValuesSpecificationTest {
     @ParameterizedTest
     @ValueSource(strings = ["42.0", "\"foo\"", "bar"])
     @Specification("2.9.1 Int Value")
-    suspend fun `Invalid Int input value`(value: String) {
+    fun `Invalid Int input value`(value: String) = runTest {
         val exception = shouldThrowExactly<InvalidInputValueException> {
             deserialize(schema.execute("{ Int(value: $value) }"))
         }
@@ -62,7 +63,7 @@ class InputValuesSpecificationTest {
 
     @Test
     @Specification("2.9.2 Float Value")
-    suspend fun `Float input value`() {
+    fun `Float input value`() = runTest {
         val input = 4356.34
         val response = deserialize(schema.execute("{ Float(value: $input) }"))
         response.extract<Double>("data/Float") shouldBe input
@@ -70,7 +71,7 @@ class InputValuesSpecificationTest {
 
     @Test
     @Specification("2.9.2 Float Value")
-    suspend fun `Double input value`() {
+    fun `Double input value`() = runTest {
         // GraphQL Float is Kotlin Double
         val input = 4356.34
         val response = deserialize(schema.execute("{ Double(value: $input) }"))
@@ -79,7 +80,7 @@ class InputValuesSpecificationTest {
 
     @Test
     @Specification("2.9.2 Float Value")
-    suspend fun `Double with exponential input value`() {
+    fun `Double with exponential input value`() = runTest {
         val input = 4356.34e2
         val response = deserialize(schema.execute("{ Double(value: $input) }"))
         response.extract<Double>("data/Double") shouldBe input
@@ -102,7 +103,7 @@ class InputValuesSpecificationTest {
         ]
     )
     @Specification("2.9.3 Boolean Value")
-    suspend fun `Boolean input value`(input: String, expected: Boolean) {
+    fun `Boolean input value`(input: String, expected: Boolean) = runTest {
         val response = deserialize(schema.execute("{ Boolean(value: $input) }"))
         response.extract<Boolean>("data/Boolean") shouldBe expected
     }
@@ -110,7 +111,7 @@ class InputValuesSpecificationTest {
     @ParameterizedTest
     @ValueSource(strings = ["null", "42", "\"foo\"", "[\"foo\", \"bar\"]"])
     @Specification("2.9.3 Boolean Value")
-    suspend fun `Invalid Boolean input value`(value: String) {
+    fun `Invalid Boolean input value`(value: String) = runTest {
         val exception = shouldThrowExactly<InvalidInputValueException> {
             deserialize(schema.execute("{ Boolean(value: $value) }"))
         }
@@ -122,7 +123,7 @@ class InputValuesSpecificationTest {
 
     @Test
     @Specification("2.9.4 String Value")
-    suspend fun `String input value`() {
+    fun `String input value`() = runTest {
         val input = "\\\\Ala ma kota \\n\\\\kot ma Alę"
         val expected = "\\Ala ma kota \n\\kot ma Alę"
         val response = deserialize(schema.execute("{ String(value: \"$input\") }"))
@@ -131,7 +132,7 @@ class InputValuesSpecificationTest {
 
     @Test
     @Specification("2.9.4 String Value")
-    suspend fun `String block input value`() {
+    fun `String block input value`() = runTest {
         val input = "\\Ala ma kota \n\\kot ma Alę"
         val expected = "\\Ala ma kota \n\\kot ma Alę"
         val response = deserialize(schema.execute("{ String(value: \"\"\"$input\"\"\") }"))
@@ -141,7 +142,7 @@ class InputValuesSpecificationTest {
     @ParameterizedTest
     @ValueSource(strings = ["null", "true", "42", "[\"foo\", \"bar\"]"])
     @Specification("2.9.4 String Value")
-    suspend fun `Invalid String input value`(value: String) {
+    fun `Invalid String input value`(value: String) = runTest {
         val exception = shouldThrowExactly<InvalidInputValueException> {
             deserialize(schema.execute("{ String(value: $value) }"))
         }
@@ -153,14 +154,14 @@ class InputValuesSpecificationTest {
 
     @Test
     @Specification("2.9.5 Null Value")
-    suspend fun `Null input value`() {
+    fun `Null input value`() = runTest {
         val response = deserialize(schema.execute("{ Null(value: null) }"))
         response.extract<Nothing?>("data/Null") shouldBe null
     }
 
     @Test
     @Specification("2.9.6 Enum Value")
-    suspend fun `Enum input value`() {
+    fun `Enum input value`() = runTest {
         val response = deserialize(schema.execute("{ Enum(value: ENUM1) }"))
         response.extract<String>("data/Enum") shouldBe FakeEnum.ENUM1.toString()
     }
@@ -168,7 +169,7 @@ class InputValuesSpecificationTest {
     @ParameterizedTest
     @ValueSource(strings = ["ENUM3"])
     @Specification("2.9.6 Enum Value")
-    suspend fun `Invalid Enum input value`(value: String) {
+    fun `Invalid Enum input value`(value: String) = runTest {
         val exception = shouldThrowExactly<InvalidInputValueException> {
             deserialize(schema.execute("{ Enum(value: $value) }"))
         }
@@ -180,7 +181,7 @@ class InputValuesSpecificationTest {
 
     @Test
     @Specification("2.9.7 List Value")
-    suspend fun `List input value`() {
+    fun `List input value`() = runTest {
         val response = deserialize(schema.execute("{ List(value: [23, 3, 23]) }"))
         response.extract<List<Int>>("data/List") shouldBe listOf(23, 3, 23)
     }
@@ -188,7 +189,7 @@ class InputValuesSpecificationTest {
     @ParameterizedTest
     @ValueSource(strings = ["true", "\"foo\""])
     @Specification("2.9.7 List Value")
-    suspend fun `Invalid List input value`(value: String) {
+    fun `Invalid List input value`(value: String) = runTest {
         val exception = shouldThrowExactly<InvalidInputValueException> {
             deserialize(schema.execute("{ List(value: $value) }"))
         }
@@ -200,7 +201,7 @@ class InputValuesSpecificationTest {
 
     @Test
     @Specification("2.9.8 Object Value")
-    suspend fun `Literal object input value`() {
+    fun `Literal object input value`() = runTest {
         val response = deserialize(
             schema.execute("{ Object(value: { number: 232, description: \"little number\" }) }")
         )
@@ -210,7 +211,7 @@ class InputValuesSpecificationTest {
     @ParameterizedTest
     @ValueSource(strings = ["null", "true", "42"])
     @Specification("2.9.8 Object Value")
-    suspend fun `Invalid Literal object input value`(value: String) {
+    fun `Invalid Literal object input value`(value: String) = runTest {
         val exception = shouldThrowExactly<InvalidInputValueException> {
             schema.execute("{ Object(value: { number: 232, description: \"little number\", list: $value }) }")
         }
@@ -222,7 +223,7 @@ class InputValuesSpecificationTest {
 
     @Test
     @Specification("2.9.8 Object Value")
-    suspend fun `Invalid Literal object input value - null`() {
+    fun `Invalid Literal object input value - null`() = runTest {
         val exception = shouldThrowExactly<InvalidInputValueException> {
             schema.execute("{ Object(value: null) }")
         }
@@ -234,7 +235,7 @@ class InputValuesSpecificationTest {
 
     @Test
     @Specification("2.9.8 Object Value")
-    suspend fun `Literal object input value with list field`() {
+    fun `Literal object input value with list field`() = runTest {
         val response = deserialize(
             schema.execute(
                 """
@@ -255,7 +256,7 @@ class InputValuesSpecificationTest {
 
     @Test
     @Specification("2.9.8 Object Value")
-    suspend fun `Object input value`() {
+    fun `Object input value`() = runTest {
         val response = deserialize(
             schema.execute(
                 request = "query(\$object: FakeData!) { Object(value: \$object) }",
@@ -267,7 +268,7 @@ class InputValuesSpecificationTest {
 
     @Test
     @Specification("2.9.8 Object Value")
-    suspend fun `Object input value with list field`() {
+    fun `Object input value with list field`() = runTest {
         val response = deserialize(
             schema.execute(
                 request = "query(\$object: FakeData!){ ObjectList(value: \$object) }",
@@ -279,7 +280,7 @@ class InputValuesSpecificationTest {
 
     @Test
     @Specification("2.9.8 Object Value")
-    suspend fun `Input object value mixed with variables`() {
+    fun `Input object value mixed with variables`() = runTest {
         val response = schema.execute(
             """
             query ObjectVariablesMixed(${'$'}description: String!, ${'$'}number: Int! = 25) {
@@ -301,7 +302,7 @@ class InputValuesSpecificationTest {
 
     @Test
     @Specification("2.9.8 Object Value")
-    suspend fun `Unknown object input value type`() {
+    fun `Unknown object input value type`() = runTest {
         val exception = shouldThrowExactly<InvalidInputValueException> {
             schema.execute("query(\$object: FakeDate) { Object(value: \$object) }")
         }
@@ -322,7 +323,7 @@ class InputValuesSpecificationTest {
 
     // https://github.com/aPureBase/KGraphQL/issues/199
     @Test
-    suspend fun `input object value with interface`() {
+    fun `input object value with interface`() = runTest {
         val schema = KGraphQL.schema {
             inputType<Dessert> {
                 name = "DessertInput"

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/ListInputCoercionTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/ListInputCoercionTest.kt
@@ -7,6 +7,7 @@ import com.apurebase.kgraphql.deserialize
 import com.apurebase.kgraphql.expect
 import com.apurebase.kgraphql.extract
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 @Specification("3.11 List", "3.12 Non-Null")
@@ -24,133 +25,133 @@ class ListInputCoercionTest {
     }
 
     @Test
-    suspend fun `null should be valid for a nullable list of Int`() {
+    fun `null should be valid for a nullable list of Int`() = runTest {
         val response = deserialize(schema.execute("{ NullableList(value: null) }"))
         response.extract<List<Int>>("data/NullableList") shouldBe null
     }
 
     @Test
-    suspend fun `1 should be valid for a nullable list of Int`() {
+    fun `1 should be valid for a nullable list of Int`() = runTest {
         val response = deserialize(schema.execute("{ NullableList(value: 1) }"))
         response.extract<List<Int>>("data/NullableList") shouldBe listOf(1)
     }
 
     @Test
-    suspend fun `a list should be valid for a nullable list of Int`() {
+    fun `a list should be valid for a nullable list of Int`() = runTest {
         val response = deserialize(schema.execute("{ NullableList(value: [1, 2, 3]) }"))
         response.extract<List<Int>>("data/NullableList") shouldBe listOf(1, 2, 3)
     }
 
     @Test
-    suspend fun `a list of mixed types should not be valid for a nullable list of Int`() {
+    fun `a list of mixed types should not be valid for a nullable list of Int`() = runTest {
         expect<InvalidInputValueException>("Cannot coerce \"b\" to numeric constant") {
             deserialize(schema.execute("{ NullableList(value: [1, \"b\", true]) }"))
         }
     }
 
     @Test
-    suspend fun `foo should not be valid for a nullable list of Int`() {
+    fun `foo should not be valid for a nullable list of Int`() = runTest {
         expect<InvalidInputValueException>("Cannot coerce \"foo\" to numeric constant") {
             deserialize(schema.execute("{ RequiredList(value: \"foo\") }"))
         }
     }
 
     @Test
-    suspend fun `null should be valid for a nullable nested list of Int`() {
+    fun `null should be valid for a nullable nested list of Int`() = runTest {
         val response = deserialize(schema.execute("{ NullableNestedList(value: null) }"))
         response.extract<List<Int>>("data/NullableNestedList") shouldBe null
     }
 
     @Test
-    suspend fun `1 should be valid for a nullable nested list of Int`() {
+    fun `1 should be valid for a nullable nested list of Int`() = runTest {
         val response = deserialize(schema.execute("{ NullableNestedList(value: 1) }"))
         response.extract<List<Int>>("data/NullableNestedList") shouldBe listOf(listOf(1))
     }
 
     @Test
-    suspend fun `a nested list should be valid for a nullable nested list of Int`() {
+    fun `a nested list should be valid for a nullable nested list of Int`() = runTest {
         val response = deserialize(schema.execute("{ NullableNestedList(value: [[1], [2, 3]]) }"))
         response.extract<List<Int>>("data/NullableNestedList") shouldBe listOf(listOf(1), listOf(2, 3))
     }
 
     @Test
-    suspend fun `a non-nested list should not be valid for a nullable nested list of Int`() {
+    fun `a non-nested list should not be valid for a nullable nested list of Int`() = runTest {
         expect<InvalidInputValueException>("argument '1' is not valid value of type List") {
             deserialize(schema.execute("{ NullableNestedList(value: [1, 2, 3]) }"))
         }
     }
 
     @Test
-    suspend fun `null should not be valid for a required list of Int`() {
+    fun `null should not be valid for a required list of Int`() = runTest {
         expect<InvalidInputValueException>("argument 'null' is not valid value of type Int") {
             deserialize(schema.execute("{ RequiredList(value: null) }"))
         }
     }
 
     @Test
-    suspend fun `a list should be valid for a required list of Int`() {
+    fun `a list should be valid for a required list of Int`() = runTest {
         val response = deserialize(schema.execute("{ RequiredList(value: [1, 2, 3]) }"))
         response.extract<List<Int?>>("data/RequiredList") shouldBe listOf(1, 2, 3)
     }
 
     @Test
-    suspend fun `a list with null value should be valid for a required list of Int`() {
+    fun `a list with null value should be valid for a required list of Int`() = runTest {
         val response = deserialize(schema.execute("{ RequiredList(value: [1, 2, null]) }"))
         response.extract<List<Int?>>("data/RequiredList") shouldBe listOf(1, 2, null)
     }
 
     @Test
-    suspend fun `null should be valid for a nullable set of Int`() {
+    fun `null should be valid for a nullable set of Int`() = runTest {
         val response = deserialize(schema.execute("{ NullableSet(value: null) }"))
         response.extract<Set<Int>>("data/NullableSet") shouldBe null
     }
 
     @Test
-    suspend fun `1 should be valid for a nullable set of Int`() {
+    fun `1 should be valid for a nullable set of Int`() = runTest {
         val response = deserialize(schema.execute("{ NullableSet(value: 1) }"))
         response.extract<List<Int>>("data/NullableSet") shouldBe listOf(1)
     }
 
     @Test
-    suspend fun `a list should be valid for a nullable set of Int`() {
+    fun `a list should be valid for a nullable set of Int`() = runTest {
         val response = deserialize(schema.execute("{ NullableSet(value: [1, 2, 3, 1]) }"))
         response.extract<List<Int>>("data/NullableSet") shouldBe listOf(1, 2, 3)
     }
 
     @Test
-    suspend fun `a list of mixed types should not be valid for a nullable set of Int`() {
+    fun `a list of mixed types should not be valid for a nullable set of Int`() = runTest {
         expect<InvalidInputValueException>("Cannot coerce \"b\" to numeric constant") {
             deserialize(schema.execute("{ NullableSet(value: [1, \"b\", true]) }"))
         }
     }
 
     @Test
-    suspend fun `foo should not be valid for a nullable set of Int`() {
+    fun `foo should not be valid for a nullable set of Int`() = runTest {
         expect<InvalidInputValueException>("Cannot coerce \"foo\" to numeric constant") {
             deserialize(schema.execute("{ RequiredSet(value: \"foo\") }"))
         }
     }
 
     @Test
-    suspend fun `null should be valid for a nullable nested set of Int`() {
+    fun `null should be valid for a nullable nested set of Int`() = runTest {
         val response = deserialize(schema.execute("{ NullableNestedSet(value: null) }"))
         response.extract<List<Int>>("data/NullableNestedSet") shouldBe null
     }
 
     @Test
-    suspend fun `1 should be valid for a nullable nested set of Int`() {
+    fun `1 should be valid for a nullable nested set of Int`() = runTest {
         val response = deserialize(schema.execute("{ NullableNestedSet(value: 1) }"))
         response.extract<List<Int>>("data/NullableNestedSet") shouldBe listOf(listOf(1))
     }
 
     @Test
-    suspend fun `a nested list should be valid for a nullable nested set of Int`() {
+    fun `a nested list should be valid for a nullable nested set of Int`() = runTest {
         val response = deserialize(schema.execute("{ NullableNestedSet(value: [[1], [2, 3, 3]]) }"))
         response.extract<List<Int>>("data/NullableNestedSet") shouldBe listOf(listOf(1), listOf(2, 3))
     }
 
     @Test
-    suspend fun `a nested list should be valid for a nullable nested set of list of set of Int`() {
+    fun `a nested list should be valid for a nullable nested set of list of set of Int`() = runTest {
         val response =
             deserialize(schema.execute("{ NullableNestedSetListSet(value: [[[1]], [[1]], [[2, 3], [2, 3, 3]]]) }"))
 
@@ -161,27 +162,27 @@ class ListInputCoercionTest {
     }
 
     @Test
-    suspend fun `a non-nested list should not be valid for a nullable nested set of Int`() {
+    fun `a non-nested list should not be valid for a nullable nested set of Int`() = runTest {
         expect<InvalidInputValueException>("argument '1' is not valid value of type List") {
             deserialize(schema.execute("{ NullableNestedSet(value: [1, 2, 3]) }"))
         }
     }
 
     @Test
-    suspend fun `null should not be valid for a required set of Int`() {
+    fun `null should not be valid for a required set of Int`() = runTest {
         expect<InvalidInputValueException>("argument 'null' is not valid value of type Int") {
             deserialize(schema.execute("{ RequiredSet(value: null) }"))
         }
     }
 
     @Test
-    suspend fun `a list should be valid for a required set of Int`() {
+    fun `a list should be valid for a required set of Int`() = runTest {
         val response = deserialize(schema.execute("{ RequiredSet(value: [1, 2, 3]) }"))
         response.extract<List<Int?>>("data/RequiredSet") shouldBe listOf(1, 2, 3)
     }
 
     @Test
-    suspend fun `a list with null value should be valid for a required set of Int`() {
+    fun `a list with null value should be valid for a required set of Int`() = runTest {
         val response = deserialize(schema.execute("{ RequiredSet(value: [1, 2, null]) }"))
         response.extract<List<Int?>>("data/RequiredSet") shouldBe listOf(1, 2, null)
     }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/ListInputCoercionTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/ListInputCoercionTest.kt
@@ -24,135 +24,135 @@ class ListInputCoercionTest {
     }
 
     @Test
-    fun `null should be valid for a nullable list of Int`() {
-        val response = deserialize(schema.executeBlocking("{ NullableList(value: null) }"))
+    suspend fun `null should be valid for a nullable list of Int`() {
+        val response = deserialize(schema.execute("{ NullableList(value: null) }"))
         response.extract<List<Int>>("data/NullableList") shouldBe null
     }
 
     @Test
-    fun `1 should be valid for a nullable list of Int`() {
-        val response = deserialize(schema.executeBlocking("{ NullableList(value: 1) }"))
+    suspend fun `1 should be valid for a nullable list of Int`() {
+        val response = deserialize(schema.execute("{ NullableList(value: 1) }"))
         response.extract<List<Int>>("data/NullableList") shouldBe listOf(1)
     }
 
     @Test
-    fun `a list should be valid for a nullable list of Int`() {
-        val response = deserialize(schema.executeBlocking("{ NullableList(value: [1, 2, 3]) }"))
+    suspend fun `a list should be valid for a nullable list of Int`() {
+        val response = deserialize(schema.execute("{ NullableList(value: [1, 2, 3]) }"))
         response.extract<List<Int>>("data/NullableList") shouldBe listOf(1, 2, 3)
     }
 
     @Test
-    fun `a list of mixed types should not be valid for a nullable list of Int`() {
+    suspend fun `a list of mixed types should not be valid for a nullable list of Int`() {
         expect<InvalidInputValueException>("Cannot coerce \"b\" to numeric constant") {
-            deserialize(schema.executeBlocking("{ NullableList(value: [1, \"b\", true]) }"))
+            deserialize(schema.execute("{ NullableList(value: [1, \"b\", true]) }"))
         }
     }
 
     @Test
-    fun `foo should not be valid for a nullable list of Int`() {
+    suspend fun `foo should not be valid for a nullable list of Int`() {
         expect<InvalidInputValueException>("Cannot coerce \"foo\" to numeric constant") {
-            deserialize(schema.executeBlocking("{ RequiredList(value: \"foo\") }"))
+            deserialize(schema.execute("{ RequiredList(value: \"foo\") }"))
         }
     }
 
     @Test
-    fun `null should be valid for a nullable nested list of Int`() {
-        val response = deserialize(schema.executeBlocking("{ NullableNestedList(value: null) }"))
+    suspend fun `null should be valid for a nullable nested list of Int`() {
+        val response = deserialize(schema.execute("{ NullableNestedList(value: null) }"))
         response.extract<List<Int>>("data/NullableNestedList") shouldBe null
     }
 
     @Test
-    fun `1 should be valid for a nullable nested list of Int`() {
-        val response = deserialize(schema.executeBlocking("{ NullableNestedList(value: 1) }"))
+    suspend fun `1 should be valid for a nullable nested list of Int`() {
+        val response = deserialize(schema.execute("{ NullableNestedList(value: 1) }"))
         response.extract<List<Int>>("data/NullableNestedList") shouldBe listOf(listOf(1))
     }
 
     @Test
-    fun `a nested list should be valid for a nullable nested list of Int`() {
-        val response = deserialize(schema.executeBlocking("{ NullableNestedList(value: [[1], [2, 3]]) }"))
+    suspend fun `a nested list should be valid for a nullable nested list of Int`() {
+        val response = deserialize(schema.execute("{ NullableNestedList(value: [[1], [2, 3]]) }"))
         response.extract<List<Int>>("data/NullableNestedList") shouldBe listOf(listOf(1), listOf(2, 3))
     }
 
     @Test
-    fun `a non-nested list should not be valid for a nullable nested list of Int`() {
+    suspend fun `a non-nested list should not be valid for a nullable nested list of Int`() {
         expect<InvalidInputValueException>("argument '1' is not valid value of type List") {
-            deserialize(schema.executeBlocking("{ NullableNestedList(value: [1, 2, 3]) }"))
+            deserialize(schema.execute("{ NullableNestedList(value: [1, 2, 3]) }"))
         }
     }
 
     @Test
-    fun `null should not be valid for a required list of Int`() {
+    suspend fun `null should not be valid for a required list of Int`() {
         expect<InvalidInputValueException>("argument 'null' is not valid value of type Int") {
-            deserialize(schema.executeBlocking("{ RequiredList(value: null) }"))
+            deserialize(schema.execute("{ RequiredList(value: null) }"))
         }
     }
 
     @Test
-    fun `a list should be valid for a required list of Int`() {
-        val response = deserialize(schema.executeBlocking("{ RequiredList(value: [1, 2, 3]) }"))
+    suspend fun `a list should be valid for a required list of Int`() {
+        val response = deserialize(schema.execute("{ RequiredList(value: [1, 2, 3]) }"))
         response.extract<List<Int?>>("data/RequiredList") shouldBe listOf(1, 2, 3)
     }
 
     @Test
-    fun `a list with null value should be valid for a required list of Int`() {
-        val response = deserialize(schema.executeBlocking("{ RequiredList(value: [1, 2, null]) }"))
+    suspend fun `a list with null value should be valid for a required list of Int`() {
+        val response = deserialize(schema.execute("{ RequiredList(value: [1, 2, null]) }"))
         response.extract<List<Int?>>("data/RequiredList") shouldBe listOf(1, 2, null)
     }
 
     @Test
-    fun `null should be valid for a nullable set of Int`() {
-        val response = deserialize(schema.executeBlocking("{ NullableSet(value: null) }"))
+    suspend fun `null should be valid for a nullable set of Int`() {
+        val response = deserialize(schema.execute("{ NullableSet(value: null) }"))
         response.extract<Set<Int>>("data/NullableSet") shouldBe null
     }
 
     @Test
-    fun `1 should be valid for a nullable set of Int`() {
-        val response = deserialize(schema.executeBlocking("{ NullableSet(value: 1) }"))
+    suspend fun `1 should be valid for a nullable set of Int`() {
+        val response = deserialize(schema.execute("{ NullableSet(value: 1) }"))
         response.extract<List<Int>>("data/NullableSet") shouldBe listOf(1)
     }
 
     @Test
-    fun `a list should be valid for a nullable set of Int`() {
-        val response = deserialize(schema.executeBlocking("{ NullableSet(value: [1, 2, 3, 1]) }"))
+    suspend fun `a list should be valid for a nullable set of Int`() {
+        val response = deserialize(schema.execute("{ NullableSet(value: [1, 2, 3, 1]) }"))
         response.extract<List<Int>>("data/NullableSet") shouldBe listOf(1, 2, 3)
     }
 
     @Test
-    fun `a list of mixed types should not be valid for a nullable set of Int`() {
+    suspend fun `a list of mixed types should not be valid for a nullable set of Int`() {
         expect<InvalidInputValueException>("Cannot coerce \"b\" to numeric constant") {
-            deserialize(schema.executeBlocking("{ NullableSet(value: [1, \"b\", true]) }"))
+            deserialize(schema.execute("{ NullableSet(value: [1, \"b\", true]) }"))
         }
     }
 
     @Test
-    fun `foo should not be valid for a nullable set of Int`() {
+    suspend fun `foo should not be valid for a nullable set of Int`() {
         expect<InvalidInputValueException>("Cannot coerce \"foo\" to numeric constant") {
-            deserialize(schema.executeBlocking("{ RequiredSet(value: \"foo\") }"))
+            deserialize(schema.execute("{ RequiredSet(value: \"foo\") }"))
         }
     }
 
     @Test
-    fun `null should be valid for a nullable nested set of Int`() {
-        val response = deserialize(schema.executeBlocking("{ NullableNestedSet(value: null) }"))
+    suspend fun `null should be valid for a nullable nested set of Int`() {
+        val response = deserialize(schema.execute("{ NullableNestedSet(value: null) }"))
         response.extract<List<Int>>("data/NullableNestedSet") shouldBe null
     }
 
     @Test
-    fun `1 should be valid for a nullable nested set of Int`() {
-        val response = deserialize(schema.executeBlocking("{ NullableNestedSet(value: 1) }"))
+    suspend fun `1 should be valid for a nullable nested set of Int`() {
+        val response = deserialize(schema.execute("{ NullableNestedSet(value: 1) }"))
         response.extract<List<Int>>("data/NullableNestedSet") shouldBe listOf(listOf(1))
     }
 
     @Test
-    fun `a nested list should be valid for a nullable nested set of Int`() {
-        val response = deserialize(schema.executeBlocking("{ NullableNestedSet(value: [[1], [2, 3, 3]]) }"))
+    suspend fun `a nested list should be valid for a nullable nested set of Int`() {
+        val response = deserialize(schema.execute("{ NullableNestedSet(value: [[1], [2, 3, 3]]) }"))
         response.extract<List<Int>>("data/NullableNestedSet") shouldBe listOf(listOf(1), listOf(2, 3))
     }
 
     @Test
-    fun `a nested list should be valid for a nullable nested set of list of set of Int`() {
+    suspend fun `a nested list should be valid for a nullable nested set of list of set of Int`() {
         val response =
-            deserialize(schema.executeBlocking("{ NullableNestedSetListSet(value: [[[1]], [[1]], [[2, 3], [2, 3, 3]]]) }"))
+            deserialize(schema.execute("{ NullableNestedSetListSet(value: [[[1]], [[1]], [[2, 3], [2, 3, 3]]]) }"))
 
         response.extract<List<Int>>("data/NullableNestedSetListSet") shouldBe listOf(
             listOf(listOf(1)),
@@ -161,28 +161,28 @@ class ListInputCoercionTest {
     }
 
     @Test
-    fun `a non-nested list should not be valid for a nullable nested set of Int`() {
+    suspend fun `a non-nested list should not be valid for a nullable nested set of Int`() {
         expect<InvalidInputValueException>("argument '1' is not valid value of type List") {
-            deserialize(schema.executeBlocking("{ NullableNestedSet(value: [1, 2, 3]) }"))
+            deserialize(schema.execute("{ NullableNestedSet(value: [1, 2, 3]) }"))
         }
     }
 
     @Test
-    fun `null should not be valid for a required set of Int`() {
+    suspend fun `null should not be valid for a required set of Int`() {
         expect<InvalidInputValueException>("argument 'null' is not valid value of type Int") {
-            deserialize(schema.executeBlocking("{ RequiredSet(value: null) }"))
+            deserialize(schema.execute("{ RequiredSet(value: null) }"))
         }
     }
 
     @Test
-    fun `a list should be valid for a required set of Int`() {
-        val response = deserialize(schema.executeBlocking("{ RequiredSet(value: [1, 2, 3]) }"))
+    suspend fun `a list should be valid for a required set of Int`() {
+        val response = deserialize(schema.execute("{ RequiredSet(value: [1, 2, 3]) }"))
         response.extract<List<Int?>>("data/RequiredSet") shouldBe listOf(1, 2, 3)
     }
 
     @Test
-    fun `a list with null value should be valid for a required set of Int`() {
-        val response = deserialize(schema.executeBlocking("{ RequiredSet(value: [1, 2, null]) }"))
+    suspend fun `a list with null value should be valid for a required set of Int`() {
+        val response = deserialize(schema.execute("{ RequiredSet(value: [1, 2, null]) }"))
         response.extract<List<Int?>>("data/RequiredSet") shouldBe listOf(1, 2, null)
     }
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/OperationsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/OperationsSpecificationTest.kt
@@ -55,7 +55,7 @@ class OperationsSpecificationTest {
     }
 
     @Test
-    fun `unnamed and named queries are equivalent`() {
+    suspend fun `unnamed and named queries are equivalent`() {
         executeEqualQueries(
             newSchema(),
             mapOf("data" to mapOf("fizz" to "buzz")),
@@ -66,7 +66,7 @@ class OperationsSpecificationTest {
     }
 
     @Test
-    fun `unnamed and named mutations are equivalent`() {
+    suspend fun `unnamed and named mutations are equivalent`() {
         executeEqualQueries(
             newSchema(),
             mapOf("data" to mapOf("createActor" to mapOf("name" to "Kurt Russel"))),
@@ -76,34 +76,34 @@ class OperationsSpecificationTest {
     }
 
     @Test
-    fun `handle subscription`() {
+    suspend fun `handle subscription`() {
         val schema = newSchema()
-        schema.executeBlocking("subscription {subscriptionActor(subscription : \"mySubscription\"){name}}")
+        schema.execute("subscription {subscriptionActor(subscription : \"mySubscription\"){name}}")
 
         subscriptionResult = ""
-        schema.executeBlocking("mutation {createActor(name : \"Kurt Russel\"){name}}")
+        schema.execute("mutation {createActor(name : \"Kurt Russel\"){name}}")
 
         subscriptionResult shouldBe "{\"data\":{\"name\":\"Kurt Russel\"}}"
 
         subscriptionResult = ""
-        schema.executeBlocking("mutation{createActor(name : \"Kurt Russel1\"){name}}")
+        schema.execute("mutation{createActor(name : \"Kurt Russel1\"){name}}")
         subscriptionResult shouldBe "{\"data\":{\"name\":\"Kurt Russel1\"}}"
 
         subscriptionResult = ""
-        schema.executeBlocking("mutation{createActor(name : \"Kurt Russel2\"){name}}")
+        schema.execute("mutation{createActor(name : \"Kurt Russel2\"){name}}")
         subscriptionResult shouldBe "{\"data\":{\"name\":\"Kurt Russel2\"}}"
 
-        schema.executeBlocking("subscription {unsubscriptionActor(subscription : \"mySubscription\"){name}}")
+        schema.execute("subscription {unsubscriptionActor(subscription : \"mySubscription\"){name}}")
 
         subscriptionResult = ""
-        schema.executeBlocking("mutation{createActor(name : \"Kurt Russel\"){name}}")
+        schema.execute("mutation{createActor(name : \"Kurt Russel\"){name}}")
         subscriptionResult shouldBe ""
     }
 
     @Test
-    fun `Subscription return type must be the same as the publisher's`() {
+    suspend fun `Subscription return type must be the same as the publisher's`() {
         val exception = shouldThrowExactly<ExecutionException> {
-            newSchema().executeBlocking("subscription {subscriptionActress(subscription : \"mySubscription\"){age}}")
+            newSchema().execute("subscription {subscriptionActress(subscription : \"mySubscription\"){age}}")
         }
         exception.originalError shouldBeInstanceOf SchemaException::class
         exception shouldHaveMessage "Subscription return type must be the same as the publisher's"

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/OperationsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/OperationsSpecificationTest.kt
@@ -11,6 +11,7 @@ import com.apurebase.kgraphql.shouldBeInstanceOf
 import io.kotest.assertions.throwables.shouldThrowExactly
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.throwable.shouldHaveMessage
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 data class Actor(var name: String? = "", var age: Int? = 0)
@@ -55,7 +56,7 @@ class OperationsSpecificationTest {
     }
 
     @Test
-    suspend fun `unnamed and named queries are equivalent`() {
+    fun `unnamed and named queries are equivalent`() = runTest {
         executeEqualQueries(
             newSchema(),
             mapOf("data" to mapOf("fizz" to "buzz")),
@@ -66,7 +67,7 @@ class OperationsSpecificationTest {
     }
 
     @Test
-    suspend fun `unnamed and named mutations are equivalent`() {
+    fun `unnamed and named mutations are equivalent`() = runTest {
         executeEqualQueries(
             newSchema(),
             mapOf("data" to mapOf("createActor" to mapOf("name" to "Kurt Russel"))),
@@ -76,7 +77,7 @@ class OperationsSpecificationTest {
     }
 
     @Test
-    suspend fun `handle subscription`() {
+    fun `handle subscription`() = runTest {
         val schema = newSchema()
         schema.execute("subscription {subscriptionActor(subscription : \"mySubscription\"){name}}")
 
@@ -101,7 +102,7 @@ class OperationsSpecificationTest {
     }
 
     @Test
-    suspend fun `Subscription return type must be the same as the publisher's`() {
+    fun `Subscription return type must be the same as the publisher's`() = runTest {
         val exception = shouldThrowExactly<ExecutionException> {
             newSchema().execute("subscription {subscriptionActress(subscription : \"mySubscription\"){age}}")
         }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/QueryDocumentSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/QueryDocumentSpecificationTest.kt
@@ -9,6 +9,7 @@ import com.apurebase.kgraphql.deserialize
 import com.apurebase.kgraphql.expect
 import com.apurebase.kgraphql.extract
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 @Specification("2.2 Query Document")
@@ -25,21 +26,21 @@ class QueryDocumentSpecificationTest {
     }
 
     @Test
-    suspend fun `anonymous operation must be the only defined operation`() {
+    fun `anonymous operation must be the only defined operation`() = runTest {
         expect<ValidationException>("anonymous operation must be the only defined operation") {
             deserialize(schema.execute("query {fizz} mutation BUZZ {createActor(name : \"Kurt Russel\"){name}}"))
         }
     }
 
     @Test
-    suspend fun `must provide operation name when multiple named operations`() {
+    fun `must provide operation name when multiple named operations`() = runTest {
         expect<ValidationException>("Must provide an operation name from: [FIZZ, BUZZ], found null") {
             deserialize(schema.execute("query FIZZ {fizz} mutation BUZZ {createActor(name : \"Kurt Russel\"){name}}"))
         }
     }
 
     @Test
-    suspend fun `execute operation by name in variable`() {
+    fun `execute operation by name in variable`() = runTest {
         val map = deserialize(
             schema.execute(
                 "query FIZZ {fizz} mutation BUZZ {createActor(name : \"Kurt Russel\"){name}}",

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/QueryDocumentSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/QueryDocumentSpecificationTest.kt
@@ -25,23 +25,23 @@ class QueryDocumentSpecificationTest {
     }
 
     @Test
-    fun `anonymous operation must be the only defined operation`() {
+    suspend fun `anonymous operation must be the only defined operation`() {
         expect<ValidationException>("anonymous operation must be the only defined operation") {
-            deserialize(schema.executeBlocking("query {fizz} mutation BUZZ {createActor(name : \"Kurt Russel\"){name}}"))
+            deserialize(schema.execute("query {fizz} mutation BUZZ {createActor(name : \"Kurt Russel\"){name}}"))
         }
     }
 
     @Test
-    fun `must provide operation name when multiple named operations`() {
+    suspend fun `must provide operation name when multiple named operations`() {
         expect<ValidationException>("Must provide an operation name from: [FIZZ, BUZZ], found null") {
-            deserialize(schema.executeBlocking("query FIZZ {fizz} mutation BUZZ {createActor(name : \"Kurt Russel\"){name}}"))
+            deserialize(schema.execute("query FIZZ {fizz} mutation BUZZ {createActor(name : \"Kurt Russel\"){name}}"))
         }
     }
 
     @Test
-    fun `execute operation by name in variable`() {
+    suspend fun `execute operation by name in variable`() {
         val map = deserialize(
-            schema.executeBlocking(
+            schema.execute(
                 "query FIZZ {fizz} mutation BUZZ {createActor(name : \"Kurt Russel\"){name}}",
                 "{\"operationName\":\"FIZZ\"}"
             )

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/SelectionSetsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/SelectionSetsSpecificationTest.kt
@@ -6,6 +6,7 @@ import com.apurebase.kgraphql.defaultSchema
 import com.apurebase.kgraphql.deserialize
 import com.apurebase.kgraphql.extract
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 @Specification("2.4 Selection Sets")
@@ -20,24 +21,23 @@ class SelectionSetsSpecificationTest {
     }
 
     @Test
-    suspend fun `operation selects the set of information it needs`() {
+    fun `operation selects the set of information it needs`() = runTest {
         val response = deserialize(schema.execute("{actor{name, age}}"))
         val map = response.extract<Map<String, Any>>("data/actor")
         map shouldBe mapOf("name" to "Boguś Linda", "age" to age)
     }
 
     @Test
-    suspend fun `operation selects the set of information it needs 2`() {
+    fun `operation selects the set of information it needs 2`() = runTest {
         val response = deserialize(schema.execute("{actor{name}}"))
         val map = response.extract<Map<String, Any>>("data/actor")
         map shouldBe mapOf<String, Any>("name" to "Boguś Linda")
     }
 
     @Test
-    suspend fun `operation selects the set of information it needs 3`() {
+    fun `operation selects the set of information it needs 3`() = runTest {
         val response = deserialize(schema.execute("{actor{age}}"))
         val map = response.extract<Map<String, Any>>("data/actor")
         map shouldBe mapOf<String, Any>("age" to age)
     }
-
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/SelectionSetsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/SelectionSetsSpecificationTest.kt
@@ -20,22 +20,22 @@ class SelectionSetsSpecificationTest {
     }
 
     @Test
-    fun `operation selects the set of information it needs`() {
-        val response = deserialize(schema.executeBlocking("{actor{name, age}}"))
+    suspend fun `operation selects the set of information it needs`() {
+        val response = deserialize(schema.execute("{actor{name, age}}"))
         val map = response.extract<Map<String, Any>>("data/actor")
         map shouldBe mapOf("name" to "Boguś Linda", "age" to age)
     }
 
     @Test
-    fun `operation selects the set of information it needs 2`() {
-        val response = deserialize(schema.executeBlocking("{actor{name}}"))
+    suspend fun `operation selects the set of information it needs 2`() {
+        val response = deserialize(schema.execute("{actor{name}}"))
         val map = response.extract<Map<String, Any>>("data/actor")
         map shouldBe mapOf<String, Any>("name" to "Boguś Linda")
     }
 
     @Test
-    fun `operation selects the set of information it needs 3`() {
-        val response = deserialize(schema.executeBlocking("{actor{age}}"))
+    suspend fun `operation selects the set of information it needs 3`() {
+        val response = deserialize(schema.execute("{actor{age}}"))
         val map = response.extract<Map<String, Any>>("data/actor")
         map shouldBe mapOf<String, Any>("age" to age)
     }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/SourceTextSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/SourceTextSpecificationTest.kt
@@ -11,6 +11,7 @@ import com.apurebase.kgraphql.executeEqualQueries
 import com.apurebase.kgraphql.expect
 import com.apurebase.kgraphql.extract
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 @Specification("2.1. Source Text")
@@ -27,7 +28,7 @@ class SourceTextSpecificationTest {
     }
 
     @Test
-    suspend fun `invalid unicode character`() {
+    fun `invalid unicode character`() = runTest {
         expect<InvalidSyntaxException>("Syntax Error: Cannot contain the invalid character \"\\u0003\".") {
             deserialize(schema.execute("\u0003"))
         }
@@ -35,7 +36,7 @@ class SourceTextSpecificationTest {
 
     @Test
     @Specification("2.1.1 Unicode")
-    suspend fun `ignore unicode BOM character`() {
+    fun `ignore unicode BOM character`() = runTest {
         val map = deserialize(schema.execute("\uFEFF{fizz}"))
         assertNoErrors(map)
         map.extract<String>("data/fizz") shouldBe "buzz"
@@ -48,7 +49,7 @@ class SourceTextSpecificationTest {
         "2.1.5 Insignificant Commas",
         "2.1.7 Ignored Tokens"
     )
-    suspend fun `ignore whitespace, line terminator, comma characters`() {
+    fun `ignore whitespace, line terminator, comma characters`() = runTest {
         executeEqualQueries(
             schema,
             mapOf(
@@ -72,7 +73,7 @@ class SourceTextSpecificationTest {
 
     @Test
     @Specification("2.1.4 Comments")
-    suspend fun `support comments`() {
+    fun `support comments`() = runTest {
         executeEqualQueries(
             schema,
             mapOf(
@@ -96,7 +97,7 @@ class SourceTextSpecificationTest {
 
     @Test
     @Specification("2.1.9 Names")
-    suspend fun `names should be case sensitive`() {
+    fun `names should be case sensitive`() = runTest {
         expect<ValidationException>("Property FIZZ on Query does not exist") {
             deserialize(schema.execute("{FIZZ}"))
         }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/SourceTextSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/SourceTextSpecificationTest.kt
@@ -27,16 +27,16 @@ class SourceTextSpecificationTest {
     }
 
     @Test
-    fun `invalid unicode character`() {
+    suspend fun `invalid unicode character`() {
         expect<InvalidSyntaxException>("Syntax Error: Cannot contain the invalid character \"\\u0003\".") {
-            deserialize(schema.executeBlocking("\u0003"))
+            deserialize(schema.execute("\u0003"))
         }
     }
 
     @Test
     @Specification("2.1.1 Unicode")
-    fun `ignore unicode BOM character`() {
-        val map = deserialize(schema.executeBlocking("\uFEFF{fizz}"))
+    suspend fun `ignore unicode BOM character`() {
+        val map = deserialize(schema.execute("\uFEFF{fizz}"))
         assertNoErrors(map)
         map.extract<String>("data/fizz") shouldBe "buzz"
     }
@@ -48,7 +48,7 @@ class SourceTextSpecificationTest {
         "2.1.5 Insignificant Commas",
         "2.1.7 Ignored Tokens"
     )
-    fun `ignore whitespace, line terminator, comma characters`() {
+    suspend fun `ignore whitespace, line terminator, comma characters`() {
         executeEqualQueries(
             schema,
             mapOf(
@@ -72,7 +72,7 @@ class SourceTextSpecificationTest {
 
     @Test
     @Specification("2.1.4 Comments")
-    fun `support comments`() {
+    suspend fun `support comments`() {
         executeEqualQueries(
             schema,
             mapOf(
@@ -96,16 +96,16 @@ class SourceTextSpecificationTest {
 
     @Test
     @Specification("2.1.9 Names")
-    fun `names should be case sensitive`() {
+    suspend fun `names should be case sensitive`() {
         expect<ValidationException>("Property FIZZ on Query does not exist") {
-            deserialize(schema.executeBlocking("{FIZZ}"))
+            deserialize(schema.execute("{FIZZ}"))
         }
 
         expect<ValidationException>("Property Fizz on Query does not exist") {
-            deserialize(schema.executeBlocking("{Fizz}"))
+            deserialize(schema.execute("{Fizz}"))
         }
 
-        val mapLowerCase = deserialize(schema.executeBlocking("{fizz}"))
+        val mapLowerCase = deserialize(schema.execute("{fizz}"))
         assertNoErrors(mapLowerCase)
         mapLowerCase.extract<String>("data/fizz") shouldBe "buzz"
     }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/VariablesSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/VariablesSpecificationTest.kt
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test
 @Specification("2.10 Variables")
 class VariablesSpecificationTest : BaseSchemaTest() {
     @Test
-    fun `query with variables`() {
+    suspend fun `query with variables`() {
         val result = execute(
             query = "mutation(\$name: String!, \$age : Int!) {createActor(name: \$name, age: \$age){name, age}}",
             variables = "{\"name\":\"Boguś Linda\", \"age\": 22}"
@@ -25,7 +25,7 @@ class VariablesSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `query with int variable`() {
+    suspend fun `query with int variable`() {
         val result =
             execute(query = "query(\$rank: Int!) {filmByRank(rank: \$rank) {title}}", variables = "{\"rank\": 1}")
         assertNoErrors(result)
@@ -35,7 +35,7 @@ class VariablesSpecificationTest : BaseSchemaTest() {
     // Json only has one number type, so "1" and "1.0" are the same, and input coercion should be able to handle
     // the value accordingly
     @Test
-    fun `query with int variable should allow whole floating point numbers`() {
+    suspend fun `query with int variable should allow whole floating point numbers`() {
         val result =
             execute(query = "query(\$rank: Int!) {filmByRank(rank: \$rank) {title}}", variables = "{\"rank\": 1.0}")
         assertNoErrors(result)
@@ -43,14 +43,14 @@ class VariablesSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `query with int variable should not allow floating point numbers that are not whole`() {
+    suspend fun `query with int variable should not allow floating point numbers that are not whole`() {
         expect<InvalidInputValueException>("Cannot coerce 1.01 to numeric constant") {
             execute(query = "query(\$rank: Int!) {filmByRank(rank: \$rank) {title}}", variables = "{\"rank\": 1.01}")
         }
     }
 
     @Test
-    fun `query with custom int scalar variable should allow whole floating point numbers`() {
+    suspend fun `query with custom int scalar variable should allow whole floating point numbers`() {
         val result = execute(
             query = "query(\$rank: Rank!) {filmByCustomRank(rank: \$rank) {title}}",
             variables = "{\"rank\": 1.0}"
@@ -60,7 +60,7 @@ class VariablesSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `query with custom int scalar variable should not allow floating point numbers that are not whole`() {
+    suspend fun `query with custom int scalar variable should not allow floating point numbers that are not whole`() {
         expect<InvalidInputValueException>("argument '1.01' is not valid value of type Rank") {
             execute(
                 query = "query(\$rank: Rank!) {filmByCustomRank(rank: \$rank) {title}}",
@@ -72,7 +72,7 @@ class VariablesSpecificationTest : BaseSchemaTest() {
     // Json only has one number type, so "1" and "1.0" are the same, and input coercion should be able to handle
     // the value accordingly
     @Test
-    fun `query with long variable should allow whole floating point numbers`() {
+    suspend fun `query with long variable should allow whole floating point numbers`() {
         val result = execute(
             query = "query(\$rank: Long!) {filmByRankLong(rank: \$rank) {title}}",
             variables = "{\"rank\": 1.0}"
@@ -82,7 +82,7 @@ class VariablesSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `query with long variable should not allow floating point numbers that are not whole`() {
+    suspend fun `query with long variable should not allow floating point numbers that are not whole`() {
         expect<InvalidInputValueException>("Cannot coerce 1.01 to numeric constant") {
             execute(
                 query = "query(\$rank: Long!) {filmByRankLong(rank: \$rank) {title}}",
@@ -94,7 +94,7 @@ class VariablesSpecificationTest : BaseSchemaTest() {
     // Json only has one number type, so "1" and "1.0" are the same, and input coercion should be able to handle
     // the value accordingly
     @Test
-    fun `query with short variable should allow whole floating point numbers`() {
+    suspend fun `query with short variable should allow whole floating point numbers`() {
         val result = execute(
             query = "query(\$rank: Short!) {filmByRankShort(rank: \$rank) {title}}",
             variables = "{\"rank\": 1.0}"
@@ -104,7 +104,7 @@ class VariablesSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `query with short variable should not allow floating point numbers that are not whole`() {
+    suspend fun `query with short variable should not allow floating point numbers that are not whole`() {
         expect<InvalidInputValueException>("Cannot coerce 1.01 to numeric constant") {
             execute(
                 query = "query(\$rank: Short!) {filmByRankShort(rank: \$rank) {title}}",
@@ -114,42 +114,42 @@ class VariablesSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `query with float variable`() {
+    suspend fun `query with float variable`() {
         val result = execute(query = "query(\$float: Float!) {float(float: \$float)}", variables = "{\"float\": 42.3}")
         assertNoErrors(result)
         result.extract<Float>("data/float") shouldBe 42.3
     }
 
     @Test
-    fun `query with float variable in exponential notation`() {
+    suspend fun `query with float variable in exponential notation`() {
         val result = execute(query = "query(\$float: Float!) {float(float: \$float)}", variables = "{\"float\": 2.1e1}")
         assertNoErrors(result)
         result.extract<Float>("data/float") shouldBe 2.1e1
     }
 
     @Test
-    fun `query with float variable should allow integer input`() {
+    suspend fun `query with float variable should allow integer input`() {
         val result = execute(query = "query(\$float: Float!) {float(float: \$float)}", variables = "{\"float\": 42}")
         assertNoErrors(result)
         result.extract<Float>("data/float") shouldBe 42.0
     }
 
     @Test
-    fun `query with boolean variable`() {
+    suspend fun `query with boolean variable`() {
         val result = execute(query = "query(\$big: Boolean!) {number(big: \$big)}", variables = "{\"big\": true}")
         assertNoErrors(result)
         result.extract<Int>("data/number") shouldBe 10000
     }
 
     @Test
-    fun `query with boolean variable default value`() {
+    suspend fun `query with boolean variable default value`() {
         val result = execute(query = "query(\$big: Boolean = true) {number(big: \$big)}")
         assertNoErrors(result)
         result.extract<Int>("data/number") shouldBe 10000
     }
 
     @Test
-    fun `query with enum variable`() {
+    suspend fun `query with enum variable`() {
         val result = execute(
             query = "query(\$type: FilmType!) {filmsByType(type: \$type) {title}}",
             variables = "{\"type\": \"FULL_LENGTH\"}"
@@ -161,7 +161,7 @@ class VariablesSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `query with variables and string default value`() {
+    suspend fun `query with variables and string default value`() {
         val result = execute(
             query = "mutation(\$name: String = \"Boguś Linda\", \$age : Int!) {createActor(name: \$name, age: \$age){name, age}}",
             variables = "{\"age\": 22}"
@@ -171,7 +171,7 @@ class VariablesSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `fragment with variable`() {
+    suspend fun `fragment with variable`() {
         val result = execute(
             query = "mutation(\$name: String = \"Boguś Linda\", \$age : Int!, \$big: Boolean!) {createActor(name: \$name, age: \$age){...Linda}}" +
                 "fragment Linda on Actor {picture(big: \$big)}",
@@ -182,7 +182,7 @@ class VariablesSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `fragment with missing variable`() {
+    suspend fun `fragment with missing variable`() {
         expect<ValidationException>("Variable '\$big' was not declared for this operation") {
             execute(
                 query = "mutation(\$name: String = \"Boguś Linda\", \$age : Int!) {createActor(name: \$name, age: \$age){...Linda}}" +
@@ -193,7 +193,7 @@ class VariablesSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `advanced variables`() {
+    suspend fun `advanced variables`() {
         val request = """
             mutation MultipleCreate(
                 ${'$'}name1: String!,
@@ -250,7 +250,7 @@ class VariablesSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `required variable arrays`() {
+    suspend fun `required variable arrays`() {
         val request = """
             mutation MultipleCreate(
                 ${'$'}agesName1: String!,
@@ -283,7 +283,7 @@ class VariablesSpecificationTest : BaseSchemaTest() {
 
     // https://github.com/aPureBase/KGraphQL/issues/137
     @Test
-    fun `complex variable arrays`() {
+    suspend fun `complex variable arrays`() {
         val schema = KGraphQL.schema {
             configure { wrapErrors = false }
             inputType<InputType>()
@@ -294,7 +294,7 @@ class VariablesSpecificationTest : BaseSchemaTest() {
             }
         }
 
-        val result = schema.executeBlocking(
+        val result = schema.execute(
             """
                 query Query(${'$'}searches: [InputType!]!) {
                     search(criteria: { inputs: ${'$'}searches })
@@ -314,7 +314,7 @@ class VariablesSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `invalid properties should result in appropriate errors`() {
+    suspend fun `invalid properties should result in appropriate errors`() {
         data class SampleObject(val id: String, val name: String)
 
         val schema = KGraphQL.schema {
@@ -350,7 +350,7 @@ class VariablesSpecificationTest : BaseSchemaTest() {
         """.trimIndent()
 
         expect<InvalidInputValueException>("Property 'readonlyExtension' on 'SampleObjectInput' does not exist") {
-            schema.executeBlocking(
+            schema.execute(
                 """
                 {
                     validateSample(sample: {id: "valid", name: "name", readonlyExtension: "readonlyExtension"})
@@ -361,7 +361,7 @@ class VariablesSpecificationTest : BaseSchemaTest() {
 
         // It should not matter if SampleObjectInput is provided directly or via variables, the error message should be equal
         expect<InvalidInputValueException>("Property 'readonlyExtension' on 'SampleObjectInput' does not exist") {
-            schema.executeBlocking(
+            schema.execute(
                 """
                 query (${'$'}sample: SampleObjectInput!) {
                     validateSample(sample: ${'$'}sample)

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/VariablesSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/VariablesSpecificationTest.kt
@@ -10,12 +10,13 @@ import com.apurebase.kgraphql.expect
 import com.apurebase.kgraphql.extract
 import com.apurebase.kgraphql.integration.BaseSchemaTest
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 @Specification("2.10 Variables")
 class VariablesSpecificationTest : BaseSchemaTest() {
     @Test
-    suspend fun `query with variables`() {
+    fun `query with variables`() = runTest {
         val result = execute(
             query = "mutation(\$name: String!, \$age : Int!) {createActor(name: \$name, age: \$age){name, age}}",
             variables = "{\"name\":\"Boguś Linda\", \"age\": 22}"
@@ -25,7 +26,7 @@ class VariablesSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `query with int variable`() {
+    fun `query with int variable`() = runTest {
         val result =
             execute(query = "query(\$rank: Int!) {filmByRank(rank: \$rank) {title}}", variables = "{\"rank\": 1}")
         assertNoErrors(result)
@@ -35,7 +36,7 @@ class VariablesSpecificationTest : BaseSchemaTest() {
     // Json only has one number type, so "1" and "1.0" are the same, and input coercion should be able to handle
     // the value accordingly
     @Test
-    suspend fun `query with int variable should allow whole floating point numbers`() {
+    fun `query with int variable should allow whole floating point numbers`() = runTest {
         val result =
             execute(query = "query(\$rank: Int!) {filmByRank(rank: \$rank) {title}}", variables = "{\"rank\": 1.0}")
         assertNoErrors(result)
@@ -43,14 +44,14 @@ class VariablesSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `query with int variable should not allow floating point numbers that are not whole`() {
+    fun `query with int variable should not allow floating point numbers that are not whole`() = runTest {
         expect<InvalidInputValueException>("Cannot coerce 1.01 to numeric constant") {
             execute(query = "query(\$rank: Int!) {filmByRank(rank: \$rank) {title}}", variables = "{\"rank\": 1.01}")
         }
     }
 
     @Test
-    suspend fun `query with custom int scalar variable should allow whole floating point numbers`() {
+    fun `query with custom int scalar variable should allow whole floating point numbers`() = runTest {
         val result = execute(
             query = "query(\$rank: Rank!) {filmByCustomRank(rank: \$rank) {title}}",
             variables = "{\"rank\": 1.0}"
@@ -60,7 +61,7 @@ class VariablesSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `query with custom int scalar variable should not allow floating point numbers that are not whole`() {
+    fun `query with custom int scalar variable should not allow floating point numbers that are not whole`() = runTest {
         expect<InvalidInputValueException>("argument '1.01' is not valid value of type Rank") {
             execute(
                 query = "query(\$rank: Rank!) {filmByCustomRank(rank: \$rank) {title}}",
@@ -72,7 +73,7 @@ class VariablesSpecificationTest : BaseSchemaTest() {
     // Json only has one number type, so "1" and "1.0" are the same, and input coercion should be able to handle
     // the value accordingly
     @Test
-    suspend fun `query with long variable should allow whole floating point numbers`() {
+    fun `query with long variable should allow whole floating point numbers`() = runTest {
         val result = execute(
             query = "query(\$rank: Long!) {filmByRankLong(rank: \$rank) {title}}",
             variables = "{\"rank\": 1.0}"
@@ -82,7 +83,7 @@ class VariablesSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `query with long variable should not allow floating point numbers that are not whole`() {
+    fun `query with long variable should not allow floating point numbers that are not whole`() = runTest {
         expect<InvalidInputValueException>("Cannot coerce 1.01 to numeric constant") {
             execute(
                 query = "query(\$rank: Long!) {filmByRankLong(rank: \$rank) {title}}",
@@ -94,7 +95,7 @@ class VariablesSpecificationTest : BaseSchemaTest() {
     // Json only has one number type, so "1" and "1.0" are the same, and input coercion should be able to handle
     // the value accordingly
     @Test
-    suspend fun `query with short variable should allow whole floating point numbers`() {
+    fun `query with short variable should allow whole floating point numbers`() = runTest {
         val result = execute(
             query = "query(\$rank: Short!) {filmByRankShort(rank: \$rank) {title}}",
             variables = "{\"rank\": 1.0}"
@@ -104,7 +105,7 @@ class VariablesSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `query with short variable should not allow floating point numbers that are not whole`() {
+    fun `query with short variable should not allow floating point numbers that are not whole`() = runTest {
         expect<InvalidInputValueException>("Cannot coerce 1.01 to numeric constant") {
             execute(
                 query = "query(\$rank: Short!) {filmByRankShort(rank: \$rank) {title}}",
@@ -114,42 +115,42 @@ class VariablesSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `query with float variable`() {
+    fun `query with float variable`() = runTest {
         val result = execute(query = "query(\$float: Float!) {float(float: \$float)}", variables = "{\"float\": 42.3}")
         assertNoErrors(result)
         result.extract<Float>("data/float") shouldBe 42.3
     }
 
     @Test
-    suspend fun `query with float variable in exponential notation`() {
+    fun `query with float variable in exponential notation`() = runTest {
         val result = execute(query = "query(\$float: Float!) {float(float: \$float)}", variables = "{\"float\": 2.1e1}")
         assertNoErrors(result)
         result.extract<Float>("data/float") shouldBe 2.1e1
     }
 
     @Test
-    suspend fun `query with float variable should allow integer input`() {
+    fun `query with float variable should allow integer input`() = runTest {
         val result = execute(query = "query(\$float: Float!) {float(float: \$float)}", variables = "{\"float\": 42}")
         assertNoErrors(result)
         result.extract<Float>("data/float") shouldBe 42.0
     }
 
     @Test
-    suspend fun `query with boolean variable`() {
+    fun `query with boolean variable`() = runTest {
         val result = execute(query = "query(\$big: Boolean!) {number(big: \$big)}", variables = "{\"big\": true}")
         assertNoErrors(result)
         result.extract<Int>("data/number") shouldBe 10000
     }
 
     @Test
-    suspend fun `query with boolean variable default value`() {
+    fun `query with boolean variable default value`() = runTest {
         val result = execute(query = "query(\$big: Boolean = true) {number(big: \$big)}")
         assertNoErrors(result)
         result.extract<Int>("data/number") shouldBe 10000
     }
 
     @Test
-    suspend fun `query with enum variable`() {
+    fun `query with enum variable`() = runTest {
         val result = execute(
             query = "query(\$type: FilmType!) {filmsByType(type: \$type) {title}}",
             variables = "{\"type\": \"FULL_LENGTH\"}"
@@ -161,7 +162,7 @@ class VariablesSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `query with variables and string default value`() {
+    fun `query with variables and string default value`() = runTest {
         val result = execute(
             query = "mutation(\$name: String = \"Boguś Linda\", \$age : Int!) {createActor(name: \$name, age: \$age){name, age}}",
             variables = "{\"age\": 22}"
@@ -171,7 +172,7 @@ class VariablesSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `fragment with variable`() {
+    fun `fragment with variable`() = runTest {
         val result = execute(
             query = "mutation(\$name: String = \"Boguś Linda\", \$age : Int!, \$big: Boolean!) {createActor(name: \$name, age: \$age){...Linda}}" +
                 "fragment Linda on Actor {picture(big: \$big)}",
@@ -182,7 +183,7 @@ class VariablesSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `fragment with missing variable`() {
+    fun `fragment with missing variable`() = runTest {
         expect<ValidationException>("Variable '\$big' was not declared for this operation") {
             execute(
                 query = "mutation(\$name: String = \"Boguś Linda\", \$age : Int!) {createActor(name: \$name, age: \$age){...Linda}}" +
@@ -193,7 +194,7 @@ class VariablesSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `advanced variables`() {
+    fun `advanced variables`() = runTest {
         val request = """
             mutation MultipleCreate(
                 ${'$'}name1: String!,
@@ -250,7 +251,7 @@ class VariablesSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `required variable arrays`() {
+    fun `required variable arrays`() = runTest {
         val request = """
             mutation MultipleCreate(
                 ${'$'}agesName1: String!,
@@ -283,7 +284,7 @@ class VariablesSpecificationTest : BaseSchemaTest() {
 
     // https://github.com/aPureBase/KGraphQL/issues/137
     @Test
-    suspend fun `complex variable arrays`() {
+    fun `complex variable arrays`() = runTest {
         val schema = KGraphQL.schema {
             configure { wrapErrors = false }
             inputType<InputType>()
@@ -314,7 +315,7 @@ class VariablesSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `invalid properties should result in appropriate errors`() {
+    fun `invalid properties should result in appropriate errors`() = runTest {
         data class SampleObject(val id: String, val name: String)
 
         val schema = KGraphQL.schema {

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/DirectivesSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/DirectivesSpecificationTest.kt
@@ -11,19 +11,19 @@ import org.junit.jupiter.api.assertThrows
 class DirectivesSpecificationTest : BaseSchemaTest() {
 
     @Test
-    fun `query with @include directive on field`() {
+    suspend fun `query with @include directive on field`() {
         val map = execute("{film{title, year @include(if: false)}}")
         assertThrows<IllegalArgumentException> { map.extract("data/film/year") }
     }
 
     @Test
-    fun `query with @skip directive on field`() {
+    suspend fun `query with @skip directive on field`() {
         val map = execute("{film{title, year @skip(if: true)}}")
         assertThrows<IllegalArgumentException> { map.extract("data/film/year") }
     }
 
     @Test
-    fun `query with @include and @skip directive on field`() {
+    suspend fun `query with @include and @skip directive on field`() {
         val mapBothSkip = execute("{film{title, year @include(if: false) @skip(if: true)}}")
         assertThrows<IllegalArgumentException> { mapBothSkip.extract("data/film/year") }
 
@@ -38,7 +38,7 @@ class DirectivesSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `query with @include and @skip directive on field object`() {
+    suspend fun `query with @include and @skip directive on field object`() {
         val mapWithSkip = execute("{ number(big: true), film @skip(if: true) { title } }")
         assertThrows<IllegalArgumentException> { mapWithSkip.extract("data/film") }
 
@@ -53,7 +53,7 @@ class DirectivesSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `mutation with @include and @skip directive on field object`() {
+    suspend fun `mutation with @include and @skip directive on field object`() {
         val mapWithSkip = execute("mutation { createActor(name: \"actor\", age: 42) @skip(if: true) { name age } }")
         assertThrows<IllegalArgumentException> { mapWithSkip.extract("data/createActor") }
 
@@ -70,7 +70,7 @@ class DirectivesSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `query with @include directive on field with variable`() {
+    suspend fun `query with @include directive on field with variable`() {
         val map = execute(
             "query film (\$include: Boolean!) {film{title, year @include(if: \$include)}}",
             "{\"include\":\"false\"}"

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/DirectivesSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/DirectivesSpecificationTest.kt
@@ -4,6 +4,7 @@ import com.apurebase.kgraphql.Specification
 import com.apurebase.kgraphql.extract
 import com.apurebase.kgraphql.integration.BaseSchemaTest
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
@@ -11,19 +12,19 @@ import org.junit.jupiter.api.assertThrows
 class DirectivesSpecificationTest : BaseSchemaTest() {
 
     @Test
-    suspend fun `query with @include directive on field`() {
+    fun `query with @include directive on field`() = runTest {
         val map = execute("{film{title, year @include(if: false)}}")
         assertThrows<IllegalArgumentException> { map.extract("data/film/year") }
     }
 
     @Test
-    suspend fun `query with @skip directive on field`() {
+    fun `query with @skip directive on field`() = runTest {
         val map = execute("{film{title, year @skip(if: true)}}")
         assertThrows<IllegalArgumentException> { map.extract("data/film/year") }
     }
 
     @Test
-    suspend fun `query with @include and @skip directive on field`() {
+    fun `query with @include and @skip directive on field`() = runTest {
         val mapBothSkip = execute("{film{title, year @include(if: false) @skip(if: true)}}")
         assertThrows<IllegalArgumentException> { mapBothSkip.extract("data/film/year") }
 
@@ -38,7 +39,7 @@ class DirectivesSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `query with @include and @skip directive on field object`() {
+    fun `query with @include and @skip directive on field object`() = runTest {
         val mapWithSkip = execute("{ number(big: true), film @skip(if: true) { title } }")
         assertThrows<IllegalArgumentException> { mapWithSkip.extract("data/film") }
 
@@ -53,7 +54,7 @@ class DirectivesSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `mutation with @include and @skip directive on field object`() {
+    fun `mutation with @include and @skip directive on field object`() = runTest {
         val mapWithSkip = execute("mutation { createActor(name: \"actor\", age: 42) @skip(if: true) { name age } }")
         assertThrows<IllegalArgumentException> { mapWithSkip.extract("data/createActor") }
 
@@ -70,7 +71,7 @@ class DirectivesSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `query with @include directive on field with variable`() {
+    fun `query with @include directive on field with variable`() = runTest {
         val map = execute(
             "query film (\$include: Boolean!) {film{title, year @include(if: \$include)}}",
             "{\"include\":\"false\"}"

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/EnumsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/EnumsSpecificationTest.kt
@@ -30,15 +30,15 @@ class EnumsSpecificationTest {
     }
 
     @Test
-    fun `string literals must not be accepted as an enum input`() {
+    suspend fun `string literals must not be accepted as an enum input`() {
         expect<InvalidInputValueException>("String literal '\"COOL\"' is invalid value for enum type Coolness") {
-            schema.executeBlocking("{cool(cool : \"COOL\")}")
+            schema.execute("{cool(cool : \"COOL\")}")
         }
     }
 
     @Test
-    fun `string constants are accepted as an enum input`() {
-        val response = deserialize(schema.executeBlocking("{cool(cool : COOL)}"))
+    suspend fun `string constants are accepted as an enum input`() {
+        val response = deserialize(schema.execute("{cool(cool : COOL)}"))
         response.extract<String>("data/cool") shouldBe "COOL"
     }
 

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/EnumsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/EnumsSpecificationTest.kt
@@ -7,6 +7,7 @@ import com.apurebase.kgraphql.deserialize
 import com.apurebase.kgraphql.expect
 import com.apurebase.kgraphql.extract
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 @Specification("3.1.5 Enums")
@@ -30,16 +31,15 @@ class EnumsSpecificationTest {
     }
 
     @Test
-    suspend fun `string literals must not be accepted as an enum input`() {
+    fun `string literals must not be accepted as an enum input`() = runTest {
         expect<InvalidInputValueException>("String literal '\"COOL\"' is invalid value for enum type Coolness") {
             schema.execute("{cool(cool : \"COOL\")}")
         }
     }
 
     @Test
-    suspend fun `string constants are accepted as an enum input`() {
+    fun `string constants are accepted as an enum input`() = runTest {
         val response = deserialize(schema.execute("{cool(cool : COOL)}"))
         response.extract<String>("data/cool") shouldBe "COOL"
     }
-
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/InputObjectsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/InputObjectsSpecificationTest.kt
@@ -31,17 +31,17 @@ class InputObjectsSpecificationTest {
     }
 
     @Test
-    fun `an input object defines a set of input fields - scalars, enums, or other input objects`() {
+    suspend fun `an input object defines a set of input fields - scalars, enums, or other input objects`() {
         val two = object {
             val two = InputTwo(InputOne(MockEnum.M1, "M1"), 3434, listOf("23", "34", "21", "434"))
         }
         val variables = objectMapper.writeValueAsString(two)
-        val response = deserialize(schema.executeBlocking("query(\$two: InputTwo!){test(input: \$two)}", variables))
+        val response = deserialize(schema.execute("query(\$two: InputTwo!){test(input: \$two)}", variables))
         response.extract<String>("data/test") shouldBe "success: InputTwo(one=InputOne(enum=M1, id=M1), quantity=3434, tokens=[23, 34, 21, 434])"
     }
 
     @Test
-    fun `input objects may contain nullable circular references`() {
+    suspend fun `input objects may contain nullable circular references`() {
         val schema = KGraphQL.schema {
             inputType<Circular>()
             query("circular") {
@@ -54,7 +54,7 @@ class InputObjectsSpecificationTest {
             val cirSuccess = Circular(Circular(null, "SUCCESS"))
         }
         val response = deserialize(
-            schema.executeBlocking(
+            schema.execute(
                 "query(\$cirNull: Circular!, \$cirSuccess: Circular!){" +
                     "null: circular(cir: \$cirNull)" +
                     "success: circular(cir: \$cirSuccess)}",
@@ -67,7 +67,7 @@ class InputObjectsSpecificationTest {
 
     // https://github.com/aPureBase/KGraphQL/issues/93
     @Test
-    fun `incorrect input parameter should throw an appropriate exception`() {
+    suspend fun `incorrect input parameter should throw an appropriate exception`() {
         data class MyInput(val value1: String)
 
         val schema = KGraphQL.schema {
@@ -77,7 +77,7 @@ class InputObjectsSpecificationTest {
         }
 
         val exception = shouldThrowExactly<InvalidInputValueException> {
-            schema.executeBlocking(
+            schema.execute(
                 """
                 {
                     main(input: { valu1: "Hello" })
@@ -97,7 +97,7 @@ class InputObjectsSpecificationTest {
     }
 
     @Test
-    fun `input objects should take fields from primary constructor`() {
+    suspend fun `input objects should take fields from primary constructor`() {
         val schema = KGraphQL.schema {
             query("test") {
                 resolver { input: NonDataClass -> input }
@@ -122,7 +122,7 @@ class InputObjectsSpecificationTest {
 
         """.trimIndent()
 
-        val response1 = schema.executeBlocking(
+        val response1 = schema.execute(
             """
             query {
                 test(input: {param1: "myParam1"}) { param2 param3 }
@@ -133,7 +133,7 @@ class InputObjectsSpecificationTest {
             {"data":{"test":{"param2":8,"param3":null}}}
         """.trimIndent()
 
-        val response2 = schema.executeBlocking(
+        val response2 = schema.execute(
             """
             query {
                 test(input: {param3: true}) { param2 param3 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/InputObjectsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/InputObjectsSpecificationTest.kt
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.kotest.assertions.throwables.shouldThrowExactly
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.throwable.shouldHaveMessage
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 @Suppress("unused")
@@ -31,7 +32,7 @@ class InputObjectsSpecificationTest {
     }
 
     @Test
-    suspend fun `an input object defines a set of input fields - scalars, enums, or other input objects`() {
+    fun `an input object defines a set of input fields - scalars, enums, or other input objects`() = runTest {
         val two = object {
             val two = InputTwo(InputOne(MockEnum.M1, "M1"), 3434, listOf("23", "34", "21", "434"))
         }
@@ -41,7 +42,7 @@ class InputObjectsSpecificationTest {
     }
 
     @Test
-    suspend fun `input objects may contain nullable circular references`() {
+    fun `input objects may contain nullable circular references`() = runTest {
         val schema = KGraphQL.schema {
             inputType<Circular>()
             query("circular") {
@@ -67,7 +68,7 @@ class InputObjectsSpecificationTest {
 
     // https://github.com/aPureBase/KGraphQL/issues/93
     @Test
-    suspend fun `incorrect input parameter should throw an appropriate exception`() {
+    fun `incorrect input parameter should throw an appropriate exception`() = runTest {
         data class MyInput(val value1: String)
 
         val schema = KGraphQL.schema {
@@ -97,7 +98,7 @@ class InputObjectsSpecificationTest {
     }
 
     @Test
-    suspend fun `input objects should take fields from primary constructor`() {
+    fun `input objects should take fields from primary constructor`() = runTest {
         val schema = KGraphQL.schema {
             query("test") {
                 resolver { input: NonDataClass -> input }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/InterfacesSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/InterfacesSpecificationTest.kt
@@ -7,6 +7,7 @@ import com.apurebase.kgraphql.deserialize
 import com.apurebase.kgraphql.expect
 import com.apurebase.kgraphql.extract
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 @Specification("3.1.3 Interfaces")
@@ -23,20 +24,20 @@ class InterfacesSpecificationTest {
     }
 
     @Test
-    suspend fun `Interfaces represent a list of named fields and their arguments`() {
+    fun `Interfaces represent a list of named fields and their arguments`() = runTest {
         val map = deserialize(schema.execute("{simple{exe}}"))
         map.extract<String>("data/simple/exe") shouldBe "EXE"
     }
 
     @Test
-    suspend fun `When querying for fields on an interface type, only those fields declared on the interface may be queried`() {
+    fun `When querying for fields on an interface type, only those fields declared on the interface may be queried`() = runTest {
         expect<ValidationException>("Property stuff on SimpleInterface does not exist") {
             schema.execute("{simple{exe, stuff}}")
         }
     }
 
     @Test
-    suspend fun `Query for fields of interface implementation can be done only by fragments`() {
+    fun `Query for fields of interface implementation can be done only by fragments`() = runTest {
         val map = deserialize(schema.execute("{simple{exe ... on Simple { stuff }}}"))
         map.extract<String>("data/simple/stuff") shouldBe "CMD"
     }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/InterfacesSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/InterfacesSpecificationTest.kt
@@ -23,21 +23,21 @@ class InterfacesSpecificationTest {
     }
 
     @Test
-    fun `Interfaces represent a list of named fields and their arguments`() {
-        val map = deserialize(schema.executeBlocking("{simple{exe}}"))
+    suspend fun `Interfaces represent a list of named fields and their arguments`() {
+        val map = deserialize(schema.execute("{simple{exe}}"))
         map.extract<String>("data/simple/exe") shouldBe "EXE"
     }
 
     @Test
-    fun `When querying for fields on an interface type, only those fields declared on the interface may be queried`() {
+    suspend fun `When querying for fields on an interface type, only those fields declared on the interface may be queried`() {
         expect<ValidationException>("Property stuff on SimpleInterface does not exist") {
-            schema.executeBlocking("{simple{exe, stuff}}")
+            schema.execute("{simple{exe, stuff}}")
         }
     }
 
     @Test
-    fun `Query for fields of interface implementation can be done only by fragments`() {
-        val map = deserialize(schema.executeBlocking("{simple{exe ... on Simple { stuff }}}"))
+    suspend fun `Query for fields of interface implementation can be done only by fragments`() {
+        val map = deserialize(schema.execute("{simple{exe ... on Simple { stuff }}}"))
         map.extract<String>("data/simple/stuff") shouldBe "CMD"
     }
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/ListsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/ListsSpecificationTest.kt
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test
 class ListsSpecificationTest {
 
     @Test
-    fun `list arguments are valid`() {
+    suspend fun `list arguments are valid`() {
         val schema = KGraphQL.schema {
             query("list") {
                 resolver { list: Iterable<String> -> list }
@@ -27,14 +27,14 @@ class ListsSpecificationTest {
         """.trimIndent()
 
         val response =
-            deserialize(schema.executeBlocking("query(\$list: [String!]!) { list(list: \$list) }", variables))
+            deserialize(schema.execute("query(\$list: [String!]!) { list(list: \$list) }", variables))
         response.extract<String>("data/list[0]") shouldBe "GAGA"
         response.extract<String>("data/list[1]") shouldBe "DADA"
         response.extract<String>("data/list[2]") shouldBe "PADA"
     }
 
     @Test
-    fun `lists with nullable entries are valid`() {
+    suspend fun `lists with nullable entries are valid`() {
         val schema = KGraphQL.schema {
             query("list") {
                 resolver { list: Iterable<String?> -> list }
@@ -46,12 +46,12 @@ class ListsSpecificationTest {
         """.trimIndent()
 
         val response =
-            deserialize(schema.executeBlocking("query(\$list: [String!]!) { list(list: \$list) }", variables))
+            deserialize(schema.execute("query(\$list: [String!]!) { list(list: \$list) }", variables))
         response.extract<String>("data/list[1]") shouldBe null
     }
 
     @Test
-    fun `lists with non-nullable entries should not accept list with null element`() {
+    suspend fun `lists with non-nullable entries should not accept list with null element`() {
         val schema = KGraphQL.schema {
             query("list") {
                 resolver { list: Iterable<String> -> list }
@@ -63,12 +63,12 @@ class ListsSpecificationTest {
         """.trimIndent()
 
         expect<InvalidInputValueException>("argument 'null' is not valid value of type String") {
-            schema.executeBlocking("query(\$list: [String!]!) { list(list: \$list) }", variables)
+            schema.execute("query(\$list: [String!]!) { list(list: \$list) }", variables)
         }
     }
 
     @Test
-    fun `by default coerce single element input as collection`() {
+    suspend fun `by default coerce single element input as collection`() {
         val schema = KGraphQL.schema {
             query("list") {
                 resolver { list: Iterable<String> -> list }
@@ -80,12 +80,12 @@ class ListsSpecificationTest {
         """.trimIndent()
 
         val response =
-            deserialize(schema.executeBlocking("query(\$list: [String!]!) { list(list: \$list) }", variables))
+            deserialize(schema.execute("query(\$list: [String!]!) { list(list: \$list) }", variables))
         response.extract<String>("data/list[0]") shouldBe "GAGA"
     }
 
     @Test
-    fun `null value is not coerced as single element collection`() {
+    suspend fun `null value is not coerced as single element collection`() {
         val schema = KGraphQL.schema {
             query("list") {
                 resolver { list: Iterable<String>? -> list }
@@ -98,12 +98,12 @@ class ListsSpecificationTest {
         """.trimIndent()
 
         val response =
-            deserialize(schema.executeBlocking("query(\$list: [String!]!) { list(list: \$list) }", variables))
+            deserialize(schema.execute("query(\$list: [String!]!) { list(list: \$list) }", variables))
         response.extract<String>("data/list") shouldBe null
     }
 
     @Test
-    fun `list argument can be declared non-nullable`() {
+    suspend fun `list argument can be declared non-nullable`() {
         val schema = KGraphQL.schema {
             query("list") {
                 resolver { list: Iterable<String> -> list }
@@ -115,12 +115,12 @@ class ListsSpecificationTest {
         """.trimIndent()
 
         val response =
-            deserialize(schema.executeBlocking("query(\$list: [String!]!) { list(list: \$list) }", variables))
+            deserialize(schema.execute("query(\$list: [String!]!) { list(list: \$list) }", variables))
         response.extract<Any>("data/list") shouldNotBe null
     }
 
     @Test
-    fun `Iterable implementations are treated as list`() {
+    suspend fun `Iterable implementations are treated as list`() {
 
         fun getResult(): Iterable<String> = listOf("POTATO", "BATATO", "ROTATO")
 
@@ -130,12 +130,12 @@ class ListsSpecificationTest {
             }
         }
 
-        val response = deserialize(schema.executeBlocking("{ list }"))
+        val response = deserialize(schema.execute("{ list }"))
         response.extract<Iterable<String>>("data/list") shouldBe getResult()
     }
 
     @Test
-    fun `input objects with sets should work properly with direct input`() {
+    suspend fun `input objects with sets should work properly with direct input`() {
         data class TestObject(val list: List<String>, val set: Set<String>)
 
         val schema = KGraphQL.schema {
@@ -146,10 +146,10 @@ class ListsSpecificationTest {
                 resolver { input: TestObject -> input }
             }
         }
-        val queryResponse = deserialize(schema.executeBlocking("{ getObject { list set } }"))
+        val queryResponse = deserialize(schema.execute("{ getObject { list set } }"))
         queryResponse.toString() shouldBe "{data={getObject={list=[foo, bar, foo, bar], set=[foo, bar]}}}"
         val mutationResponse = deserialize(
-            schema.executeBlocking(
+            schema.execute(
                 """
                 mutation {
                   addObject(input: { list: ["foo", "bar", "foo", "bar"], set: ["foo", "bar", "foo", "bar"] }) {
@@ -163,7 +163,7 @@ class ListsSpecificationTest {
     }
 
     @Test
-    fun `input objects with sets should work properly with variables`() {
+    suspend fun `input objects with sets should work properly with variables`() {
         data class TestObject(val list: List<String>, val set: Set<String>)
 
         val schema = KGraphQL.schema {
@@ -177,10 +177,10 @@ class ListsSpecificationTest {
         val variables = """
             { "inputData": { "list": ["foo", "bar", "foo", "bar"], "set": ["foo", "bar", "foo", "bar"] } }
         """.trimIndent()
-        val queryResponse = deserialize(schema.executeBlocking("{ getObject { list set } }"))
+        val queryResponse = deserialize(schema.execute("{ getObject { list set } }"))
         queryResponse.toString() shouldBe "{data={getObject={list=[foo, bar, foo, bar], set=[foo, bar]}}}"
         val mutationResponse = deserialize(
-            schema.executeBlocking(
+            schema.execute(
                 """
                 mutation(${'$'}inputData: TestObjectInput!) {
                   addObject(input: ${'$'}inputData) {
@@ -195,14 +195,14 @@ class ListsSpecificationTest {
 
     // https://github.com/stuebingerb/KGraphQL/issues/110
     @Test
-    fun `queries with nested lists should work properly`() {
+    suspend fun `queries with nested lists should work properly`() {
         val schema = KGraphQL.schema {
             query("getNestedList") {
                 resolver { -> listOf(listOf("foo", "bar"), listOf("foobar")) }
             }
         }
 
-        val response = deserialize(schema.executeBlocking("{ getNestedList }"))
+        val response = deserialize(schema.execute("{ getNestedList }"))
         response.extract<List<List<String>>>("data/getNestedList") shouldBe listOf(
             listOf("foo", "bar"),
             listOf("foobar")
@@ -210,7 +210,7 @@ class ListsSpecificationTest {
     }
 
     @Test
-    fun `mutations with nested lists should work properly`() {
+    suspend fun `mutations with nested lists should work properly`() {
         data class NestedLists(
             val nested1: List<List<String?>>,
             val nested2: List<List<List<List<List<String>?>>?>>,
@@ -231,7 +231,7 @@ class ListsSpecificationTest {
         }
 
         val response = deserialize(
-            schema.executeBlocking(
+            schema.execute(
                 """
                     mutation {
                       createNestedLists(

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/ListsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/ListsSpecificationTest.kt
@@ -8,6 +8,7 @@ import com.apurebase.kgraphql.expect
 import com.apurebase.kgraphql.extract
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 @Specification("3.1.7 Lists")
@@ -15,7 +16,7 @@ import org.junit.jupiter.api.Test
 class ListsSpecificationTest {
 
     @Test
-    suspend fun `list arguments are valid`() {
+    fun `list arguments are valid`() = runTest {
         val schema = KGraphQL.schema {
             query("list") {
                 resolver { list: Iterable<String> -> list }
@@ -34,7 +35,7 @@ class ListsSpecificationTest {
     }
 
     @Test
-    suspend fun `lists with nullable entries are valid`() {
+    fun `lists with nullable entries are valid`() = runTest {
         val schema = KGraphQL.schema {
             query("list") {
                 resolver { list: Iterable<String?> -> list }
@@ -51,7 +52,7 @@ class ListsSpecificationTest {
     }
 
     @Test
-    suspend fun `lists with non-nullable entries should not accept list with null element`() {
+    fun `lists with non-nullable entries should not accept list with null element`() = runTest {
         val schema = KGraphQL.schema {
             query("list") {
                 resolver { list: Iterable<String> -> list }
@@ -68,7 +69,7 @@ class ListsSpecificationTest {
     }
 
     @Test
-    suspend fun `by default coerce single element input as collection`() {
+    fun `by default coerce single element input as collection`() = runTest {
         val schema = KGraphQL.schema {
             query("list") {
                 resolver { list: Iterable<String> -> list }
@@ -85,7 +86,7 @@ class ListsSpecificationTest {
     }
 
     @Test
-    suspend fun `null value is not coerced as single element collection`() {
+    fun `null value is not coerced as single element collection`() = runTest {
         val schema = KGraphQL.schema {
             query("list") {
                 resolver { list: Iterable<String>? -> list }
@@ -103,7 +104,7 @@ class ListsSpecificationTest {
     }
 
     @Test
-    suspend fun `list argument can be declared non-nullable`() {
+    fun `list argument can be declared non-nullable`() = runTest {
         val schema = KGraphQL.schema {
             query("list") {
                 resolver { list: Iterable<String> -> list }
@@ -120,7 +121,7 @@ class ListsSpecificationTest {
     }
 
     @Test
-    suspend fun `Iterable implementations are treated as list`() {
+    fun `Iterable implementations are treated as list`() = runTest {
 
         fun getResult(): Iterable<String> = listOf("POTATO", "BATATO", "ROTATO")
 
@@ -135,7 +136,7 @@ class ListsSpecificationTest {
     }
 
     @Test
-    suspend fun `input objects with sets should work properly with direct input`() {
+    fun `input objects with sets should work properly with direct input`() = runTest {
         data class TestObject(val list: List<String>, val set: Set<String>)
 
         val schema = KGraphQL.schema {
@@ -163,7 +164,7 @@ class ListsSpecificationTest {
     }
 
     @Test
-    suspend fun `input objects with sets should work properly with variables`() {
+    fun `input objects with sets should work properly with variables`() = runTest {
         data class TestObject(val list: List<String>, val set: Set<String>)
 
         val schema = KGraphQL.schema {
@@ -195,7 +196,7 @@ class ListsSpecificationTest {
 
     // https://github.com/stuebingerb/KGraphQL/issues/110
     @Test
-    suspend fun `queries with nested lists should work properly`() {
+    fun `queries with nested lists should work properly`() = runTest {
         val schema = KGraphQL.schema {
             query("getNestedList") {
                 resolver { -> listOf(listOf("foo", "bar"), listOf("foobar")) }
@@ -210,7 +211,7 @@ class ListsSpecificationTest {
     }
 
     @Test
-    suspend fun `mutations with nested lists should work properly`() {
+    fun `mutations with nested lists should work properly`() = runTest {
         data class NestedLists(
             val nested1: List<List<String?>>,
             val nested2: List<List<List<List<List<String>?>>?>>,

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/NonNullSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/NonNullSpecificationTest.kt
@@ -11,13 +11,14 @@ import com.apurebase.kgraphql.extract
 import com.apurebase.kgraphql.shouldBeInstanceOf
 import io.kotest.assertions.throwables.shouldThrowExactly
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 @Specification("3.1.8 Non-null")
 class NonNullSpecificationTest {
 
     @Test
-    suspend fun `if the result of non-null type is null, error should be raised`() {
+    fun `if the result of non-null type is null, error should be raised`() = runTest {
         val schema = KGraphQL.schema {
             query("nonNull") {
                 resolver { string: String? -> string!! }
@@ -30,7 +31,7 @@ class NonNullSpecificationTest {
     }
 
     @Test
-    suspend fun `nullable input types are always optional`() {
+    fun `nullable input types are always optional`() = runTest {
         val schema = KGraphQL.schema {
             query("nullable") {
                 resolver { input: String? -> input }
@@ -45,7 +46,7 @@ class NonNullSpecificationTest {
     }
 
     @Test
-    suspend fun `non-null types are always required`() {
+    fun `non-null types are always required`() = runTest {
         val schema = KGraphQL.schema {
             query("nonNull") {
                 resolver { input: String -> input }
@@ -57,7 +58,7 @@ class NonNullSpecificationTest {
     }
 
     @Test
-    suspend fun `variable of a nullable type cannot be provided to a non-null argument`() {
+    fun `variable of a nullable type cannot be provided to a non-null argument`() = runTest {
         val schema = KGraphQL.schema {
             query("nonNull") {
                 resolver { input: String -> input }
@@ -73,7 +74,7 @@ class NonNullSpecificationTest {
     data class Type2(val items: List<Type1?>)
 
     @Test
-    suspend fun `null within arrays should work`() {
+    fun `null within arrays should work`() = runTest {
         val schema = KGraphQL.schema {
             query("data") {
                 resolver { ->
@@ -106,7 +107,7 @@ class NonNullSpecificationTest {
     data class MyInput(val value1: String, val value2: String?, val value3: Int)
 
     @Test
-    suspend fun `missing nullable values without Kotlin default values should execute successfully and use null`() {
+    fun `missing nullable values without Kotlin default values should execute successfully and use null`() = runTest {
         val schema = KGraphQL.schema {
             query("main") {
                 resolver { input: MyInput -> "${input.value1} - ${input.value2 ?: "Nada"} - ${input.value3}" }
@@ -125,7 +126,7 @@ class NonNullSpecificationTest {
     }
 
     @Test
-    suspend fun `missing non-nullable values without Kotlin default values should raise an error`() {
+    fun `missing non-nullable values without Kotlin default values should raise an error`() = runTest {
         val schema = KGraphQL.schema {
             inputType<MyInput> {
                 property(MyInput::value1) {
@@ -151,7 +152,7 @@ class NonNullSpecificationTest {
     data class MyOptionalInput(val value1: String = "Hello", val value2: String? = "World")
 
     @Test
-    suspend fun `missing nullable values with Kotlin default values should execute successfully and use Kotlin defaults`() {
+    fun `missing nullable values with Kotlin default values should execute successfully and use Kotlin defaults`() = runTest {
         val schema = KGraphQL.schema {
             query("main") {
                 resolver { input: MyOptionalInput -> "${input.value1} - ${input.value2 ?: "Nada"}" }
@@ -170,7 +171,7 @@ class NonNullSpecificationTest {
     }
 
     @Test
-    suspend fun `missing non-nullable values with Kotlin default values should execute successfully and use Kotlin defaults`() {
+    fun `missing non-nullable values with Kotlin default values should execute successfully and use Kotlin defaults`() = runTest {
         val schema = KGraphQL.schema {
             query("main") {
                 resolver { input: MyOptionalInput -> "${input.value1} - ${input.value2 ?: "Nada"}" }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/ObjectsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/ObjectsSpecificationTest.kt
@@ -8,6 +8,7 @@ import com.apurebase.kgraphql.schema.SchemaException
 import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import kotlinx.coroutines.test.runTest
 import nidomiro.kdataloader.ExecutionResult
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -302,7 +303,7 @@ class ObjectsSpecificationTest {
     data class FewFields(val name: String = "Boguś", val surname: String = "Linda")
 
     @Test
-    suspend fun `fields are conceptually ordered in the same order in which they were encountered during query execution`() {
+    fun `fields are conceptually ordered in the same order in which they were encountered during query execution`() = runTest {
         val schema = schema {
             query("many") { resolver { -> ManyFields() } }
             type<ManyFields> {
@@ -332,7 +333,7 @@ class ObjectsSpecificationTest {
     }
 
     @Test
-    suspend fun `fragment spread fields occur before the following fields`() {
+    fun `fragment spread fields occur before the following fields`() = runTest {
         val schema = schema {
             query("many") { resolver { -> ManyFields() } }
         }
@@ -348,7 +349,7 @@ class ObjectsSpecificationTest {
     }
 
     @Test
-    suspend fun `fragments for which the type does not apply does not affect ordering`() {
+    fun `fragments for which the type does not apply does not affect ordering`() = runTest {
         val schema = schema {
             query("many") { resolver { -> ManyFields() } }
             type<FewFields>()
@@ -368,7 +369,7 @@ class ObjectsSpecificationTest {
     }
 
     @Test
-    suspend fun `if a field is queried multiple times in a selection, it is ordered by the first time it is encountered`() {
+    fun `if a field is queried multiple times in a selection, it is ordered by the first time it is encountered`() = runTest {
         val schema = schema {
             query("many") { resolver { -> ManyFields() } }
         }
@@ -416,7 +417,7 @@ class ObjectsSpecificationTest {
     }
 
     @Test
-    suspend fun `field resolution order does not affect response field order`() {
+    fun `field resolution order does not affect response field order`() = runTest {
         val schema = schema {
             type<Actor> {
                 property("long") {
@@ -450,7 +451,7 @@ class ObjectsSpecificationTest {
     }
 
     @Test
-    suspend fun `operation resolution order does not affect response field order`() {
+    fun `operation resolution order does not affect response field order`() = runTest {
         val schema = schema {
             query("long") {
                 resolver<String> {

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/ObjectsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/ObjectsSpecificationTest.kt
@@ -302,7 +302,7 @@ class ObjectsSpecificationTest {
     data class FewFields(val name: String = "Boguś", val surname: String = "Linda")
 
     @Test
-    fun `fields are conceptually ordered in the same order in which they were encountered during query execution`() {
+    suspend fun `fields are conceptually ordered in the same order in which they were encountered during query execution`() {
         val schema = schema {
             query("many") { resolver { -> ManyFields() } }
             type<ManyFields> {
@@ -312,7 +312,7 @@ class ObjectsSpecificationTest {
             }
         }
 
-        val result = schema.executeBlocking("{many{id, id2, value, active, smooth, name}}")
+        val result = schema.execute("{many{id, id2, value, active, smooth, name}}")
         with(result) {
             indexOf("\"name\"") shouldBeGreaterThan indexOf("\"smooth\"")
             indexOf("\"smooth\"") shouldBeGreaterThan indexOf("\"active\"")
@@ -321,7 +321,7 @@ class ObjectsSpecificationTest {
             indexOf("\"id2\"") shouldBeGreaterThan indexOf("\"id\"")
         }
 
-        val result2 = schema.executeBlocking("{many{name, active, id2, value, smooth, id}}")
+        val result2 = schema.execute("{many{name, active, id2, value, smooth, id}}")
         with(result2) {
             indexOf("\"id\"") shouldBeGreaterThan indexOf("\"smooth\"")
             indexOf("\"smooth\"") shouldBeGreaterThan indexOf("\"value\"")
@@ -332,13 +332,13 @@ class ObjectsSpecificationTest {
     }
 
     @Test
-    fun `fragment spread fields occur before the following fields`() {
+    suspend fun `fragment spread fields occur before the following fields`() {
         val schema = schema {
             query("many") { resolver { -> ManyFields() } }
         }
 
         val result =
-            schema.executeBlocking("{many{active, ...Fields , smooth, id}} fragment Fields on ManyFields { id2, value }")
+            schema.execute("{many{active, ...Fields , smooth, id}} fragment Fields on ManyFields { id2, value }")
         with(result) {
             indexOf("\"id\"") shouldBeGreaterThan indexOf("\"smooth\"")
             indexOf("\"smooth\"") shouldBeGreaterThan indexOf("\"value\"")
@@ -348,13 +348,13 @@ class ObjectsSpecificationTest {
     }
 
     @Test
-    fun `fragments for which the type does not apply does not affect ordering`() {
+    suspend fun `fragments for which the type does not apply does not affect ordering`() {
         val schema = schema {
             query("many") { resolver { -> ManyFields() } }
             type<FewFields>()
         }
 
-        val result = schema.executeBlocking(
+        val result = schema.execute(
             "{many{active, ...Fields, ...Few , smooth, id}} " +
                 "fragment Fields on ManyFields { id2, value }" +
                 "fragment Few on FewFields { name } "
@@ -368,12 +368,12 @@ class ObjectsSpecificationTest {
     }
 
     @Test
-    fun `if a field is queried multiple times in a selection, it is ordered by the first time it is encountered`() {
+    suspend fun `if a field is queried multiple times in a selection, it is ordered by the first time it is encountered`() {
         val schema = schema {
             query("many") { resolver { -> ManyFields() } }
         }
 
-        val result = schema.executeBlocking("{many{id, id2, value, id, active, smooth}}")
+        val result = schema.execute("{many{id, id2, value, id, active, smooth}}")
         with(result) {
             //ensure that "id" appears only once
             indexOf("\"id\"") shouldBe lastIndexOf("\"id\"")
@@ -385,7 +385,7 @@ class ObjectsSpecificationTest {
         }
 
         val resultFragment =
-            schema.executeBlocking("{many{id, id2, ...Many, active, smooth}} fragment Many on ManyFields{value, id}")
+            schema.execute("{many{id, id2, ...Many, active, smooth}} fragment Many on ManyFields{value, id}")
         with(resultFragment) {
             //ensure that "id" appears only once
             indexOf("\"id\"") shouldBe lastIndexOf("\"id\"")
@@ -416,7 +416,7 @@ class ObjectsSpecificationTest {
     }
 
     @Test
-    fun `field resolution order does not affect response field order`() {
+    suspend fun `field resolution order does not affect response field order`() {
         val schema = schema {
             type<Actor> {
                 property("long") {
@@ -438,19 +438,19 @@ class ObjectsSpecificationTest {
             }
         }
 
-        val responseShortAfterLong = schema.executeBlocking("{actor{long, short}}")
+        val responseShortAfterLong = schema.execute("{actor{long, short}}")
         with(responseShortAfterLong) {
             indexOf("short") shouldBeGreaterThan indexOf("long")
         }
 
-        val responseLongAfterShort = schema.executeBlocking("{actor{short, long}}")
+        val responseLongAfterShort = schema.execute("{actor{short, long}}")
         with(responseLongAfterShort) {
             indexOf("long") shouldBeGreaterThan indexOf("short")
         }
     }
 
     @Test
-    fun `operation resolution order does not affect response field order`() {
+    suspend fun `operation resolution order does not affect response field order`() {
         val schema = schema {
             query("long") {
                 resolver<String> {
@@ -466,7 +466,7 @@ class ObjectsSpecificationTest {
             }
         }
 
-        val responseShortAfterLong = schema.executeBlocking("{long, short}")
+        val responseShortAfterLong = schema.execute("{long, short}")
         with(responseShortAfterLong) {
             indexOf("short") shouldBeGreaterThan indexOf("long")
         }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/ScalarsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/ScalarsSpecificationTest.kt
@@ -11,6 +11,7 @@ import com.apurebase.kgraphql.schema.model.ast.ValueNode
 import com.apurebase.kgraphql.schema.scalar.ID
 import com.apurebase.kgraphql.schema.scalar.StringScalarCoercion
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.util.UUID
@@ -19,7 +20,7 @@ import java.util.UUID
 class ScalarsSpecificationTest {
 
     @Test
-    suspend fun `built-in scalars should be available by default`() {
+    fun `built-in scalars should be available by default`() = runTest {
         val schema = KGraphQL.schema {
             query("int") {
                 resolver<Int> { 1 }
@@ -67,7 +68,7 @@ class ScalarsSpecificationTest {
     }
 
     @Test
-    suspend fun `extended scalars should be available if included`() {
+    fun `extended scalars should be available if included`() = runTest {
         val schema = KGraphQL.schema {
             extendedScalars()
             query("long") {
@@ -86,7 +87,7 @@ class ScalarsSpecificationTest {
     data class Person(val uuid: UUID, val name: String)
 
     @Test
-    suspend fun `type systems can add additional scalars with semantic meaning`() {
+    fun `type systems can add additional scalars with semantic meaning`() = runTest {
         val uuid = UUID.randomUUID()
         val testedSchema = KGraphQL.schema {
             stringScalar<UUID> {
@@ -119,7 +120,7 @@ class ScalarsSpecificationTest {
     }
 
     @Test
-    suspend fun `integer value represents a value grater than 2^-31 and less or equal to 2^31`() {
+    fun `integer value represents a value grater than 2^-31 and less or equal to 2^31`() = runTest {
         val schema = KGraphQL.schema {
             query("dummy") {
                 resolver { -> "dummy" }
@@ -135,7 +136,7 @@ class ScalarsSpecificationTest {
     }
 
     @Test
-    suspend fun `when float is expected as an input type, both integer and float input values are accepted`() {
+    fun `when float is expected as an input type, both integer and float input values are accepted`() = runTest {
         val schema = KGraphQL.schema {
             query("dummy") {
                 resolver { -> "dummy" }
@@ -149,7 +150,7 @@ class ScalarsSpecificationTest {
     }
 
     @Test
-    suspend fun `server can declare custom UUID type`() {
+    fun `server can declare custom UUID type`() = runTest {
         val testedSchema = KGraphQL.schema {
             stringScalar<UUID> {
                 name = "UUID"
@@ -169,7 +170,7 @@ class ScalarsSpecificationTest {
     }
 
     @Test
-    suspend fun `server can use built-in ID type`() {
+    fun `server can use built-in ID type`() = runTest {
         data class IdPerson(val id: ID, val name: String)
 
         val testedSchema = KGraphQL.schema {
@@ -259,7 +260,7 @@ class ScalarsSpecificationTest {
     }
 
     @Test
-    suspend fun `for numeric scalars, input string with numeric content must raise a query error indicating an incorrect type`() {
+    fun `for numeric scalars, input string with numeric content must raise a query error indicating an incorrect type`() = runTest {
         val schema = KGraphQL.schema {
             query("dummy") {
                 resolver { -> "dummy" }
@@ -277,7 +278,7 @@ class ScalarsSpecificationTest {
     data class Number(val int: Int)
 
     @Test
-    suspend fun `Schema may declare custom int scalar type`() {
+    fun `Schema may declare custom int scalar type`() = runTest {
         val schema = KGraphQL.schema {
             intScalar<Number> {
                 deserialize = ::Number
@@ -297,7 +298,7 @@ class ScalarsSpecificationTest {
     data class Bool(val boolean: Boolean)
 
     @Test
-    suspend fun `Schema may declare custom boolean scalar type`() {
+    fun `Schema may declare custom boolean scalar type`() = runTest {
         val schema = KGraphQL.schema {
             booleanScalar<Bool> {
                 deserialize = ::Bool
@@ -323,7 +324,7 @@ class ScalarsSpecificationTest {
     data class Multi(val boo: Boo, val str: String, val num: Num)
 
     @Test
-    suspend fun `schema may declare custom double scalar type`() {
+    fun `schema may declare custom double scalar type`() = runTest {
         val schema = KGraphQL.schema {
             floatScalar<Dob> {
                 deserialize = ::Dob
@@ -341,7 +342,7 @@ class ScalarsSpecificationTest {
     }
 
     @Test
-    suspend fun `scalars within input variables`() {
+    fun `scalars within input variables`() = runTest {
         val schema = KGraphQL.schema {
             booleanScalar<Boo> {
                 deserialize = ::Boo
@@ -448,7 +449,7 @@ class ScalarsSpecificationTest {
     data class NewPart(val manufacturer: String, val name: String, val oem: Boolean, val addedDate: LocalDate)
 
     @Test
-    suspend fun `schema may declare LocalDate custom scalar`() {
+    fun `schema may declare LocalDate custom scalar`() = runTest {
         val schema = KGraphQL.schema {
             query("dummy") {
                 resolver { -> "dummy" }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/UnionsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/UnionsSpecificationTest.kt
@@ -22,7 +22,7 @@ import java.time.Instant
 class UnionsSpecificationTest : BaseSchemaTest() {
 
     @Test
-    fun `query union property`() {
+    suspend fun `query union property`() {
         val map = execute(
             "{actors{name, favourite{ ... on Actor {name}, ... on Director {name age}, ... on Scenario{content(uppercase: false)}}}}",
             null
@@ -39,7 +39,7 @@ class UnionsSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `query union property with external fragment`() {
+    suspend fun `query union property with external fragment`() {
         val map = execute(
             "{actors{name, favourite{ ...actor, ...director, ...scenario }}}" +
                 "fragment actor on Actor {name}" +
@@ -58,14 +58,14 @@ class UnionsSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `query union property with invalid selection set`() {
+    suspend fun `query union property with invalid selection set`() {
         expect<ValidationException>("Invalid selection set with properties: [name] on union type property favourite : [Actor, Scenario, Director]") {
             execute("{actors{name, favourite{ name }}}")
         }
     }
 
     @Test
-    fun `a union type should allow requesting __typename`() {
+    suspend fun `a union type should allow requesting __typename`() {
         val result = execute(
             """{
                 actors {
@@ -92,7 +92,7 @@ class UnionsSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `a union type should allow requesting __typename only`() {
+    suspend fun `a union type should allow requesting __typename only`() {
         val result = execute(
             """{
                 actors {
@@ -111,7 +111,7 @@ class UnionsSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `a union type should require a selection for all potential types`() {
+    suspend fun `a union type should require a selection for all potential types`() {
         expect<ValidationException>("Missing selection set for type Scenario") {
             execute(
                 """{
@@ -128,7 +128,7 @@ class UnionsSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `Nullable union types should be valid`() {
+    suspend fun `Nullable union types should be valid`() {
         val result = execute(
             """{
               actors(all: true) {
@@ -149,7 +149,7 @@ class UnionsSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `Non nullable union types should fail`() {
+    suspend fun `Non nullable union types should fail`() {
         expect<ExecutionException>("Unexpected type of union property value, expected one of [Actor, Scenario, Director] but was null") {
             execute(
                 """{
@@ -227,7 +227,7 @@ class UnionsSpecificationTest : BaseSchemaTest() {
 
     @Suppress("UNUSED_ANONYMOUS_PARAMETER") // "ctx" must stay as-is because resolver cannot handle unnamed parameter
     @Test
-    fun `automatic unions out of sealed classes`() {
+    suspend fun `automatic unions out of sealed classes`() {
         defaultSchema {
             unionType<AAA>()
 
@@ -241,7 +241,7 @@ class UnionsSpecificationTest : BaseSchemaTest() {
                 }
             }
         }
-            .executeBlocking(
+            .execute(
                 """
                 {
                     f: returnUnion(isB: false) {
@@ -267,7 +267,7 @@ class UnionsSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `union types in lists`() {
+    suspend fun `union types in lists`() {
         defaultSchema {
             unionType<WithFields>()
 
@@ -276,7 +276,7 @@ class UnionsSpecificationTest : BaseSchemaTest() {
                     WithFields.Value1(1, node.getFields())
                 }
             }
-        }.executeBlocking(
+        }.execute(
             """
             {
                 returnUnion {
@@ -293,7 +293,7 @@ class UnionsSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `union types with custom name def resolver`() {
+    suspend fun `union types with custom name def resolver`() {
         defaultSchema {
             unionType<WithFields> {
                 subTypeBlock = {
@@ -309,7 +309,7 @@ class UnionsSpecificationTest : BaseSchemaTest() {
                     )
                 }
             }
-        }.executeBlocking(
+        }.execute(
             """
             {
                 returnUnion {
@@ -346,7 +346,7 @@ class UnionsSpecificationTest : BaseSchemaTest() {
 
     // https://github.com/aPureBase/KGraphQL/issues/105
     @Test
-    fun `sealed classes unions should allow requesting __typename`() {
+    suspend fun `sealed classes unions should allow requesting __typename`() {
         val schema = KGraphQL.schema {
             longScalar<Instant> {
                 serialize = { it.toEpochMilli() }
@@ -357,7 +357,7 @@ class UnionsSpecificationTest : BaseSchemaTest() {
                 resolver { -> ContactStatus.Onboarded(userId = "someUserId") }
             }
         }
-        val results = schema.executeBlocking(
+        val results = schema.execute(
             """
             {
                 contactStatus {
@@ -384,7 +384,7 @@ class UnionsSpecificationTest : BaseSchemaTest() {
 
     // https://github.com/aPureBase/KGraphQL/issues/105
     @Test
-    fun `inner sealed classes unions should allow requesting __typename`() {
+    suspend fun `inner sealed classes unions should allow requesting __typename`() {
         val schema = KGraphQL.schema {
             longScalar<Instant> {
                 serialize = { it.toEpochMilli() }
@@ -396,7 +396,7 @@ class UnionsSpecificationTest : BaseSchemaTest() {
             }
         }
 
-        val results = schema.executeBlocking(
+        val results = schema.execute(
             """
             {
                 carrier {
@@ -433,7 +433,7 @@ class UnionsSpecificationTest : BaseSchemaTest() {
 
     // https://github.com/aPureBase/KGraphQL/issues/109
     @Test
-    fun `list of union type should work as expected`() {
+    suspend fun `list of union type should work as expected`() {
         val schema = KGraphQL.schema {
             unionType<QualificationItem>()
 
@@ -444,7 +444,7 @@ class UnionsSpecificationTest : BaseSchemaTest() {
             }
         }
 
-        val result = schema.executeBlocking(
+        val result = schema.execute(
             """
                 query IntrospectionQuery {
                     __schema {

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/UnionsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/UnionsSpecificationTest.kt
@@ -15,6 +15,7 @@ import com.apurebase.kgraphql.schema.SchemaException
 import com.apurebase.kgraphql.schema.execution.Execution
 import io.kotest.assertions.throwables.shouldThrowExactly
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import java.time.Instant
 
@@ -22,7 +23,7 @@ import java.time.Instant
 class UnionsSpecificationTest : BaseSchemaTest() {
 
     @Test
-    suspend fun `query union property`() {
+    fun `query union property`() = runTest {
         val map = execute(
             "{actors{name, favourite{ ... on Actor {name}, ... on Director {name age}, ... on Scenario{content(uppercase: false)}}}}",
             null
@@ -39,7 +40,7 @@ class UnionsSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `query union property with external fragment`() {
+    fun `query union property with external fragment`() = runTest {
         val map = execute(
             "{actors{name, favourite{ ...actor, ...director, ...scenario }}}" +
                 "fragment actor on Actor {name}" +
@@ -58,14 +59,14 @@ class UnionsSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `query union property with invalid selection set`() {
+    fun `query union property with invalid selection set`() = runTest {
         expect<ValidationException>("Invalid selection set with properties: [name] on union type property favourite : [Actor, Scenario, Director]") {
             execute("{actors{name, favourite{ name }}}")
         }
     }
 
     @Test
-    suspend fun `a union type should allow requesting __typename`() {
+    fun `a union type should allow requesting __typename`() = runTest {
         val result = execute(
             """{
                 actors {
@@ -92,7 +93,7 @@ class UnionsSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `a union type should allow requesting __typename only`() {
+    fun `a union type should allow requesting __typename only`() = runTest {
         val result = execute(
             """{
                 actors {
@@ -111,7 +112,7 @@ class UnionsSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `a union type should require a selection for all potential types`() {
+    fun `a union type should require a selection for all potential types`() = runTest {
         expect<ValidationException>("Missing selection set for type Scenario") {
             execute(
                 """{
@@ -128,7 +129,7 @@ class UnionsSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `Nullable union types should be valid`() {
+    fun `Nullable union types should be valid`() = runTest {
         val result = execute(
             """{
               actors(all: true) {
@@ -149,7 +150,7 @@ class UnionsSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `Non nullable union types should fail`() {
+    fun `Non nullable union types should fail`() = runTest {
         expect<ExecutionException>("Unexpected type of union property value, expected one of [Actor, Scenario, Director] but was null") {
             execute(
                 """{
@@ -227,7 +228,7 @@ class UnionsSpecificationTest : BaseSchemaTest() {
 
     @Suppress("UNUSED_ANONYMOUS_PARAMETER") // "ctx" must stay as-is because resolver cannot handle unnamed parameter
     @Test
-    suspend fun `automatic unions out of sealed classes`() {
+    fun `automatic unions out of sealed classes`() = runTest {
         defaultSchema {
             unionType<AAA>()
 
@@ -267,7 +268,7 @@ class UnionsSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `union types in lists`() {
+    fun `union types in lists`() = runTest {
         defaultSchema {
             unionType<WithFields>()
 
@@ -293,7 +294,7 @@ class UnionsSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    suspend fun `union types with custom name def resolver`() {
+    fun `union types with custom name def resolver`() = runTest {
         defaultSchema {
             unionType<WithFields> {
                 subTypeBlock = {
@@ -346,7 +347,7 @@ class UnionsSpecificationTest : BaseSchemaTest() {
 
     // https://github.com/aPureBase/KGraphQL/issues/105
     @Test
-    suspend fun `sealed classes unions should allow requesting __typename`() {
+    fun `sealed classes unions should allow requesting __typename`() = runTest {
         val schema = KGraphQL.schema {
             longScalar<Instant> {
                 serialize = { it.toEpochMilli() }
@@ -384,7 +385,7 @@ class UnionsSpecificationTest : BaseSchemaTest() {
 
     // https://github.com/aPureBase/KGraphQL/issues/105
     @Test
-    suspend fun `inner sealed classes unions should allow requesting __typename`() {
+    fun `inner sealed classes unions should allow requesting __typename`() = runTest {
         val schema = KGraphQL.schema {
             longScalar<Instant> {
                 serialize = { it.toEpochMilli() }
@@ -433,7 +434,7 @@ class UnionsSpecificationTest : BaseSchemaTest() {
 
     // https://github.com/aPureBase/KGraphQL/issues/109
     @Test
-    suspend fun `list of union type should work as expected`() {
+    fun `list of union type should work as expected`() = runTest {
         val schema = KGraphQL.schema {
             unionType<QualificationItem>()
 


### PR DESCRIPTION
Using it has the following benefits over `runBlocking`:
* concept of virtual time when using e.g. `delay`, which is useful to e.g. specify something runs in parallel instead of in sequence
* less manual calls to `runBlocking` which are IMO clutter in tests
* built-in timeout functionality (configurable)