### PR TITLE
fix!: validate fragment usage

### DIFF
--- a/kgraphql/api/kgraphql.api
+++ b/kgraphql/api/kgraphql.api
@@ -1486,20 +1486,19 @@ public abstract class com/apurebase/kgraphql/schema/model/ast/DefinitionNode : c
 public abstract class com/apurebase/kgraphql/schema/model/ast/DefinitionNode$ExecutableDefinitionNode : com/apurebase/kgraphql/schema/model/ast/DefinitionNode {
 	public synthetic fun <init> (Lcom/apurebase/kgraphql/schema/model/ast/Location;Lcom/apurebase/kgraphql/schema/model/ast/NameNode;Ljava/util/List;Ljava/util/List;Lcom/apurebase/kgraphql/schema/model/ast/SelectionSetNode;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getDirectives ()Ljava/util/List;
-	public final fun getName ()Lcom/apurebase/kgraphql/schema/model/ast/NameNode;
+	public fun getName ()Lcom/apurebase/kgraphql/schema/model/ast/NameNode;
 	public final fun getSelectionSet ()Lcom/apurebase/kgraphql/schema/model/ast/SelectionSetNode;
 	public final fun getVariableDefinitions ()Ljava/util/List;
 }
 
 public final class com/apurebase/kgraphql/schema/model/ast/DefinitionNode$ExecutableDefinitionNode$FragmentDefinitionNode : com/apurebase/kgraphql/schema/model/ast/DefinitionNode$ExecutableDefinitionNode {
 	public fun <init> (Lcom/apurebase/kgraphql/schema/model/ast/Location;Lcom/apurebase/kgraphql/schema/model/ast/NameNode;Ljava/util/List;Lcom/apurebase/kgraphql/schema/model/ast/SelectionSetNode;Lcom/apurebase/kgraphql/schema/model/ast/TypeNode$NamedTypeNode;)V
-	public synthetic fun <init> (Lcom/apurebase/kgraphql/schema/model/ast/Location;Lcom/apurebase/kgraphql/schema/model/ast/NameNode;Ljava/util/List;Lcom/apurebase/kgraphql/schema/model/ast/SelectionSetNode;Lcom/apurebase/kgraphql/schema/model/ast/TypeNode$NamedTypeNode;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getName ()Lcom/apurebase/kgraphql/schema/model/ast/NameNode;
 	public final fun getTypeCondition ()Lcom/apurebase/kgraphql/schema/model/ast/TypeNode$NamedTypeNode;
 }
 
 public final class com/apurebase/kgraphql/schema/model/ast/DefinitionNode$ExecutableDefinitionNode$OperationDefinitionNode : com/apurebase/kgraphql/schema/model/ast/DefinitionNode$ExecutableDefinitionNode {
 	public fun <init> (Lcom/apurebase/kgraphql/schema/model/ast/Location;Lcom/apurebase/kgraphql/schema/model/ast/NameNode;Ljava/util/List;Ljava/util/List;Lcom/apurebase/kgraphql/schema/model/ast/SelectionSetNode;Lcom/apurebase/kgraphql/schema/model/ast/OperationTypeNode;)V
-	public synthetic fun <init> (Lcom/apurebase/kgraphql/schema/model/ast/Location;Lcom/apurebase/kgraphql/schema/model/ast/NameNode;Ljava/util/List;Ljava/util/List;Lcom/apurebase/kgraphql/schema/model/ast/SelectionSetNode;Lcom/apurebase/kgraphql/schema/model/ast/OperationTypeNode;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getOperation ()Lcom/apurebase/kgraphql/schema/model/ast/OperationTypeNode;
 }
 
@@ -2142,13 +2141,6 @@ public final class com/apurebase/kgraphql/schema/structure/LookupSchema$DefaultI
 public final class com/apurebase/kgraphql/schema/structure/RequestInterpreter {
 	public fun <init> (Lcom/apurebase/kgraphql/schema/structure/SchemaModel;)V
 	public final fun createExecutionPlan (Lcom/apurebase/kgraphql/schema/model/ast/DocumentNode;Ljava/lang/String;Lcom/apurebase/kgraphql/request/VariablesJson;)Lcom/apurebase/kgraphql/schema/execution/ExecutionPlan;
-}
-
-public final class com/apurebase/kgraphql/schema/structure/RequestInterpreter$InterpreterContext {
-	public fun <init> (Lcom/apurebase/kgraphql/schema/structure/RequestInterpreter;Ljava/util/Map;Ljava/util/List;)V
-	public final fun get (Lcom/apurebase/kgraphql/schema/model/ast/SelectionNode$FragmentNode$FragmentSpreadNode;)Lcom/apurebase/kgraphql/schema/execution/Execution$Fragment;
-	public final fun getDeclaredVariables ()Ljava/util/List;
-	public final fun getFragments ()Ljava/util/Map;
 }
 
 public class com/apurebase/kgraphql/schema/structure/SchemaCompilation {

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/ast/DefinitionNode.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/ast/DefinitionNode.kt
@@ -7,22 +7,22 @@ sealed class DefinitionNode(override val loc: Location?) : ASTNode() {
 
     sealed class ExecutableDefinitionNode(
         loc: Location?,
-        val name: NameNode?,
+        open val name: NameNode?,
         val variableDefinitions: List<VariableDefinitionNode>?,
         val directives: List<DirectiveNode>?,
         val selectionSet: SelectionSetNode
     ) : DefinitionNode(loc) {
         class FragmentDefinitionNode(
             loc: Location?,
-            name: NameNode,
-            directives: List<DirectiveNode> = listOf(),
+            override val name: NameNode,
+            directives: List<DirectiveNode>,
             selectionSet: SelectionSetNode,
             val typeCondition: NamedTypeNode
         ) : ExecutableDefinitionNode(loc, name, emptyList(), directives, selectionSet)
 
         class OperationDefinitionNode(
             loc: Location?,
-            name: NameNode? = null,
+            name: NameNode?,
             variableDefinitions: List<VariableDefinitionNode>?,
             directives: List<DirectiveNode>?,
             selectionSet: SelectionSetNode,

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/dsl/DataLoaderPropertyDSLTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/dsl/DataLoaderPropertyDSLTest.kt
@@ -69,7 +69,7 @@ class DataLoaderPropertyDSLTest {
 
     @Test
     fun `creation of data properties from a list`() {
-        val props = listOf(Prop(typeOf<Int>()) { 0 }, Prop(typeOf<String>()) { "test" })
+        val props: List<Prop<Any>> = listOf(Prop(typeOf<Int>()) { 0 }, Prop(typeOf<String>()) { "test" })
 
         val schema = defaultSchema {
             query("scenario") {

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/FragmentsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/FragmentsSpecificationTest.kt
@@ -189,6 +189,39 @@ class FragmentsSpecificationTest {
         }
     }
 
+    @Test
+    fun `queries with unused fragments should be denied`() {
+        expect<ValidationException>("Found unused fragments: [unused_film_title]") {
+            baseTestSchema.execute(
+                """
+            {
+                film {
+                    ...film_title
+                }
+            }
+            
+            fragment film_title on Film {
+                title
+                director {
+                    ...director_name
+                }
+            }
+            
+            fragment director_name on Director {
+                name
+            }
+            
+            fragment unused_film_title on Film {
+                director {
+                    name
+                    age
+                }
+            }
+        """
+            )
+        }
+    }
+
     sealed class TopUnion(val field: String) {
         class Union1(val names: List<String>) : TopUnion("union1")
         class Union2(val numbers: List<Int>, val booleans: List<Boolean>) : TopUnion("union2")

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/UnionsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/UnionsSpecificationTest.kt
@@ -40,10 +40,15 @@ class UnionsSpecificationTest : BaseSchemaTest() {
     @Test
     fun `query union property with external fragment`() {
         val map = execute(
-            "{actors{name, favourite{ ...actor, ...director, ...scenario }}}" +
-                "fragment actor on Actor {name}" +
-                "fragment director on Director {name age}" +
-                "fragment scenario on Scenario{content(uppercase: false)} ", null
+            """
+            {
+                actors{ name, favourite{ ...actor, ...director, ...scenario }}}
+                
+                fragment actor on Actor {name}
+                fragment director on Director {name age}
+                fragment scenario on Scenario{content(uppercase: false)
+            }
+        """.trimIndent()
         )
         for (i in 0..4) {
             val name = map.extract<String>("data/actors[$i]/name")


### PR DESCRIPTION
Unused fragments now result in an error, as required by the spec.

Resolves #105

BREAKING CHANGE: Queries with unused fragments previously succeeded but fail now. This indicates a potential problem with the GraphQL client, though.