### PR TITLE
feat: add ktor error handler

### DIFF
--- a/kgraphql-ktor/api/kgraphql-ktor.api
+++ b/kgraphql-ktor/api/kgraphql-ktor.api
@@ -7,6 +7,7 @@ public final class com/apurebase/kgraphql/GraphQL {
 public final class com/apurebase/kgraphql/GraphQL$Configuration : com/apurebase/kgraphql/schema/dsl/SchemaConfigurationDSL {
 	public fun <init> ()V
 	public final fun context (Lkotlin/jvm/functions/Function2;)V
+	public final fun errorHandler (Lkotlin/jvm/functions/Function1;)V
 	public final fun getEndpoint ()Ljava/lang/String;
 	public final fun getPlayground ()Z
 	public final fun schema (Lkotlin/jvm/functions/Function1;)V

--- a/kgraphql-ktor/src/test/kotlin/com/apurebase/kgraphql/KtorTest.kt
+++ b/kgraphql-ktor/src/test/kotlin/com/apurebase/kgraphql/KtorTest.kt
@@ -18,6 +18,7 @@ open class KtorTest {
     fun withServer(
         ctxBuilder: ContextBuilder.(ApplicationCall) -> Unit = {},
         authHeader: String? = null,
+        errorHandler: ((Throwable) -> GraphQLError)? = null,
         block: SchemaBuilder.() -> Unit
     ): (String, Kraph.() -> Unit) -> HttpResponse {
         return { type, kraph ->
@@ -36,6 +37,7 @@ open class KtorTest {
                     wrap { next ->
                         authenticate(optional = authHeader == null) { next() }
                     }
+                    errorHandler?.let { this.errorHandler(it) }
                     schema(block)
                 }
 

--- a/kgraphql-ktor/src/test/kotlin/com/apurebase/kgraphql/KtorTest.kt
+++ b/kgraphql-ktor/src/test/kotlin/com/apurebase/kgraphql/KtorTest.kt
@@ -19,6 +19,7 @@ open class KtorTest {
         ctxBuilder: ContextBuilder.(ApplicationCall) -> Unit = {},
         authHeader: String? = null,
         errorHandler: ((Throwable) -> GraphQLError)? = null,
+        wrapErrors: Boolean? = null,
         block: SchemaBuilder.() -> Unit
     ): (String, Kraph.() -> Unit) -> HttpResponse {
         return { type, kraph ->
@@ -38,6 +39,7 @@ open class KtorTest {
                         authenticate(optional = authHeader == null) { next() }
                     }
                     errorHandler?.let { this.errorHandler(it) }
+                    wrapErrors?.let { this.wrapErrors = it }
                     schema(block)
                 }
 


### PR DESCRIPTION
### Summary

Added support for custom error handling in `kgraphql-ktor`.

This feature allows developers to handle non-`GraphQLError` exceptions in a more controlled way, without requiring additional setup.

Previously, all non-`GraphQLError` exceptions were treated as `ExecutionException` (when `wrapErrors = true`) or propagated outside GraphQL to be handled by the `StatusPages` plugin.

---

### Example usage

```kotlin
install(GraphQL) {
    errorHandler { e ->
        log.error("Handled error: {}", e.message, e)
        when (e) {
            is ValidationException -> GraphQLError(e.message, extensions = mapOf("type" to "VALIDATION_ERROR"))
            is DomainException -> GraphQLError(e.message, extensions = mapOf("type" to "DOMAIN_ERROR"))
            is GraphQLError -> e
            else -> ExecutionException(e.message ?: "Unknown execution error", cause = e)
        }
    }

    schema {
        // ...
    }
}
```

---

### Open question

I’m still considering whether the `errorHandler` function should **strictly require returning a `GraphQLError`**,
or if it would be more flexible to **allow returning any `Throwable`** (with only `GraphQLError` being serialized directly).
Open to feedback on which approach feels more idiomatic for this API.