### PR TITLE
feat: improve error handling during schema compilation

### DIFF
--- a/kgraphql-ktor-stitched/src/main/kotlin/com/apurebase/kgraphql/stitched/schema/model/StitchedMutableSchemaDefinition.kt
+++ b/kgraphql-ktor-stitched/src/main/kotlin/com/apurebase/kgraphql/stitched/schema/model/StitchedMutableSchemaDefinition.kt
@@ -35,7 +35,7 @@ class StitchedMutableSchemaDefinition : MutableSchemaDefinition() {
 
     fun addRemoteSchema(url: String, schema: __Schema) {
         if (url in remoteSchemas.keys) {
-            throw SchemaException("Cannot add remote schema with duplicated url $url")
+            throw SchemaException("Cannot add remote schema with duplicated url '$url'")
         }
         remoteSchemas[url] = schema
     }

--- a/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/execution/StitchedSchemaExecutionTest.kt
+++ b/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/execution/StitchedSchemaExecutionTest.kt
@@ -1930,7 +1930,7 @@ class StitchedSchemaExecutionTest {
                 )
             )
         }.bodyAsText() shouldBe """
-            {"errors":[{"message":"Property nonexisting on Remote2 does not exist","locations":[{"line":2,"column":13}],"path":[],"extensions":{"type":"GRAPHQL_VALIDATION_FAILED"}}]}
+            {"errors":[{"message":"Property 'nonexisting' on 'Remote2' does not exist","locations":[{"line":2,"column":13}],"path":[],"extensions":{"type":"GRAPHQL_VALIDATION_FAILED"}}]}
         """.trimIndent()
     }
 
@@ -2988,7 +2988,7 @@ class StitchedSchemaExecutionTest {
             header(HttpHeaders.ContentType, ContentType.Application.Json)
             setBody(graphqlRequest("{ failSyntax }"))
         }.bodyAsText() shouldBe """
-            {"errors":[{"message":"Property failSyntax on Query does not exist","locations":[{"line":1,"column":3}],"path":[],"extensions":{"type":"GRAPHQL_VALIDATION_FAILED"}}]}
+            {"errors":[{"message":"Property 'failSyntax' on 'Query' does not exist","locations":[{"line":1,"column":3}],"path":[],"extensions":{"type":"GRAPHQL_VALIDATION_FAILED"}}]}
         """.trimIndent()
 
         // Query that failed during execution

--- a/kgraphql-ktor/src/test/kotlin/com/apurebase/kgraphql/KtorFeatureTest.kt
+++ b/kgraphql-ktor/src/test/kotlin/com/apurebase/kgraphql/KtorFeatureTest.kt
@@ -156,7 +156,9 @@ class KtorFeatureTest : KtorTest() {
             }
         }
         runBlocking {
-            response.bodyAsText() shouldBe "{\"errors\":[{\"message\":\"Property nickname on Actor does not exist\",\"locations\":[{\"line\":3,\"column\":1}],\"path\":[],\"extensions\":{\"type\":\"GRAPHQL_VALIDATION_FAILED\"}}]}"
+            response.bodyAsText() shouldBe """
+                {"errors":[{"message":"Property 'nickname' on 'Actor' does not exist","locations":[{"line":3,"column":1}],"path":[],"extensions":{"type":"GRAPHQL_VALIDATION_FAILED"}}]}
+            """.trimIndent()
             response.contentType() shouldBe ContentType.Application.Json
         }
     }

--- a/kgraphql/api/kgraphql.api
+++ b/kgraphql/api/kgraphql.api
@@ -2161,17 +2161,17 @@ public class com/apurebase/kgraphql/schema/structure/SchemaCompilation {
 	protected final fun getScalars ()Ljava/util/Map;
 	protected final fun getSchemaProxy ()Lcom/apurebase/kgraphql/schema/introspection/SchemaProxy;
 	protected final fun getUnions ()Ljava/util/List;
-	protected final fun handleInputType (Lkotlin/reflect/KClass;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	protected final fun handleBaseTypes (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	protected final fun handleMutations (Ljava/util/List;)Lcom/apurebase/kgraphql/schema/structure/Type;
-	protected final fun handleObjectType (Lkotlin/reflect/KClass;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	protected final fun handleOperation (Lcom/apurebase/kgraphql/schema/model/BaseOperationDef;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	protected final fun handlePartialDirective (Lcom/apurebase/kgraphql/schema/directive/Directive$Partial;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	protected final fun handleQueries (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	protected final fun handleSubscriptions (Ljava/util/List;)Lcom/apurebase/kgraphql/schema/structure/Type;
-	protected final fun handleUnionType (Lcom/apurebase/kgraphql/schema/model/TypeDef$Union;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	protected final fun introspectInterfaces (Lkotlin/reflect/KClass;Lcom/apurebase/kgraphql/schema/structure/TypeProxy;)V
-	protected final fun introspectPossibleTypes (Lkotlin/reflect/KClass;Lcom/apurebase/kgraphql/schema/structure/TypeProxy;)V
+	protected final fun introspectTypes ()V
+	protected final fun localMutationFields (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	protected final fun localQueryFields (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	protected final fun localSubscriptionFields (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun perform (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	protected final fun wrapExceptions (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class com/apurebase/kgraphql/schema/structure/SchemaModel : com/apurebase/kgraphql/schema/introspection/__Schema {

--- a/kgraphql/src/jvm/kotlin/com/apurebase/kgraphql/FunctionExecutionBenchmark.kt
+++ b/kgraphql/src/jvm/kotlin/com/apurebase/kgraphql/FunctionExecutionBenchmark.kt
@@ -17,7 +17,7 @@ import java.util.function.BiFunction
 /**
  * Contrary to Java 8 which has about 43 different specialized function interfaces
  * to avoid boxing and unboxing as much as possible, the Function objects compiled by Kotlin
- * only implement fully generic interfaces, effectively using the Object type for any input or output value.
+ * only implement fully generic interfaces, effectively using the object type for any input or output value.
  *
  * This benchmark proves, that it makes no performance difference?
  */

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/SchemaBuilder.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/SchemaBuilder.kt
@@ -179,6 +179,10 @@ class SchemaBuilder {
             }
         }
 
+        if (enumValues.isEmpty()) {
+            throw SchemaException("Enum '${type.name}' must have at least one value")
+        }
+
         val kqlEnumValues = enumValues.map { value ->
             type.valueDefinitions[value]?.let { valueDSL ->
                 EnumValueDef(
@@ -194,12 +198,7 @@ class SchemaBuilder {
     }
 
     inline fun <reified T : Enum<T>> enum(noinline block: (EnumDSL<T>.() -> Unit)? = null) {
-        val enumValues = enumValues<T>()
-        if (enumValues.isEmpty()) {
-            throw SchemaException("Enum of type ${T::class} must have at least one value")
-        } else {
-            enum(T::class, enumValues<T>(), block)
-        }
+        enum(T::class, enumValues<T>(), block)
     }
 
     //================================================================================
@@ -213,7 +212,9 @@ class SchemaBuilder {
     }
 
     inline fun <reified T : Any> unionType(noinline block: UnionTypeDSL.() -> Unit = {}): TypeID {
-        if (!T::class.isSealed) throw SchemaException("Can't generate a union type out of a non sealed class. '${T::class.simpleName}'")
+        if (!T::class.isSealed) {
+            throw SchemaException("Can't generate a union type out of a non-sealed class '${T::class.simpleName}'")
+        }
 
         return unionType(T::class.simpleName!!) {
             block()

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/ArgumentTransformer.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/ArgumentTransformer.kt
@@ -32,7 +32,7 @@ open class ArgumentTransformer {
 
         if (unsupportedArguments?.isNotEmpty() == true) {
             throw InvalidInputValueException(
-                "$funName does support arguments ${inputValues.map { it.name }}. Found arguments ${args.keys}",
+                "'$funName' does support arguments: ${inputValues.map { it.name }}. Found arguments: ${args.keys}",
                 executionNode.selectionNode
             )
         }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/MutableSchemaDefinition.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/MutableSchemaDefinition.kt
@@ -89,17 +89,16 @@ open class MutableSchemaDefinition {
     ) {
         if (scalars.any { it.kClass == member } || enums.any { it.kClass == member }) {
             throw SchemaException(
-                "The member types of a Union type must all be Object base types; " +
-                    "Scalar, Interface and Union types may not be member types of a Union"
+                "The member types of a union type must all be object base types; scalar, interface and union types may not be member types of a union"
             )
         }
 
         if (member.isSubclassOf(Collection::class)) {
-            throw SchemaException("Collection may not be member type of a Union '${union.name}'")
+            throw SchemaException("Collection may not be member type of a union '${union.name}'")
         }
 
         if (member.isSubclassOf(Map::class)) {
-            throw SchemaException("Map may not be member type of a Union '${union.name}'")
+            throw SchemaException("Map may not be member type of a union '${union.name}'")
         }
 
         if (compiledObjects.none { it.kClass == member }) {
@@ -109,39 +108,39 @@ open class MutableSchemaDefinition {
 
     fun addQuery(query: QueryDef<*>) {
         if (query.checkEqualName(queries)) {
-            throw SchemaException("Cannot add query with duplicated name ${query.name}")
+            throw SchemaException("Cannot add query with duplicated name '${query.name}'")
         }
         queries.add(query)
     }
 
     fun addMutation(mutation: MutationDef<*>) {
         if (mutation.checkEqualName(mutations)) {
-            throw SchemaException("Cannot add mutation with duplicated name ${mutation.name}")
+            throw SchemaException("Cannot add mutation with duplicated name '${mutation.name}'")
         }
         mutations.add(mutation)
     }
 
     fun addSubscription(subscription: SubscriptionDef<*>) {
         if (subscription.checkEqualName(subscriptions)) {
-            throw SchemaException("Cannot add subscription with duplicated name ${subscription.name}")
+            throw SchemaException("Cannot add subscription with duplicated name '${subscription.name}'")
         }
         subscriptions.add(subscription)
     }
 
-    fun addScalar(scalar: TypeDef.Scalar<*>) = addType(scalar, scalars, "Scalar")
+    fun addScalar(scalar: TypeDef.Scalar<*>) = addType(scalar, scalars, "scalar")
 
-    fun addEnum(enum: TypeDef.Enumeration<*>) = addType(enum, enums, "Enumeration")
+    fun addEnum(enum: TypeDef.Enumeration<*>) = addType(enum, enums, "enumeration")
 
-    fun addObject(objectType: TypeDef.Object<*>) = addType(objectType, objects, "Object")
+    fun addObject(objectType: TypeDef.Object<*>) = addType(objectType, objects, "object")
 
-    fun addUnion(union: TypeDef.Union) = addType(union, unions, "Union")
+    fun addUnion(union: TypeDef.Union) = addType(union, unions, "union")
 
-    fun addInputObject(input: TypeDef.Input<*>) = addType(input, inputObjects, "Input")
+    fun addInputObject(input: TypeDef.Input<*>) = addType(input, inputObjects, "input")
 
     private fun <T : Definition> addType(type: T, target: ArrayList<T>, typeCategory: String) {
         validateName(type.name)
         if (type.checkEqualName(objects, inputObjects, scalars, unions, enums)) {
-            throw SchemaException("Cannot add $typeCategory type with duplicated name ${type.name}")
+            throw SchemaException("Cannot add $typeCategory type with duplicated name '${type.name}'")
         }
         target.add(type)
     }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/RequestInterpreter.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/RequestInterpreter.kt
@@ -78,7 +78,7 @@ class RequestInterpreter(private val schemaModel: SchemaModel) {
             val name = fragmentDef.name!!.value
 
             if (fragmentDefinitionNodes.count { it.name!!.value == name } > 1) {
-                throw ValidationException("There can be only one fragment named $name.", fragmentDef)
+                throw ValidationException("There can be only one fragment named '$name'", fragmentDef)
             }
 
             name to (type to fragmentDef.selectionSet)
@@ -109,7 +109,7 @@ class RequestInterpreter(private val schemaModel: SchemaModel) {
         }
     } else if (type.unwrapped().fields?.isNotEmpty() == true) {
         throw ValidationException(
-            "Missing selection set on property ${propertyName?.value} of type ${type.unwrapped().name}",
+            "Missing selection set on property '${propertyName?.value}' of type '${type.unwrapped().name}'",
             selectionSet
         )
     } else {
@@ -158,7 +158,7 @@ class RequestInterpreter(private val schemaModel: SchemaModel) {
     ): Execution.Node {
         return when (val field = this[node.name.value]) {
             null -> throw ValidationException(
-                "Property ${node.name.value} on $name does not exist",
+                "Property '${node.name.value}' on '$name' does not exist",
                 node
             )
 
@@ -272,7 +272,7 @@ class RequestInterpreter(private val schemaModel: SchemaModel) {
                 if (!mergedSelectionsForType.isNullOrEmpty()) {
                     handleReturnType(ctx, possibleType, SelectionSetNode(null, mergedSelectionsForType))
                 } else {
-                    throw ValidationException("Missing selection set for type ${possibleType.name}", selectionNode)
+                    throw ValidationException("Missing selection set for type '${possibleType.name}'", selectionNode)
                 }
             }
 
@@ -288,12 +288,12 @@ class RequestInterpreter(private val schemaModel: SchemaModel) {
 
     private fun unknownFragmentTypeException(fragment: FragmentNode) = when (fragment) {
         is FragmentSpreadNode -> ValidationException(
-            message = "Fragment ${fragment.name.value} not found",
+            message = "Fragment '${fragment.name.value}' not found",
             node = fragment
         )
 
         is InlineFragmentNode -> ValidationException(
-            message = "Unknown type ${fragment.typeCondition?.name?.value} in type condition on fragment",
+            message = "Unknown type '${fragment.typeCondition?.name?.value}' in type condition on fragment",
             node = fragment
         )
     }
@@ -302,7 +302,7 @@ class RequestInterpreter(private val schemaModel: SchemaModel) {
 
     private fun findDirective(invocation: DirectiveNode): Directive {
         return directivesByName[invocation.name.value.removePrefix("@")]
-            ?: throw ValidationException("Directive ${invocation.name.value} does not exist", invocation)
+            ?: throw ValidationException("Directive '${invocation.name.value}' does not exist", invocation)
     }
 
     private fun DocumentNode.getOperation(
@@ -315,7 +315,7 @@ class RequestInterpreter(private val schemaModel: SchemaModel) {
             else -> {
                 val operationNamesFound = operations.mapNotNull { it.name?.value }.also {
                     if (it.size != operations.size) {
-                        throw ValidationException("anonymous operation must be the only defined operation")
+                        throw ValidationException("Anonymous operation must be the only defined operation")
                     }
                 }.joinToString(prefix = "[", postfix = "]")
 
@@ -325,7 +325,7 @@ class RequestInterpreter(private val schemaModel: SchemaModel) {
                 )?.let { it as? ValueNode.StringValueNode }?.value
 
                 operations.firstOrNull { it.name?.value == operationName }
-                    ?: throw ValidationException("Must provide an operation name from: $operationNamesFound, found $operationName")
+                    ?: throw ValidationException("Must provide an operation name from: $operationNamesFound, found: $operationName")
             }
         }
     }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/Validation.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/Validation.kt
@@ -24,7 +24,7 @@ fun Field.validateArguments(selectionArgs: List<ArgumentNode>?, parentTypeName: 
     if (!(args.isNotEmpty() || selectionArgs?.isNotEmpty() != true)) {
         return listOf(
             ValidationException(
-                message = "Property $name on type $parentTypeName has no arguments, found: ${selectionArgs.map { it.name.value }}",
+                message = "Property '$name' on type '$parentTypeName' has no arguments, found: ${selectionArgs.map { it.name.value }}",
                 nodes = selectionArgs
             )
         )
@@ -38,7 +38,7 @@ fun Field.validateArguments(selectionArgs: List<ArgumentNode>?, parentTypeName: 
     if (!invalidArguments.isNullOrEmpty()) {
         exceptions.add(
             ValidationException(
-                message = "$name does support arguments $parameterNames. Found arguments ${selectionArgs.map { it.name.value }}"
+                message = "'$name' does support arguments: $parameterNames, found: ${selectionArgs.map { it.name.value }}"
             )
         )
     }
@@ -91,7 +91,7 @@ fun validateName(name: String) {
 
 // function before generic, because it is its subset
 fun assertValidObjectType(kClass: KClass<*>) = when {
-    kClass.isSubclassOf(Function::class) -> throw SchemaException("Cannot handle function $kClass as Object type")
-    kClass.isSubclassOf(Enum::class) -> throw SchemaException("Cannot handle enum class $kClass as Object type")
+    kClass.isSubclassOf(Function::class) -> throw SchemaException("Cannot handle function class '${kClass.qualifiedName}' as object type")
+    kClass.isSubclassOf(Enum::class) -> throw SchemaException("Cannot handle enum class '${kClass.qualifiedName}' as object type")
     else -> Unit
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/InputObjectTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/InputObjectTest.kt
@@ -159,7 +159,7 @@ class InputObjectTest {
 
     @Test
     fun `property name must not start with __ when configured`() {
-        expect<SchemaException>("Illegal name '__name'. Names starting with '__' are reserved for introspection system") {
+        expect<SchemaException>("Unable to handle input type 'Person': Illegal name '__name'. Names starting with '__' are reserved for introspection system") {
             KGraphQL.schema {
                 inputType<Person> {
                     property(Person::name) {

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/MutationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/MutationTest.kt
@@ -39,7 +39,7 @@ class MutationTest : BaseSchemaTest() {
 
     @Test
     fun `invalid mutation name`() {
-        expect<ValidationException>("Property createBanana on Mutation does not exist") {
+        expect<ValidationException>("Property 'createBanana' on 'Mutation' does not exist") {
             execute("mutation {createBanana(name: \"${testActor.name}\", age: ${testActor.age}){age}}")
         }
     }
@@ -53,14 +53,14 @@ class MutationTest : BaseSchemaTest() {
 
     @Test
     fun `invalid arguments number`() {
-        expect<ValidationException>("createActor does support arguments [name, age]. Found arguments [name, age, bananan]") {
+        expect<ValidationException>("'createActor' does support arguments: [name, age], found: [name, age, bananan]") {
             execute("mutation {createActor(name: \"${testActor.name}\", age: ${testActor.age}, bananan: \"fwfwf\"){age}}")
         }
     }
 
     @Test
     fun `invalid arguments number with NotIntrospected class`() {
-        expect<ValidationException>("createActorWithContext does support arguments [name, age]. Found arguments [name, age, bananan]") {
+        expect<ValidationException>("'createActorWithContext' does support arguments: [name, age], found: [name, age, bananan]") {
             execute("mutation {createActorWithContext(name: \"${testActor.name}\", age: ${testActor.age}, bananan: \"fwfwf\"){age}}")
         }
     }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/ObjectTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/ObjectTest.kt
@@ -84,7 +84,7 @@ class ObjectTest {
 
     @Test
     fun `property name must not start with __ when configured`() {
-        expect<SchemaException>("Illegal name '__name'. Names starting with '__' are reserved for introspection system") {
+        expect<SchemaException>("Unable to handle object type 'Person': Illegal name '__name'. Names starting with '__' are reserved for introspection system") {
             KGraphQL.schema {
                 type<Person> {
                     property(Person::name) {

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/QueryTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/QueryTest.kt
@@ -60,7 +60,7 @@ class QueryTest : BaseSchemaTest() {
         val exception = shouldThrowExactly<ValidationException> {
             execute("{film{title, director{name, favDish}}}")
         }
-        exception shouldHaveMessage "Property favDish on Director does not exist"
+        exception shouldHaveMessage "Property 'favDish' on 'Director' does not exist"
         exception.extensions shouldBe mapOf(
             "type" to "GRAPHQL_VALIDATION_FAILED"
         )
@@ -107,7 +107,7 @@ class QueryTest : BaseSchemaTest() {
         val exception = shouldThrowExactly<ValidationException> {
             execute("{scenario{author, content}}")
         }
-        exception shouldHaveMessage "Property author on Scenario does not exist"
+        exception shouldHaveMessage "Property 'author' on 'Scenario' does not exist"
         exception.extensions shouldBe mapOf(
             "type" to "GRAPHQL_VALIDATION_FAILED"
         )
@@ -208,7 +208,7 @@ class QueryTest : BaseSchemaTest() {
         val exception = shouldThrowExactly<ValidationException> {
             execute("{scenario{id(uppercase: true), content}}")
         }
-        exception shouldHaveMessage "Property id on type Scenario has no arguments, found: [uppercase]"
+        exception shouldHaveMessage "Property 'id' on type 'Scenario' has no arguments, found: [uppercase]"
         exception.extensions shouldBe mapOf(
             "type" to "GRAPHQL_VALIDATION_FAILED"
         )
@@ -456,7 +456,7 @@ class QueryTest : BaseSchemaTest() {
                 """.trimIndent()
             )
         }
-        exception shouldHaveMessage "Unknown type MissingType in type condition on fragment"
+        exception shouldHaveMessage "Unknown type 'MissingType' in type condition on fragment"
         exception.extensions shouldBe mapOf(
             "type" to "GRAPHQL_VALIDATION_FAILED"
         )
@@ -475,7 +475,7 @@ class QueryTest : BaseSchemaTest() {
                 """.trimIndent()
             )
         }
-        exception shouldHaveMessage "Fragment film_title not found"
+        exception shouldHaveMessage "Fragment 'film_title' not found"
         exception.extensions shouldBe mapOf(
             "type" to "GRAPHQL_VALIDATION_FAILED"
         )
@@ -486,7 +486,7 @@ class QueryTest : BaseSchemaTest() {
         val exception = shouldThrowExactly<ValidationException> {
             execute("{film}")
         }
-        exception shouldHaveMessage "Missing selection set on property film of type Film"
+        exception shouldHaveMessage "Missing selection set on property 'film' of type 'Film'"
         exception.extensions shouldBe mapOf(
             "type" to "GRAPHQL_VALIDATION_FAILED"
         )

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaInheritanceTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaInheritanceTest.kt
@@ -31,11 +31,11 @@ class SchemaInheritanceTest {
             query("c") { resolver { -> C(name, age) } }
         }
 
-        expect<ValidationException>("Property id on B does not exist") {
+        expect<ValidationException>("Property 'id' on 'B' does not exist") {
             deserialize(schema.executeBlocking("{b{id, name, age}}"))
         }
 
-        expect<ValidationException>("Property id on C does not exist") {
+        expect<ValidationException>("Property 'id' on 'C' does not exist") {
             deserialize(schema.executeBlocking("{c{id, name, age}}"))
         }
     }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/introspection/DeprecationSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/introspection/DeprecationSpecificationTest.kt
@@ -161,7 +161,7 @@ class DeprecationSpecificationTest {
     fun `required input value may not be deprecated`() {
         data class InputType(val oldRequired: String, val new: String)
 
-        expect<SchemaException>("Required fields cannot be marked as deprecated") {
+        expect<SchemaException>("Unable to handle input type 'InputType': Required field 'oldRequired' cannot be marked as deprecated") {
             defaultSchema {
                 inputType<InputType> {
                     InputType::oldRequired.configure {
@@ -230,7 +230,7 @@ class DeprecationSpecificationTest {
     @Test
     fun `required field args may not be deprecated`() {
         @Suppress("UNUSED_ANONYMOUS_PARAMETER")
-        expect<SchemaException>("Required arguments cannot be marked as deprecated") {
+        expect<SchemaException>("Unable to handle 'query(\"data\")': Required argument 'oldRequired' cannot be marked as deprecated") {
             defaultSchema {
                 query("data") {
                     resolver { oldRequired: String, new: String -> "" }.withArgs {

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/introspection/IntrospectionSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/introspection/IntrospectionSpecificationTest.kt
@@ -80,7 +80,7 @@ class IntrospectionSpecificationTest {
             }
         }
 
-        expect<ValidationException>("Property __typename on String does not exist") {
+        expect<ValidationException>("Property '__typename' on 'String' does not exist") {
             schema.executeBlocking("{sample{string{__typename}}}")
         }
     }
@@ -99,7 +99,7 @@ class IntrospectionSpecificationTest {
             }
         }
 
-        expect<ValidationException>("Property __typename on SampleEnum does not exist") {
+        expect<ValidationException>("Property '__typename' on 'SampleEnum' does not exist") {
             schema.executeBlocking("{sample{enum{__typename}}}")
         }
     }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/FragmentsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/FragmentsSpecificationTest.kt
@@ -165,7 +165,7 @@ class FragmentsSpecificationTest {
 
     @Test
     fun `queries with duplicated fragments are denied`() {
-        expect<ValidationException>("There can be only one fragment named film_title.") {
+        expect<ValidationException>("There can be only one fragment named 'film_title'") {
             baseTestSchema.execute(
                 """
             {
@@ -349,7 +349,7 @@ class FragmentsSpecificationTest {
     // https://github.com/aPureBase/KGraphQL/issues/189
     @Test
     fun `queries with missing fragments should return proper error message`() {
-        expect<ValidationException>("Fragment film_title_misspelled not found") {
+        expect<ValidationException>("Fragment 'film_title_misspelled' not found") {
             baseTestSchema.execute(
                 """
             {

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/QueryDocumentSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/QueryDocumentSpecificationTest.kt
@@ -26,14 +26,14 @@ class QueryDocumentSpecificationTest {
 
     @Test
     fun `anonymous operation must be the only defined operation`() {
-        expect<ValidationException>("anonymous operation must be the only defined operation") {
+        expect<ValidationException>("Anonymous operation must be the only defined operation") {
             deserialize(schema.executeBlocking("query {fizz} mutation BUZZ {createActor(name : \"Kurt Russel\"){name}}"))
         }
     }
 
     @Test
     fun `must provide operation name when multiple named operations`() {
-        expect<ValidationException>("Must provide an operation name from: [FIZZ, BUZZ], found null") {
+        expect<ValidationException>("Must provide an operation name from: [FIZZ, BUZZ], found: null") {
             deserialize(schema.executeBlocking("query FIZZ {fizz} mutation BUZZ {createActor(name : \"Kurt Russel\"){name}}"))
         }
     }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/SourceTextSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/SourceTextSpecificationTest.kt
@@ -97,11 +97,11 @@ class SourceTextSpecificationTest {
     @Test
     @Specification("2.1.9 Names")
     fun `names should be case sensitive`() {
-        expect<ValidationException>("Property FIZZ on Query does not exist") {
+        expect<ValidationException>("Property 'FIZZ' on 'Query' does not exist") {
             deserialize(schema.executeBlocking("{FIZZ}"))
         }
 
-        expect<ValidationException>("Property Fizz on Query does not exist") {
+        expect<ValidationException>("Property 'Fizz' on 'Query' does not exist") {
             deserialize(schema.executeBlocking("{Fizz}"))
         }
 

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/DirectivesSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/DirectivesSpecificationTest.kt
@@ -1,6 +1,8 @@
 package com.apurebase.kgraphql.specification.typesystem
 
 import com.apurebase.kgraphql.Specification
+import com.apurebase.kgraphql.ValidationException
+import com.apurebase.kgraphql.expect
 import com.apurebase.kgraphql.extract
 import com.apurebase.kgraphql.integration.BaseSchemaTest
 import io.kotest.matchers.shouldBe
@@ -76,5 +78,12 @@ class DirectivesSpecificationTest : BaseSchemaTest() {
             "{\"include\":\"false\"}"
         )
         assertThrows<IllegalArgumentException> { map.extract("data/film/year") }
+    }
+
+    @Test
+    fun `missing directive should result in an error`() {
+        expect<ValidationException>("Directive 'nonExisting' does not exist") {
+            execute("{film{title year @nonExisting}}")
+        }
     }
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/EnumsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/EnumsSpecificationTest.kt
@@ -6,6 +6,7 @@ import com.apurebase.kgraphql.Specification
 import com.apurebase.kgraphql.deserialize
 import com.apurebase.kgraphql.expect
 import com.apurebase.kgraphql.extract
+import com.apurebase.kgraphql.schema.SchemaException
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 
@@ -42,4 +43,49 @@ class EnumsSpecificationTest {
         response.extract<String>("data/cool") shouldBe "COOL"
     }
 
+    enum class Empty
+
+    @Test
+    fun `enums must have at least one value`() {
+        expect<SchemaException>("Enum 'Empty' must have at least one value") {
+            KGraphQL.schema {
+                enum<Empty>()
+                query("test") {
+                    resolver { -> "test" }
+                }
+            }
+        }
+
+        expect<SchemaException>("Enum 'EmptyCoolness' must have at least one value") {
+            KGraphQL.schema {
+                enum(Coolness::class, emptyArray()) {
+                    name = "EmptyCoolness"
+                }
+                query("test") {
+                    resolver { -> "test" }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `enums should allow to limit their values`() {
+        val schema = KGraphQL.schema {
+            enum(Coolness::class, arrayOf(Coolness.TOTALLY_COOL))
+            query("test") {
+                resolver { -> "test" }
+            }
+        }
+
+        schema.printSchema() shouldBe """
+            type Query {
+              test: String!
+            }
+            
+            enum Coolness {
+              TOTALLY_COOL
+            }
+            
+        """.trimIndent()
+    }
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/InputObjectsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/InputObjectsSpecificationTest.kt
@@ -152,7 +152,7 @@ class InputObjectsSpecificationTest {
             val hello: String = "world"
         }
 
-        expect<SchemaException>("An input type must define one or more fields. Found none on type ClassWithEmptyConstructorInput") {
+        expect<SchemaException>("Unable to handle 'query(\"test\")': An input type must define one or more fields. Found none on type 'ClassWithEmptyConstructorInput'") {
             KGraphQL.schema {
                 query("test") {
                     resolver { input: ClassWithEmptyConstructor -> input }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/InterfacesSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/InterfacesSpecificationTest.kt
@@ -30,7 +30,7 @@ class InterfacesSpecificationTest {
 
     @Test
     fun `When querying for fields on an interface type, only those fields declared on the interface may be queried`() {
-        expect<ValidationException>("Property stuff on SimpleInterface does not exist") {
+        expect<ValidationException>("Property 'stuff' on 'SimpleInterface' does not exist") {
             schema.executeBlocking("{simple{exe, stuff}}")
         }
     }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/ScalarsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/ScalarsSpecificationTest.kt
@@ -36,20 +36,23 @@ class ScalarsSpecificationTest {
             query("boolean") {
                 resolver<Boolean> { true }
             }
-            // TODO: ID, cf. https://github.com/stuebingerb/KGraphQL/issues/83
+            query("id") {
+                resolver<ID> { ID("bar") }
+            }
         }
 
-        val response = deserialize(schema.executeBlocking("{ int float double string boolean }"))
+        val response = deserialize(schema.executeBlocking("{ int float double string boolean id }"))
         response.extract<Int>("data/int") shouldBe 1
         response.extract<Float>("data/float") shouldBe 2.0
         response.extract<Double>("data/double") shouldBe 3.0
         response.extract<String>("data/string") shouldBe "foo"
         response.extract<Boolean>("data/boolean") shouldBe true
+        response.extract<ID>("data/id") shouldBe "bar"
     }
 
     @Test
     fun `extended scalars should not be available by default`() {
-        expect<SchemaException>("An object type must define one or more fields. Found none on type Long") {
+        expect<SchemaException>("Unable to handle 'query(\"long\")': An object type must define one or more fields. Found none on type 'Long'") {
             KGraphQL.schema {
                 query("long") {
                     resolver<Long> { 1L }
@@ -57,7 +60,7 @@ class ScalarsSpecificationTest {
             }
         }
 
-        expect<SchemaException>("An object type must define one or more fields. Found none on type Short") {
+        expect<SchemaException>("Unable to handle 'query(\"short\")': An object type must define one or more fields. Found none on type 'Short'") {
             KGraphQL.schema {
                 query("short") {
                     resolver<Short> { 2.toShort() }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/TypeSystemSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/TypeSystemSpecificationTest.kt
@@ -131,7 +131,7 @@ class TypeSystemSpecificationTest {
 
     @Test
     fun `all types within a GraphQL schema must have unique names`() {
-        expect<SchemaException>("Cannot add Object type with duplicated name String") {
+        expect<SchemaException>("Cannot add object type with duplicated name 'String'") {
             schema {
                 type<String>()
                 query("getString") {
@@ -139,21 +139,51 @@ class TypeSystemSpecificationTest {
                 }
             }
         }
-        expect<SchemaException>("Cannot add Object type with duplicated name String") {
+        expect<SchemaException>("Unable to handle 'query(\"getString\")': Cannot add object type with duplicated name 'Type'") {
+            schema {
+                type<InputType> {
+                    name = "Type"
+                }
+                query("getString") {
+                    resolver { -> Type("string") }
+                }
+            }
+        }
+        expect<SchemaException>("Unable to handle 'query(\"getString\")': Cannot add object type with duplicated name 'Type'") {
+            schema {
+                inputType<InputType> {
+                    name = "Type"
+                }
+                query("getString") {
+                    resolver { -> Type("string") }
+                }
+            }
+        }
+        expect<SchemaException>("Cannot add object type with duplicated name 'String'") {
             schema {
                 type<Type> {
                     name = "String"
                 }
             }
         }
-        expect<SchemaException>("Cannot add Input type with duplicated name String") {
+        expect<SchemaException>("Cannot add input type with duplicated name 'String'") {
             schema {
                 inputType<Type> {
                     name = "String"
                 }
             }
         }
-        expect<SchemaException>("Cannot add Object type with duplicated name Type") {
+        expect<SchemaException>("Unable to handle 'query(\"getString\")': Cannot add input type with duplicated name 'InputTypeInput'") {
+            schema {
+                type<Type> {
+                    name = "InputTypeInput"
+                }
+                query("getString") {
+                    resolver { input: InputType -> input.name }
+                }
+            }
+        }
+        expect<SchemaException>("Cannot add object type with duplicated name 'Type'") {
             schema {
                 inputType<Type>()
                 type<Type>()
@@ -162,7 +192,7 @@ class TypeSystemSpecificationTest {
                 }
             }
         }
-        expect<SchemaException>("Cannot add Object type with duplicated name Type") {
+        expect<SchemaException>("Unable to handle 'query(\"getString\")': Cannot add object type with duplicated name 'Type'") {
             schema {
                 type<__Type> {
                     name = "Type"
@@ -172,7 +202,7 @@ class TypeSystemSpecificationTest {
                 }
             }
         }
-        expect<SchemaException>("Cannot add Input type with duplicated name Type") {
+        expect<SchemaException>("Cannot add input type with duplicated name 'Type'") {
             schema {
                 type<Type>()
                 inputType<Type>()
@@ -181,7 +211,7 @@ class TypeSystemSpecificationTest {
                 }
             }
         }
-        expect<SchemaException>("Cannot add Input type with duplicated name Type") {
+        expect<SchemaException>("Cannot add input type with duplicated name 'Type'") {
             schema {
                 type<Type>()
                 inputType<TypeInput> {
@@ -189,7 +219,7 @@ class TypeSystemSpecificationTest {
                 }
             }
         }
-        expect<SchemaException>("Cannot add Input type with duplicated name TypeInput") {
+        expect<SchemaException>("Cannot add input type with duplicated name 'TypeInput'") {
             schema {
                 type<Type> {
                     name = "TypeInput"
@@ -197,7 +227,7 @@ class TypeSystemSpecificationTest {
                 inputType<TypeInput>()
             }
         }
-        expect<SchemaException>("Cannot add Input type with duplicated name TypeInput") {
+        expect<SchemaException>("Unable to handle 'query(\"test\")': Cannot add input type with duplicated name 'TypeInput'") {
             schema {
                 type<Type> {
                     name = "TypeInput"
@@ -207,10 +237,58 @@ class TypeSystemSpecificationTest {
                 }
             }
         }
-        expect<SchemaException>("Cannot add Input type with duplicated name TypeInput") {
+        expect<SchemaException>("Unable to handle 'query(\"test\")': Cannot add input type with duplicated name 'TypeInput'") {
             schema {
                 query("test") {
                     resolver { input: TypeInput -> input }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `all queries within a GraphQL schema must have unique names`() {
+        expect<SchemaException>("Cannot add query with duplicated name 'test'") {
+            schema {
+                query("test") {
+                    resolver { -> "test1" }
+                }
+                query("test") {
+                    resolver { -> "test2" }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `all mutations within a GraphQL schema must have unique names`() {
+        expect<SchemaException>("Cannot add mutation with duplicated name 'test'") {
+            schema {
+                query("dummy") {
+                    resolver { -> "dummy"}
+                }
+                mutation("test") {
+                    resolver { -> "test1" }
+                }
+                mutation("test") {
+                    resolver { -> "test2" }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `all subscriptions within a GraphQL schema must have unique names`() {
+        expect<SchemaException>("Cannot add subscription with duplicated name 'test'") {
+            schema {
+                query("dummy") {
+                    resolver { -> "dummy"}
+                }
+                subscription("test") {
+                    resolver { -> "test1" }
+                }
+                subscription("test") {
+                    resolver { -> "test2" }
                 }
             }
         }
@@ -242,14 +320,14 @@ class TypeSystemSpecificationTest {
                 }
             }
         }
-        expect<SchemaException>("Illegal name '__Type'. Names starting with '__' are reserved for introspection system") {
+        expect<SchemaException>("Unable to handle 'query(\"testQuery\")': Illegal name '__Type'. Names starting with '__' are reserved for introspection system") {
             schema {
                 query("testQuery") {
                     resolver { -> __Type("name") }
                 }
             }
         }
-        expect<SchemaException>("Illegal name '__TypeInput'. Names starting with '__' are reserved for introspection system") {
+        expect<SchemaException>("Unable to handle 'mutation(\"testMutation\")': Illegal name '__TypeInput'. Names starting with '__' are reserved for introspection system") {
             schema {
                 query("testQuery") {
                     resolver { -> Type("name") }


### PR DESCRIPTION
Enhances existing error messages by:

- adding more details for some errors:
  ```
  Old: "Required arguments cannot be marked as deprecated"
  New: "Required argument 'oldRequired' cannot be marked as deprecated"
  ```
  ```
  Old: "Invalid input values on data: [intss]"
  New: "Invalid input values: [intss], available: [int, string]"
  ```
- aligning wording of similar errors to reduce potential for confusion
- encapsulating dynamic values in single quotes `'` to improve clarity:
  ```
  Old: "Property __typename on String does not exist"
  New: "Property '__typename' on 'String' does not exist"
  ```
- wrapping errors to prefix their current entry point:
  ```
  Old: "Context type cannot be part of schema"
  New: "Unable to handle 'query("name")': Context type cannot be part of schema"
  ```

Resolves #434