### PR TITLE
feat: provide proper node path

### DIFF
--- a/docs/content/assets/hljs/styles/lightfair.css
+++ b/docs/content/assets/hljs/styles/lightfair.css
@@ -8,7 +8,6 @@ Lightfair style (c) Tristian Kelly <tristian.kelly560@gmail.com>
     display: block;
     overflow-x: auto;
     padding: 0.5em;
-    /* TODO: background? */
 }
 
 .hljs-name {

--- a/kgraphql-ktor-stitched/src/main/kotlin/com/apurebase/kgraphql/stitched/schema/execution/RemoteArgumentTransformer.kt
+++ b/kgraphql-ktor-stitched/src/main/kotlin/com/apurebase/kgraphql/stitched/schema/execution/RemoteArgumentTransformer.kt
@@ -54,15 +54,14 @@ class RemoteArgumentTransformer : ArgumentTransformer() {
                     selectionNode = executionNode.selectionNode,
                     field = executionNode.field,
                     children = executionNode.children,
-                    key = executionNode.key,
-                    alias = executionNode.alias,
                     arguments = mappedArgumentNodes,
                     directives = executionNode.directives,
                     variables = executionNode.variables,
                     namedFragments = executionNode.namedFragments,
                     remoteUrl = executionNode.remoteUrl,
                     remoteOperation = executionNode.remoteOperation,
-                    operationType = executionNode.operationType
+                    operationType = executionNode.operationType,
+                    parent = executionNode.parent
                 )
 
                 else -> null

--- a/kgraphql/api/kgraphql.api
+++ b/kgraphql/api/kgraphql.api
@@ -755,44 +755,57 @@ public class com/apurebase/kgraphql/schema/execution/DefaultGenericTypeResolver 
 
 public abstract class com/apurebase/kgraphql/schema/execution/Execution {
 	public abstract fun getDirectives ()Ljava/util/Map;
+	public abstract fun getFullPath ()Ljava/util/List;
+	public abstract fun getParent ()Lcom/apurebase/kgraphql/schema/execution/Execution;
 	public abstract fun getSelectionNode ()Lcom/apurebase/kgraphql/schema/model/ast/SelectionNode;
 }
 
 public final class com/apurebase/kgraphql/schema/execution/Execution$Fragment : com/apurebase/kgraphql/schema/execution/Execution {
-	public fun <init> (Lcom/apurebase/kgraphql/schema/model/ast/SelectionNode;Lcom/apurebase/kgraphql/schema/execution/TypeCondition;Ljava/util/List;Ljava/util/Map;)V
+	public fun <init> (Lcom/apurebase/kgraphql/schema/model/ast/SelectionNode$FragmentNode;Lcom/apurebase/kgraphql/schema/execution/TypeCondition;Ljava/util/List;Ljava/util/Map;Lcom/apurebase/kgraphql/schema/execution/Execution;)V
 	public final fun getCondition ()Lcom/apurebase/kgraphql/schema/execution/TypeCondition;
 	public fun getDirectives ()Ljava/util/Map;
 	public final fun getElements ()Ljava/util/List;
-	public fun getSelectionNode ()Lcom/apurebase/kgraphql/schema/model/ast/SelectionNode;
+	public fun getFullPath ()Ljava/util/List;
+	public fun getParent ()Lcom/apurebase/kgraphql/schema/execution/Execution;
+	public fun getSelectionNode ()Lcom/apurebase/kgraphql/schema/model/ast/SelectionNode$FragmentNode;
+	public synthetic fun getSelectionNode ()Lcom/apurebase/kgraphql/schema/model/ast/SelectionNode;
+	public synthetic fun withParent$kgraphql (Lcom/apurebase/kgraphql/schema/execution/Execution;)Lcom/apurebase/kgraphql/schema/execution/Execution;
 }
 
 public class com/apurebase/kgraphql/schema/execution/Execution$Node : com/apurebase/kgraphql/schema/execution/Execution {
-	public fun <init> (Lcom/apurebase/kgraphql/schema/model/ast/SelectionNode;Lcom/apurebase/kgraphql/schema/structure/Field;Ljava/util/Collection;Ljava/lang/String;Ljava/lang/String;Lcom/apurebase/kgraphql/schema/model/ast/ArgumentNodes;Ljava/util/Map;Ljava/util/List;)V
-	public synthetic fun <init> (Lcom/apurebase/kgraphql/schema/model/ast/SelectionNode;Lcom/apurebase/kgraphql/schema/structure/Field;Ljava/util/Collection;Ljava/lang/String;Ljava/lang/String;Lcom/apurebase/kgraphql/schema/model/ast/ArgumentNodes;Ljava/util/Map;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getAlias ()Ljava/lang/String;
+	public fun <init> (Lcom/apurebase/kgraphql/schema/model/ast/SelectionNode$FieldNode;Lcom/apurebase/kgraphql/schema/structure/Field;Ljava/util/Collection;Lcom/apurebase/kgraphql/schema/model/ast/ArgumentNodes;Ljava/util/Map;Ljava/util/List;Ljava/lang/Integer;Lcom/apurebase/kgraphql/schema/execution/Execution;)V
 	public final fun getAliasOrKey ()Ljava/lang/String;
 	public final fun getArguments ()Lcom/apurebase/kgraphql/schema/model/ast/ArgumentNodes;
+	public final fun getArrayIndex ()Ljava/lang/Integer;
 	public final fun getChildren ()Ljava/util/Collection;
 	public fun getDirectives ()Ljava/util/Map;
 	public final fun getField ()Lcom/apurebase/kgraphql/schema/structure/Field;
+	public fun getFullPath ()Ljava/util/List;
 	public final fun getKey ()Ljava/lang/String;
-	public fun getSelectionNode ()Lcom/apurebase/kgraphql/schema/model/ast/SelectionNode;
+	public fun getParent ()Lcom/apurebase/kgraphql/schema/execution/Execution;
+	public fun getSelectionNode ()Lcom/apurebase/kgraphql/schema/model/ast/SelectionNode$FieldNode;
+	public synthetic fun getSelectionNode ()Lcom/apurebase/kgraphql/schema/model/ast/SelectionNode;
 	public final fun getVariables ()Ljava/util/List;
+	public synthetic fun withParent$kgraphql (Lcom/apurebase/kgraphql/schema/execution/Execution;)Lcom/apurebase/kgraphql/schema/execution/Execution;
 }
 
 public final class com/apurebase/kgraphql/schema/execution/Execution$Remote : com/apurebase/kgraphql/schema/execution/Execution$Node {
-	public fun <init> (Lcom/apurebase/kgraphql/schema/model/ast/SelectionNode;Lcom/apurebase/kgraphql/schema/structure/Field;Ljava/util/Collection;Ljava/lang/String;Ljava/lang/String;Lcom/apurebase/kgraphql/schema/model/ast/ArgumentNodes;Ljava/util/Map;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Lcom/apurebase/kgraphql/schema/model/ast/OperationTypeNode;)V
+	public fun <init> (Lcom/apurebase/kgraphql/schema/model/ast/SelectionNode$FieldNode;Lcom/apurebase/kgraphql/schema/structure/Field;Ljava/util/Collection;Lcom/apurebase/kgraphql/schema/model/ast/ArgumentNodes;Ljava/util/Map;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Lcom/apurebase/kgraphql/schema/model/ast/OperationTypeNode;Lcom/apurebase/kgraphql/schema/execution/Execution;)V
 	public final fun getNamedFragments ()Ljava/util/List;
 	public final fun getOperationType ()Lcom/apurebase/kgraphql/schema/model/ast/OperationTypeNode;
 	public final fun getRemoteOperation ()Ljava/lang/String;
 	public final fun getRemoteUrl ()Ljava/lang/String;
+	public synthetic fun withParent$kgraphql (Lcom/apurebase/kgraphql/schema/execution/Execution;)Lcom/apurebase/kgraphql/schema/execution/Execution$Node;
+	public synthetic fun withParent$kgraphql (Lcom/apurebase/kgraphql/schema/execution/Execution;)Lcom/apurebase/kgraphql/schema/execution/Execution;
 }
 
 public final class com/apurebase/kgraphql/schema/execution/Execution$Union : com/apurebase/kgraphql/schema/execution/Execution$Node {
-	public fun <init> (Lcom/apurebase/kgraphql/schema/model/ast/SelectionNode;Lcom/apurebase/kgraphql/schema/structure/Field$Union;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public fun <init> (Lcom/apurebase/kgraphql/schema/model/ast/SelectionNode$FieldNode;Lcom/apurebase/kgraphql/schema/structure/Field$Union;Ljava/util/Map;Ljava/util/Map;Lcom/apurebase/kgraphql/schema/execution/Execution;)V
 	public final fun getMemberChildren ()Ljava/util/Map;
 	public final fun getUnionField ()Lcom/apurebase/kgraphql/schema/structure/Field$Union;
 	public final fun memberExecution (Lcom/apurebase/kgraphql/schema/structure/Type;)Lcom/apurebase/kgraphql/schema/execution/Execution$Node;
+	public synthetic fun withParent$kgraphql (Lcom/apurebase/kgraphql/schema/execution/Execution;)Lcom/apurebase/kgraphql/schema/execution/Execution$Node;
+	public synthetic fun withParent$kgraphql (Lcom/apurebase/kgraphql/schema/execution/Execution;)Lcom/apurebase/kgraphql/schema/execution/Execution;
 }
 
 public final class com/apurebase/kgraphql/schema/execution/ExecutionPlan : java/util/List, kotlin/jvm/internal/markers/KMappedMarker {
@@ -1718,7 +1731,6 @@ public final class com/apurebase/kgraphql/schema/model/ast/OperationTypeNode : j
 
 public abstract class com/apurebase/kgraphql/schema/model/ast/SelectionNode : com/apurebase/kgraphql/schema/model/ast/ASTNode {
 	public synthetic fun <init> (Lcom/apurebase/kgraphql/schema/model/ast/SelectionNode;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public abstract fun getFullPath ()Ljava/lang/String;
 	public final fun getParent ()Lcom/apurebase/kgraphql/schema/model/ast/SelectionNode;
 }
 
@@ -1728,7 +1740,6 @@ public final class com/apurebase/kgraphql/schema/model/ast/SelectionNode$FieldNo
 	public final fun getAliasOrName ()Lcom/apurebase/kgraphql/schema/model/ast/NameNode;
 	public final fun getArguments ()Ljava/util/List;
 	public final fun getDirectives ()Ljava/util/List;
-	public fun getFullPath ()Ljava/lang/String;
 	public fun getLoc ()Lcom/apurebase/kgraphql/schema/model/ast/Location;
 	public final fun getName ()Lcom/apurebase/kgraphql/schema/model/ast/NameNode;
 	public final fun getSelectionSet ()Lcom/apurebase/kgraphql/schema/model/ast/SelectionSetNode;
@@ -1737,7 +1748,6 @@ public final class com/apurebase/kgraphql/schema/model/ast/SelectionNode$FieldNo
 public abstract class com/apurebase/kgraphql/schema/model/ast/SelectionNode$FragmentNode : com/apurebase/kgraphql/schema/model/ast/SelectionNode {
 	public synthetic fun <init> (Lcom/apurebase/kgraphql/schema/model/ast/SelectionNode;Ljava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getDirectives ()Ljava/util/List;
-	public fun getFullPath ()Ljava/lang/String;
 }
 
 public final class com/apurebase/kgraphql/schema/model/ast/SelectionNode$FragmentNode$FragmentSpreadNode : com/apurebase/kgraphql/schema/model/ast/SelectionNode$FragmentNode {
@@ -1963,7 +1973,6 @@ public abstract interface class com/apurebase/kgraphql/schema/scalar/BooleanScal
 
 public final class com/apurebase/kgraphql/schema/scalar/CoercionKt {
 	public static final fun deserializeScalar (Lcom/apurebase/kgraphql/schema/structure/Type$Scalar;Lcom/apurebase/kgraphql/schema/model/ast/ValueNode;)Ljava/lang/Object;
-	public static final fun serializeScalar (Lcom/apurebase/kgraphql/schema/structure/Type$Scalar;Ljava/lang/Object;Lcom/apurebase/kgraphql/schema/execution/Execution;)Lkotlinx/serialization/json/JsonElement;
 	public static final fun serializeScalar (Lcom/fasterxml/jackson/databind/node/JsonNodeFactory;Lcom/apurebase/kgraphql/schema/structure/Type$Scalar;Ljava/lang/Object;Lcom/apurebase/kgraphql/schema/execution/Execution;)Lcom/fasterxml/jackson/databind/node/ValueNode;
 }
 

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/Execution.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/Execution.kt
@@ -12,70 +12,131 @@ import com.apurebase.kgraphql.schema.structure.Type
 sealed class Execution {
     abstract val selectionNode: SelectionNode
     abstract val directives: Map<Directive, ArgumentNodes?>?
+    abstract val parent: Execution?
+    abstract val fullPath: List<Any>
+
+    internal abstract fun withParent(parent: Execution): Execution
 
     @NotIntrospected
     open class Node(
-        override val selectionNode: SelectionNode,
+        override val selectionNode: SelectionNode.FieldNode,
         val field: Field,
         val children: Collection<Execution>,
-        val key: String,
-        val alias: String? = null,
-        val arguments: ArgumentNodes? = null,
-        override val directives: Map<Directive, ArgumentNodes?>? = null,
-        val variables: List<VariableDefinitionNode>? = null
+        val arguments: ArgumentNodes?,
+        override val directives: Map<Directive, ArgumentNodes?>?,
+        val variables: List<VariableDefinitionNode>?,
+        val arrayIndex: Int?,
+        override val parent: Execution?
     ) : Execution() {
-        val aliasOrKey = alias ?: key
+        val key = selectionNode.name.value
+        val aliasOrKey = selectionNode.aliasOrName.value
+
+        override val fullPath = parent?.fullPath.orEmpty() + aliasOrKey + listOfNotNull(arrayIndex)
+
+        internal fun withIndex(index: Int): Node = Node(
+            selectionNode,
+            field,
+            children,
+            arguments,
+            directives,
+            variables,
+            index,
+            parent
+        )
+
+        override fun withParent(parent: Execution): Node = Node(
+            selectionNode,
+            field,
+            children,
+            arguments,
+            directives,
+            variables,
+            arrayIndex,
+            parent
+        )
     }
 
     class Fragment(
-        override val selectionNode: SelectionNode,
+        override val selectionNode: SelectionNode.FragmentNode,
         val condition: TypeCondition,
         val elements: List<Execution>,
-        override val directives: Map<Directive, ArgumentNodes?>?
-    ) : Execution()
+        override val directives: Map<Directive, ArgumentNodes?>?,
+        override val parent: Execution?
+    ) : Execution() {
+        override val fullPath = parent?.fullPath.orEmpty()
+
+        override fun withParent(parent: Execution): Fragment = Fragment(
+            selectionNode,
+            condition,
+            elements,
+            directives,
+            parent
+        )
+    }
 
     class Union(
-        node: SelectionNode,
+        node: SelectionNode.FieldNode,
         val unionField: Field.Union<*>,
         val memberChildren: Map<Type, Collection<Execution>>,
-        key: String,
-        alias: String?,
-        directives: Map<Directive, ArgumentNodes?>?
+        directives: Map<Directive, ArgumentNodes?>?,
+        parent: Execution?
     ) : Node(
         selectionNode = node,
         field = unionField,
         children = emptyList(),
-        key = key,
-        alias = alias,
-        directives = directives
+        arguments = null,
+        directives = directives,
+        variables = null,
+        arrayIndex = null,
+        parent = parent
     ) {
-        fun memberExecution(type: Type): Node {
-            return Node(
-                selectionNode = selectionNode,
-                field = field,
-                children = requireNotNull(memberChildren[type]) {
-                    "Union ${unionField.name} has no member $type"
-                },
-                key = key,
-                alias = alias,
-                arguments = arguments,
-                directives = directives
-            )
-        }
+        fun memberExecution(type: Type): Node = Node(
+            selectionNode = selectionNode,
+            field = field,
+            children = requireNotNull(memberChildren[type]) {
+                "Union ${unionField.name} has no member $type"
+            },
+            arguments = arguments,
+            directives = directives,
+            variables = variables,
+            arrayIndex = arrayIndex,
+            parent = parent
+        )
+
+        override fun withParent(parent: Execution): Union = Union(
+            selectionNode,
+            unionField,
+            memberChildren,
+            directives,
+            parent
+        )
     }
 
     class Remote(
-        selectionNode: SelectionNode,
+        selectionNode: SelectionNode.FieldNode,
         field: Field,
         children: Collection<Execution>,
-        key: String,
-        alias: String?,
         arguments: ArgumentNodes?,
         directives: Map<Directive, ArgumentNodes?>?,
         variables: List<VariableDefinitionNode>?,
         val namedFragments: List<Fragment>?,
         val remoteUrl: String,
         val remoteOperation: String,
-        val operationType: OperationTypeNode
-    ) : Node(selectionNode, field, children, key, alias, arguments, directives, variables)
+        val operationType: OperationTypeNode,
+        parent: Execution?
+    ) : Node(selectionNode, field, children, arguments, directives, variables, null, parent) {
+        override fun withParent(parent: Execution): Remote = Remote(
+            selectionNode,
+            field,
+            children,
+            arguments,
+            directives,
+            variables,
+            namedFragments,
+            remoteUrl,
+            remoteOperation,
+            operationType,
+            parent
+        )
+    }
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/ast/SelectionNode.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/model/ast/SelectionNode.kt
@@ -3,9 +3,6 @@ package com.apurebase.kgraphql.schema.model.ast
 import com.apurebase.kgraphql.schema.model.ast.TypeNode.NamedTypeNode
 
 sealed class SelectionNode(val parent: SelectionNode?) : ASTNode() {
-
-    abstract val fullPath: String
-
     class FieldNode(
         parent: SelectionNode?,
         val alias: NameNode?,
@@ -25,14 +22,10 @@ sealed class SelectionNode(val parent: SelectionNode?) : ASTNode() {
             return this
         }
 
-        val aliasOrName get() = alias ?: name
-
-        override val fullPath get() = (parent?.fullPath?.let { "$it." } ?: "") + aliasOrName.value
+        val aliasOrName = alias ?: name
     }
 
     sealed class FragmentNode(parent: SelectionNode?, val directives: List<DirectiveNode>?) : SelectionNode(parent) {
-        override val fullPath get() = parent?.fullPath?.let { "$it." } ?: ""
-
         /**
          * ...FragmentName
          */

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/scalar/Coercion.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/scalar/Coercion.kt
@@ -16,8 +16,6 @@ import com.apurebase.kgraphql.schema.model.ast.ValueNode
 import com.apurebase.kgraphql.schema.model.ast.ValueNode.StringValueNode
 import com.apurebase.kgraphql.schema.structure.Type
 import com.fasterxml.jackson.databind.node.JsonNodeFactory
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonPrimitive
 
 private typealias JsonValueNode = com.fasterxml.jackson.databind.node.ValueNode
 
@@ -90,33 +88,3 @@ fun <T> serializeScalar(
 
     else -> throw ExecutionException("Unsupported coercion for scalar type ${scalar.name}", executionNode)
 }
-
-@Suppress("UNCHECKED_CAST")
-fun <T> serializeScalar(scalar: Type.Scalar<*>, value: T, executionNode: Execution): JsonElement =
-    when (scalar.coercion) {
-        is StringScalarCoercion<*> -> {
-            JsonPrimitive((scalar.coercion as StringScalarCoercion<T>).serialize(value))
-        }
-
-        is ShortScalarCoercion<*> -> {
-            JsonPrimitive((scalar.coercion as ShortScalarCoercion<T>).serialize(value))
-        }
-
-        is IntScalarCoercion<*> -> {
-            JsonPrimitive((scalar.coercion as IntScalarCoercion<T>).serialize(value))
-        }
-
-        is DoubleScalarCoercion<*> -> {
-            JsonPrimitive((scalar.coercion as DoubleScalarCoercion<T>).serialize(value))
-        }
-
-        is LongScalarCoercion<*> -> {
-            JsonPrimitive((scalar.coercion as LongScalarCoercion<T>).serialize(value))
-        }
-
-        is BooleanScalarCoercion<*> -> {
-            JsonPrimitive((scalar.coercion as BooleanScalarCoercion<T>).serialize(value))
-        }
-
-        else -> throw ExecutionException("Unsupported coercion for scalar type ${scalar.name}", executionNode)
-    }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/BaseSchemaTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/BaseSchemaTest.kt
@@ -83,7 +83,9 @@ abstract class BaseSchemaTest {
             description = "all actors"
             resolver { all: Boolean? ->
                 mutableListOf(bradPitt, morganFreeman, kevinSpacey, tomHardy, christianBale).also {
-                    if (all == true) it.add(rickyGervais)
+                    if (all == true) {
+                        it.add(rickyGervais)
+                    }
                 }
             }
         }


### PR DESCRIPTION
`Execution` nodes now know about their current path in the response.

This also cleans up some unused/unnecessary code and narrows down a few types to be more specific. Integration with `GraphQLError` will come in a follow-up PR.