### PR TITLE
fix: enhance support for remote schemas

### DIFF
--- a/kgraphql-ktor-stitched/src/main/kotlin/com/apurebase/kgraphql/stitched/schema/structure/StitchedSchemaCompilation.kt
+++ b/kgraphql-ktor-stitched/src/main/kotlin/com/apurebase/kgraphql/stitched/schema/structure/StitchedSchemaCompilation.kt
@@ -92,7 +92,15 @@ class StitchedSchemaCompilation(
             subscription = subscriptionType,
             queryTypes = queryTypeProxies + enums + scalars,
             inputTypes = inputTypeProxies + enums + scalars,
-            allTypes = typesByName.values.toList(),
+            // Query, mutation, and subscription type are added for introspection (only) in SchemaModel; filter them
+            // out here to prevent duplicates when remote schemas have references to any
+            allTypes = typesByName.values.filter {
+                it.name !in setOfNotNull(
+                    queryType.name,
+                    mutationType?.name,
+                    subscriptionType?.name
+                )
+            },
             directives = definition.directives.map { handlePartialDirective(it) },
             // TODO: we shouldn't need to do a full recompilation again
             remoteTypesBySchema = definition.remoteSchemas.mapValues {

--- a/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/structure/IntrospectedSchemaTest.kt
+++ b/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/structure/IntrospectedSchemaTest.kt
@@ -3,6 +3,7 @@ package com.apurebase.kgraphql.stitched.schema.structure
 import com.apurebase.kgraphql.KGraphQL
 import com.apurebase.kgraphql.request.Introspection
 import com.apurebase.kgraphql.schema.SchemaPrinter
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 
@@ -36,5 +37,40 @@ class IntrospectedSchemaTest {
         )
 
         SchemaPrinter().print(schemaFromIntrospection) shouldBe SchemaPrinter().print(schema)
+    }
+
+    @Test
+    fun `introspection of remote schema should not fail when there are additional entries`() {
+        // A minimal introspection response with an extensions node (supported by the spec), and another (unsupported
+        // by the spec) one. Both must not make schema introspection fail.
+        val introspectionResponse = """
+            {
+                "data": {
+                    "__schema": {
+                        "queryType": {
+                            "name": "Query"
+                        },
+                        "mutationType": null,
+                        "subscriptionType": null,
+                        "types": [],
+                        "directives": []
+                    }
+                },
+                "extensions": {
+                    "cost": {
+                        "requestedQueryCost": 1,
+                        "actualQueryCost": 1
+                    }
+                },
+                "unsupported_extensions": {
+                    "version": "1.0.0"
+                }
+            }
+        """.trimIndent()
+
+        // The introspected schema won't be very useful but at least it must not throw any exception
+        shouldNotThrowAny {
+            IntrospectedSchema.fromIntrospectionResponse(response = introspectionResponse)
+        }
     }
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/SchemaModel.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/SchemaModel.kt
@@ -29,7 +29,7 @@ data class SchemaModel(
     private fun toTypeList(): List<Type> {
         val list = allTypes
             // workaround on the fact that Double and Float are treated as GraphQL Float
-            .filterNot { it is Type.Scalar<*> && it.kClass == Float::class }
+            .filterNot { it is Type.Scalar<*> && it.kClass == Double::class }
             .filterNot { it.kClass?.findAnnotation<NotIntrospected>() != null }
             // query must be present in introspection 'types' field for introspection tools
             .plus(query)
@@ -40,7 +40,7 @@ data class SchemaModel(
         if (subscription != null) {
             list += subscription
         }
-        return list.toList()
+        return list.sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.name.toString() })
     }
 
     override val queryType: Type = query

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/introspection/IntrospectionSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/introspection/IntrospectionSpecificationTest.kt
@@ -10,6 +10,7 @@ import com.apurebase.kgraphql.request.Introspection
 import com.apurebase.kgraphql.schema.introspection.TypeKind
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldBeSortedBy
 import io.kotest.matchers.collections.shouldBeUnique
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
@@ -348,6 +349,20 @@ class IntrospectionSpecificationTest {
 
         val typenames = types.map { type -> type["name"] as String }
         typenames.shouldBeUnique()
+    }
+
+    @Test
+    fun `introspection types should be sorted alphabetically ignoring case`() {
+        val schema = defaultSchema {
+            query("interface") {
+                resolver { -> Face("~~MOCK~~") }
+            }
+        }
+
+        val map = deserialize(schema.executeBlocking(Introspection.query()))
+        val types = map.extract<List<Map<Any, *>>>("data/__schema/types")
+
+        types shouldBeSortedBy { type -> (type["name"] as String).lowercase() }
     }
 
     @Test


### PR DESCRIPTION
- remote schema introspection no longer breaks when the response has extensions
- remote root types are correctly picked up when they have non-default names
- remote schemas using the `Float` type now work
- feat: introspected types are now sorted as well

Resolves #461