### PR TITLE
feat: support generic input types

### DIFF
--- a/kgraphql-ktor-stitched/api/kgraphql-ktor-stitched.api
+++ b/kgraphql-ktor-stitched/api/kgraphql-ktor-stitched.api
@@ -132,7 +132,7 @@ public abstract class com/apurebase/kgraphql/stitched/schema/execution/AbstractR
 }
 
 public final class com/apurebase/kgraphql/stitched/schema/execution/RemoteArgumentTransformer : com/apurebase/kgraphql/schema/execution/ArgumentTransformer {
-	public fun <init> ()V
+	public fun <init> (Lcom/apurebase/kgraphql/schema/execution/GenericTypeResolver;)V
 	public fun transformArguments (Ljava/lang/String;Ljava/lang/Object;Ljava/util/List;Lcom/apurebase/kgraphql/schema/model/ast/ArgumentNodes;Lcom/apurebase/kgraphql/request/Variables;Lcom/apurebase/kgraphql/schema/execution/Execution;Lcom/apurebase/kgraphql/Context;Lcom/apurebase/kgraphql/schema/model/FunctionWrapper;)Ljava/util/List;
 }
 

--- a/kgraphql-ktor-stitched/src/main/kotlin/com/apurebase/kgraphql/stitched/schema/dsl/StitchedSchemaConfigurationDSL.kt
+++ b/kgraphql-ktor-stitched/src/main/kotlin/com/apurebase/kgraphql/stitched/schema/dsl/StitchedSchemaConfigurationDSL.kt
@@ -26,7 +26,7 @@ open class StitchedSchemaConfigurationDSL : SchemaConfigurationDSL() {
             wrapErrors = wrapErrors,
             introspection = introspection,
             genericTypeResolver = genericTypeResolver,
-            argumentTransformer = RemoteArgumentTransformer(),
+            argumentTransformer = RemoteArgumentTransformer(genericTypeResolver),
             remoteExecutor = requireNotNull(remoteExecutor) { "Remote executor not defined" },
             localUrl = localUrl
         )

--- a/kgraphql-ktor-stitched/src/main/kotlin/com/apurebase/kgraphql/stitched/schema/execution/RemoteArgumentTransformer.kt
+++ b/kgraphql-ktor-stitched/src/main/kotlin/com/apurebase/kgraphql/stitched/schema/execution/RemoteArgumentTransformer.kt
@@ -5,6 +5,7 @@ import com.apurebase.kgraphql.helpers.toValueNode
 import com.apurebase.kgraphql.request.Variables
 import com.apurebase.kgraphql.schema.execution.ArgumentTransformer
 import com.apurebase.kgraphql.schema.execution.Execution
+import com.apurebase.kgraphql.schema.execution.GenericTypeResolver
 import com.apurebase.kgraphql.schema.introspection.TypeKind
 import com.apurebase.kgraphql.schema.introspection.__InputValue
 import com.apurebase.kgraphql.schema.model.FunctionWrapper
@@ -16,7 +17,7 @@ import com.apurebase.kgraphql.schema.structure.Field
 import com.apurebase.kgraphql.schema.structure.InputValue
 import com.fasterxml.jackson.databind.node.ObjectNode
 
-class RemoteArgumentTransformer : ArgumentTransformer() {
+class RemoteArgumentTransformer(genericTypeResolver: GenericTypeResolver) : ArgumentTransformer(genericTypeResolver) {
     override fun transformArguments(
         funName: String,
         receiver: Any?,

--- a/kgraphql/api/kgraphql.api
+++ b/kgraphql/api/kgraphql.api
@@ -743,12 +743,14 @@ public final class com/apurebase/kgraphql/schema/dsl/types/UnionTypeDSL : com/ap
 }
 
 public class com/apurebase/kgraphql/schema/execution/ArgumentTransformer {
-	public fun <init> ()V
+	public fun <init> (Lcom/apurebase/kgraphql/schema/execution/GenericTypeResolver;)V
+	public final fun getGenericTypeResolver ()Lcom/apurebase/kgraphql/schema/execution/GenericTypeResolver;
 	public fun transformArguments (Ljava/lang/String;Ljava/lang/Object;Ljava/util/List;Lcom/apurebase/kgraphql/schema/model/ast/ArgumentNodes;Lcom/apurebase/kgraphql/request/Variables;Lcom/apurebase/kgraphql/schema/execution/Execution;Lcom/apurebase/kgraphql/Context;Lcom/apurebase/kgraphql/schema/model/FunctionWrapper;)Ljava/util/List;
 }
 
 public class com/apurebase/kgraphql/schema/execution/DefaultGenericTypeResolver : com/apurebase/kgraphql/schema/execution/GenericTypeResolver {
 	public fun <init> ()V
+	public fun box (Ljava/lang/Object;Lkotlin/reflect/KType;)Ljava/lang/Object;
 	public fun resolveMonad (Lkotlin/reflect/KType;)Lkotlin/reflect/KType;
 	public fun unbox (Ljava/lang/Object;)Ljava/lang/Object;
 }
@@ -851,12 +853,17 @@ public final class com/apurebase/kgraphql/schema/execution/ExecutionPlan : java/
 
 public abstract interface class com/apurebase/kgraphql/schema/execution/GenericTypeResolver {
 	public static final field Companion Lcom/apurebase/kgraphql/schema/execution/GenericTypeResolver$Companion;
+	public abstract fun box (Ljava/lang/Object;Lkotlin/reflect/KType;)Ljava/lang/Object;
 	public abstract fun resolveMonad (Lkotlin/reflect/KType;)Lkotlin/reflect/KType;
 	public abstract fun unbox (Ljava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class com/apurebase/kgraphql/schema/execution/GenericTypeResolver$Companion {
 	public final fun getDEFAULT ()Lcom/apurebase/kgraphql/schema/execution/DefaultGenericTypeResolver;
+}
+
+public final class com/apurebase/kgraphql/schema/execution/GenericTypeResolver$DefaultImpls {
+	public static fun box (Lcom/apurebase/kgraphql/schema/execution/GenericTypeResolver;Ljava/lang/Object;Lkotlin/reflect/KType;)Ljava/lang/Object;
 }
 
 public final class com/apurebase/kgraphql/schema/execution/ParallelRequestExecutor : com/apurebase/kgraphql/schema/execution/RequestExecutor {

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/SchemaConfigurationDSL.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/SchemaConfigurationDSL.kt
@@ -32,7 +32,7 @@ open class SchemaConfigurationDSL {
             wrapErrors = wrapErrors,
             introspection = introspection,
             genericTypeResolver = genericTypeResolver,
-            argumentTransformer = ArgumentTransformer()
+            argumentTransformer = ArgumentTransformer(genericTypeResolver)
         )
     }
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/ArgumentTransformer.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/ArgumentTransformer.kt
@@ -14,7 +14,7 @@ import com.apurebase.kgraphql.schema.structure.Type
 import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.full.primaryConstructor
 
-open class ArgumentTransformer {
+open class ArgumentTransformer(val genericTypeResolver: GenericTypeResolver) {
 
     open fun transformArguments(
         funName: String,
@@ -135,7 +135,12 @@ open class ArgumentTransformer {
                 val valueMap = constructorParametersByName.mapNotNull { (name, parameter) ->
                     if (providedValuesByKParameter.containsKey(parameter)) {
                         // Value was provided: use provided value
-                        parameter to providedValuesByKParameter[parameter]
+                        val provided = providedValuesByKParameter[parameter]
+                        val value =
+                            if (parameter.type.arguments.isNotEmpty()) genericTypeResolver.box(provided, parameter.type)
+                            else provided
+
+                        parameter to value
                     } else if (parameter.isOptional) {
                         // Value was not provided but parameter is optional: skip it (and use default from Kotlin)
                         null

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/ArgumentTransformer.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/ArgumentTransformer.kt
@@ -137,8 +137,11 @@ open class ArgumentTransformer(val genericTypeResolver: GenericTypeResolver) {
                         // Value was provided: use provided value
                         val provided = providedValuesByKParameter[parameter]
                         val value =
-                            if (parameter.type.arguments.isNotEmpty()) genericTypeResolver.box(provided, parameter.type)
-                            else provided
+                            if (parameter.type.arguments.isNotEmpty()) {
+                                genericTypeResolver.box(provided, parameter.type)
+                            } else {
+                                provided
+                            }
 
                         parameter to value
                     } else if (parameter.isOptional) {

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/GenericTypeResolver.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/GenericTypeResolver.kt
@@ -11,6 +11,7 @@ import kotlin.reflect.KType
 interface GenericTypeResolver {
 
     fun unbox(obj: Any): Any?
+    fun box(obj: Any?, type: KType): Any? = obj
 
     fun resolveMonad(type: KType): KType
 

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaBuilderTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaBuilderTest.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.delay
 import org.junit.jupiter.api.Test
 import kotlin.reflect.KType
 import kotlin.reflect.full.isSupertypeOf
+import kotlin.reflect.jvm.jvmErasure
 import kotlin.reflect.typeOf
 
 /**
@@ -353,7 +354,7 @@ class SchemaBuilderTest {
         schema.inputTypeByKClass(InputTwo::class) shouldNotBe null
     }
 
-    private sealed class Maybe<out T> {
+    sealed class Maybe<out T> {
         abstract fun get(): T
 
         data object Undefined : Maybe<Nothing>() {
@@ -421,6 +422,52 @@ class SchemaBuilderTest {
         }
         expect<IllegalArgumentException>("Requested value is not defined!") {
             deserialize(schema.executeBlocking("{undefinedValueProp {value}}"))
+        }
+    }
+
+    data class InputType(
+        val value: Maybe<String?> = Maybe.Undefined
+    )
+
+    @Test
+    fun `input types can have generic components`() {
+        val typeResolver = object : DefaultGenericTypeResolver() {
+            override fun box(obj: Any?, type: KType) = when (type.jvmErasure) {
+                Maybe::class -> Maybe.Defined(obj)
+                else -> super.box(obj, type)
+            }
+            override fun resolveMonad(type: KType) = when (type.jvmErasure) {
+                Maybe::class -> type.arguments.first().type ?: error("Could not resolve component type of $type")
+                else -> super.resolveMonad(type)
+            }
+        }
+
+        val schema = defaultSchema {
+            configure { genericTypeResolver = typeResolver }
+
+            //Schema must define at least one query
+            query("query") {
+                resolver { x: String -> "" }
+            }
+            mutation("mutation") {
+                resolver { data: InputType ->
+                    if (data.value is Maybe.Undefined) "undefined"
+                    else if (data.value.get() == null) "null"
+                    else "<${data.value.get()}>"
+                }
+            }
+        }
+
+        deserialize(schema.executeBlocking("mutation { mutation(data: {}) }")).let {
+            it.extract<String>("data/mutation") shouldBe "undefined"
+        }
+
+        deserialize(schema.executeBlocking("mutation { mutation(data: { value: null }) }")).let {
+            it.extract<String>("data/mutation") shouldBe "null"
+        }
+
+        deserialize(schema.executeBlocking("mutation { mutation(data: { value: \"test\" }) }")).let {
+            it.extract<String>("data/mutation") shouldBe "<test>"
         }
     }
 

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaBuilderTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaBuilderTest.kt
@@ -436,6 +436,7 @@ class SchemaBuilderTest {
                 Maybe::class -> Maybe.Defined(obj)
                 else -> super.box(obj, type)
             }
+
             override fun resolveMonad(type: KType) = when (type.jvmErasure) {
                 Maybe::class -> type.arguments.first().type ?: error("Could not resolve component type of $type")
                 else -> super.resolveMonad(type)
@@ -445,15 +446,18 @@ class SchemaBuilderTest {
         val schema = defaultSchema {
             configure { genericTypeResolver = typeResolver }
 
-            //Schema must define at least one query
-            query("query") {
-                resolver { x: String -> "" }
+            query("dummy") {
+                resolver { -> "dummy" }
             }
             mutation("mutation") {
                 resolver { data: InputType ->
-                    if (data.value is Maybe.Undefined) "undefined"
-                    else if (data.value.get() == null) "null"
-                    else "<${data.value.get()}>"
+                    if (data.value is Maybe.Undefined) {
+                        "undefined"
+                    } else if (data.value.get() == null) {
+                        "null"
+                    } else {
+                        "<${data.value.get()}>"
+                    }
                 }
             }
         }


### PR DESCRIPTION
Currently, it is not possible to define an input type like this:
```kt
data class TestInput(
  val value: Omissible<String> = Omissible.omitted()
)
```

This PR allows such input types by defining the following `GenericTypeResolver`:
```kt
object : DefaultGenericTypeResolver() {
    override fun box(obj: Any?, type: KType) = when (type.jvmErasure) {
        Omissible::class -> Omissible.of(obj)
        else -> super.box(obj, type)
    }
    override fun resolveMonad(type: KType) = when (type.jvmErasure) {
        Omissible::class -> type.arguments.first().type ?: error("Could not resolve component type of $type")
        else -> super.resolveMonad(type)
    }
}
```

This is useful for generic update mutations, where users can either leave a field as is or explicitly set it to `null`.