### PR TITLE
ci: run test workflows on pull_request

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,6 +1,10 @@
 name: Benchmarks (Library)
+
 on:
   push:
+    branches:
+      - main
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,6 +1,10 @@
 name: Tests (Examples)
+
 on:
   push:
+    branches:
+      - main
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,4 +1,5 @@
 name: Maven Publish
+
 on:
   release:
     types:

--- a/.github/workflows/publish-documentation.yml
+++ b/.github/workflows/publish-documentation.yml
@@ -1,4 +1,5 @@
 name: 'Publish Documentation'
+
 on:
   push:
     branches:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,10 @@
 name: Tests (Library)
+
 on:
   push:
+    branches:
+      - main
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -1,4 +1,5 @@
 name: Validate PR title
+
 on:
   pull_request:
     types: [ opened, synchronize, reopened, edited ]


### PR DESCRIPTION
This should prevent stale actions from fork pull requests, as seen in #465 or #437