### PR TITLE
feat: support parent fields from local types

### DIFF
--- a/kgraphql-ktor-stitched/api/kgraphql-ktor-stitched.api
+++ b/kgraphql-ktor-stitched/api/kgraphql-ktor-stitched.api
@@ -132,7 +132,8 @@ public abstract class com/apurebase/kgraphql/stitched/schema/execution/AbstractR
 }
 
 public final class com/apurebase/kgraphql/stitched/schema/execution/RemoteArgumentTransformer : com/apurebase/kgraphql/schema/execution/ArgumentTransformer {
-	public fun <init> (Lcom/apurebase/kgraphql/schema/execution/GenericTypeResolver;)V
+	public fun <init> (Lcom/fasterxml/jackson/databind/ObjectMapper;Lcom/apurebase/kgraphql/schema/execution/GenericTypeResolver;)V
+	public final fun getObjectMapper ()Lcom/fasterxml/jackson/databind/ObjectMapper;
 	public fun transformArguments (Ljava/lang/String;Ljava/lang/Object;Ljava/util/List;Lcom/apurebase/kgraphql/schema/model/ast/ArgumentNodes;Lcom/apurebase/kgraphql/request/Variables;Lcom/apurebase/kgraphql/schema/execution/Execution;Lcom/apurebase/kgraphql/Context;Lcom/apurebase/kgraphql/schema/model/FunctionWrapper;)Ljava/util/List;
 }
 

--- a/kgraphql-ktor-stitched/src/main/kotlin/com/apurebase/kgraphql/stitched/schema/dsl/StitchedSchemaConfigurationDSL.kt
+++ b/kgraphql-ktor-stitched/src/main/kotlin/com/apurebase/kgraphql/stitched/schema/dsl/StitchedSchemaConfigurationDSL.kt
@@ -26,7 +26,7 @@ open class StitchedSchemaConfigurationDSL : SchemaConfigurationDSL() {
             wrapErrors = wrapErrors,
             introspection = introspection,
             genericTypeResolver = genericTypeResolver,
-            argumentTransformer = RemoteArgumentTransformer(genericTypeResolver),
+            argumentTransformer = RemoteArgumentTransformer(objectMapper, genericTypeResolver),
             remoteExecutor = requireNotNull(remoteExecutor) { "Remote executor not defined" },
             localUrl = localUrl
         )


### PR DESCRIPTION
Support reading values from parent fields for local types in stitched schemas. Previously, `parentFieldName` could only be resolved from remote objects.