### PR TITLE
refactor: minor enhancements

### DIFF
--- a/kgraphql-ktor-stitched/src/main/kotlin/com/apurebase/kgraphql/stitched/schema/execution/AbstractRemoteRequestExecutor.kt
+++ b/kgraphql-ktor-stitched/src/main/kotlin/com/apurebase/kgraphql/stitched/schema/execution/AbstractRemoteRequestExecutor.kt
@@ -101,8 +101,7 @@ abstract class AbstractRemoteRequestExecutor(private val objectMapper: ObjectMap
 
     private fun StringBuilder.addSelectionsForField(node: Execution.Remote) {
         val filteredSelections =
-            (node.selectionNode as? SelectionNode.FieldNode)?.selectionSet?.selections?.filterForType(node.field.returnType)
-                .orEmpty()
+            node.selectionNode.selectionSet?.selections?.filterForType(node.field.returnType).orEmpty()
         if (filteredSelections.isNotEmpty()) {
             append("{")
             filteredSelections.forEach {

--- a/kgraphql-ktor/src/test/kotlin/com/apurebase/kgraphql/KtorFeatureTest.kt
+++ b/kgraphql-ktor/src/test/kotlin/com/apurebase/kgraphql/KtorFeatureTest.kt
@@ -187,7 +187,7 @@ class KtorFeatureTest : KtorTest() {
 
         val server = withServer(errorHandler = errorHandler) {
             query("error") {
-                resolver<String> { -> throw Exception("Error message") }
+                resolver<String> { throw Exception("Error message") }
             }
         }
 
@@ -204,7 +204,7 @@ class KtorFeatureTest : KtorTest() {
     fun `should work without error handler`() {
         val server = withServer {
             query("error") {
-                resolver<String> { -> throw Exception("Error message") }
+                resolver<String> { throw Exception("Error message") }
             }
         }
 
@@ -221,7 +221,7 @@ class KtorFeatureTest : KtorTest() {
     fun `should work without error handler and wrap errors`() {
         val server = withServer(wrapErrors = false) {
             query("error") {
-                resolver<String> { -> throw Exception("Error message") }
+                resolver<String> { throw Exception("Error message") }
             }
         }
 

--- a/kgraphql/api/kgraphql.api
+++ b/kgraphql/api/kgraphql.api
@@ -97,7 +97,6 @@ public class com/apurebase/kgraphql/configuration/SchemaConfiguration {
 
 public final class com/apurebase/kgraphql/helpers/KGraphQLExtensionsKt {
 	public static final fun getFields (Lcom/apurebase/kgraphql/schema/execution/Execution;)Ljava/util/List;
-	public static final fun toJsonElement (Ljava/util/Collection;)Lkotlinx/serialization/json/JsonElement;
 	public static final fun toJsonElement (Ljava/util/Map;)Lkotlinx/serialization/json/JsonElement;
 	public static final fun toValueNode (Lcom/fasterxml/jackson/databind/JsonNode;Lcom/apurebase/kgraphql/schema/introspection/__Type;)Lcom/apurebase/kgraphql/schema/model/ast/ValueNode;
 }
@@ -2696,11 +2695,7 @@ public class com/apurebase/kgraphql/schema/structure/TypeProxy : com/apurebase/k
 }
 
 public final class com/apurebase/kgraphql/schema/structure/ValidationKt {
-	public static final fun assertValidObjectType (Lkotlin/reflect/KClass;)V
-	public static final fun validateArguments (Lcom/apurebase/kgraphql/schema/structure/Field;Ljava/util/List;Ljava/lang/String;)Ljava/util/List;
 	public static final fun validateName (Ljava/lang/String;)V
-	public static final fun validatePropertyArguments (Lcom/apurebase/kgraphql/schema/structure/Type;Lcom/apurebase/kgraphql/schema/structure/Field;Lcom/apurebase/kgraphql/schema/model/ast/SelectionNode$FieldNode;)V
-	public static final fun validateUnionRequest (Lcom/apurebase/kgraphql/schema/structure/Field$Union;Lcom/apurebase/kgraphql/schema/model/ast/SelectionNode$FieldNode;)V
 }
 
 public abstract class nidomiro/kdataloader/BatchMode {

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/GraphQLError.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/GraphQLError.kt
@@ -48,7 +48,7 @@ open class GraphQLError(
      * Custom error extensions.
      */
     open val extensions: Map<String, Any?>? = mapOf("type" to BuiltInErrorCodes.INTERNAL_SERVER_ERROR.name)
-) : Exception(message) {
+) : Exception(message, originalError) {
 
     /**
      * An array of { line, column } locations within the source GraphQL document

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/helpers/KGraphQLExtensions.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/helpers/KGraphQLExtensions.kt
@@ -40,7 +40,7 @@ fun Execution.getFields(): List<String> = when (this) {
 /**
  * Collection : Convert to JsonElement
  */
-fun Collection<*>.toJsonElement(): JsonElement {
+private fun Collection<*>.toJsonElement(): JsonElement {
     val list: MutableList<JsonElement> = mutableListOf()
     forEach {
         val value = it ?: return@forEach

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/request/Variables.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/request/Variables.kt
@@ -39,7 +39,7 @@ data class Variables(private val variablesJson: VariablesJson, private val varia
 
         if (invalidName || invalidIsList || invalidNullability) {
             throw InvalidInputValueException(
-                "Invalid variable $${variable.variable.name.value} argument type ${variableType.nameNode.value}, expected ${expectedType.typeReference()}",
+                "Invalid variable '$${variable.variable.name.value}' argument type '${variableType.nameNode.value}', expected '${expectedType.typeReference()}'",
                 variable
             )
         }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/builtin/BuiltInScalars.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/builtin/BuiltInScalars.kt
@@ -62,10 +62,8 @@ object STRING_COERCION : StringScalarCoercion<String> {
 
     override fun deserialize(raw: String, valueNode: ValueNode) = when (valueNode) {
         is StringValueNode -> valueNode.value
-        else -> throw InvalidInputValueException(
-            "Cannot coerce ${valueNode.valueNodeName} to string constant",
-            valueNode
-        )
+
+        else -> throw InvalidInputValueException("Cannot coerce '${valueNode.valueNodeName}' to String", valueNode)
     }
 }
 
@@ -75,10 +73,8 @@ object DOUBLE_COERCION : StringScalarCoercion<Double> {
     override fun deserialize(raw: String, valueNode: ValueNode) = when (valueNode) {
         is DoubleValueNode -> valueNode.value
         is NumberValueNode -> valueNode.value.toDouble()
-        else -> throw InvalidInputValueException(
-            "Cannot coerce ${valueNode.valueNodeName} to numeric constant",
-            valueNode
-        )
+
+        else -> throw InvalidInputValueException("Cannot coerce '${valueNode.valueNodeName}' to Float", valueNode)
     }
 }
 
@@ -86,12 +82,10 @@ object FLOAT_COERCION : StringScalarCoercion<Float> {
     override fun serialize(instance: Float): String = instance.toDouble().toString()
 
     override fun deserialize(raw: String, valueNode: ValueNode) = when (valueNode) {
-        is DoubleValueNode -> DOUBLE_COERCION.deserialize(raw, valueNode).toFloat()
-        is NumberValueNode -> DOUBLE_COERCION.deserialize(raw, valueNode).toFloat()
-        else -> throw InvalidInputValueException(
-            "Cannot coerce ${valueNode.valueNodeName} to numeric constant",
-            valueNode
-        )
+        is DoubleValueNode -> valueNode.value.toFloat()
+        is NumberValueNode -> valueNode.value.toFloat()
+
+        else -> throw InvalidInputValueException("Cannot coerce '${valueNode.valueNodeName}' to Float", valueNode)
     }
 }
 
@@ -101,22 +95,19 @@ object INT_COERCION : StringScalarCoercion<Int> {
     override fun deserialize(raw: String, valueNode: ValueNode) = when (valueNode) {
         is NumberValueNode -> when {
             valueNode.value > Integer.MAX_VALUE -> throw InvalidInputValueException(
-                "Cannot coerce to type of Int as '${valueNode.value}' is greater than (2^-31)-1",
+                "Cannot coerce '${valueNode.valueNodeName}' to Int as it is greater than (2^-31)-1",
                 valueNode
             )
 
             valueNode.value < Integer.MIN_VALUE -> throw InvalidInputValueException(
-                "Cannot coerce to type of Int as '${valueNode.value}' is less than -(2^-31)",
+                "Cannot coerce '${valueNode.valueNodeName}' to Int as it is less than -(2^-31)",
                 valueNode
             )
 
             else -> valueNode.value.toInt()
         }
 
-        else -> throw InvalidInputValueException(
-            "Cannot coerce ${valueNode.valueNodeName} to numeric constant",
-            valueNode
-        )
+        else -> throw InvalidInputValueException("Cannot coerce '${valueNode.valueNodeName}' to Int", valueNode)
     }
 }
 
@@ -126,22 +117,19 @@ object SHORT_COERCION : StringScalarCoercion<Short> {
     override fun deserialize(raw: String, valueNode: ValueNode) = when (valueNode) {
         is NumberValueNode -> when {
             valueNode.value > Short.MAX_VALUE -> throw InvalidInputValueException(
-                "Cannot coerce to type of Int as '${valueNode.value}' is greater than (2^-15)-1",
+                "Cannot coerce '${valueNode.value}' to Short as it is greater than (2^-15)-1",
                 valueNode
             )
 
             valueNode.value < Short.MIN_VALUE -> throw InvalidInputValueException(
-                "Cannot coerce to type of Int as '${valueNode.value}' is less than -(2^-15)",
+                "Cannot coerce '${valueNode.value}' to Short as it is less than -(2^-15)",
                 valueNode
             )
 
             else -> valueNode.value.toShort()
         }
 
-        else -> throw InvalidInputValueException(
-            "Cannot coerce ${valueNode.valueNodeName} to numeric constant",
-            valueNode
-        )
+        else -> throw InvalidInputValueException("Cannot coerce '${valueNode.valueNodeName}' to Short", valueNode)
     }
 }
 
@@ -150,10 +138,7 @@ object LONG_COERCION : StringScalarCoercion<Long> {
 
     override fun deserialize(raw: String, valueNode: ValueNode) = when (valueNode) {
         is NumberValueNode -> valueNode.value
-        else -> throw InvalidInputValueException(
-            "Cannot coerce ${valueNode.valueNodeName} to numeric constant",
-            valueNode
-        )
+        else -> throw InvalidInputValueException("Cannot coerce '${valueNode.valueNodeName}' to Long", valueNode)
     }
 }
 
@@ -165,19 +150,18 @@ object BOOLEAN_COERCION : StringScalarCoercion<Boolean> {
         is StringValueNode -> when {
             valueNode.value.equals("true", true) -> true
             valueNode.value.equals("false", true) -> false
-            else -> throw IllegalArgumentException("${valueNode.value} does not represent valid Boolean value")
+
+            else -> throw IllegalArgumentException("Cannot coerce '${valueNode.value}' to Boolean")
         }
 
         is NumberValueNode -> when (valueNode.value) {
             0L, -1L -> false
             1L -> true
-            else -> throw IllegalArgumentException("${valueNode.value} does not represent valid Boolean value")
+
+            else -> throw IllegalArgumentException("Cannot coerce '${valueNode.value}' to Boolean")
         }
 
-        else -> throw InvalidInputValueException(
-            "Cannot coerce ${valueNode.valueNodeName} to boolean constant",
-            valueNode
-        )
+        else -> throw InvalidInputValueException("Cannot coerce '${valueNode.valueNodeName}' to Boolean", valueNode)
     }
 }
 
@@ -188,9 +172,6 @@ object ID_COERCION : StringScalarCoercion<ID> {
         is StringValueNode -> ID(valueNode.value)
         is NumberValueNode -> ID(valueNode.value.toString())
 
-        else -> throw InvalidInputValueException(
-            "Cannot coerce ${valueNode.valueNodeName} to ID",
-            valueNode
-        )
+        else -> throw InvalidInputValueException("Cannot coerce '${valueNode.valueNodeName}' to ID", valueNode)
     }
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/operations/AbstractOperationDSL.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/operations/AbstractOperationDSL.kt
@@ -9,9 +9,7 @@ import com.apurebase.kgraphql.schema.model.InputValueDef
 import kotlin.reflect.KFunction
 import kotlin.reflect.KType
 
-abstract class AbstractOperationDSL(
-    val name: String
-) : LimitedAccessItemDSL<Nothing>(),
+abstract class AbstractOperationDSL(val name: String) : LimitedAccessItemDSL<Nothing>(),
     ResolverDSL.Target {
 
     protected val inputValues = mutableListOf<InputValueDef<*>>()

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/operations/MutationDSL.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/operations/MutationDSL.kt
@@ -2,9 +2,7 @@ package com.apurebase.kgraphql.schema.dsl.operations
 
 import com.apurebase.kgraphql.schema.model.MutationDef
 
-class MutationDSL(
-    name: String
-) : AbstractOperationDSL(name) {
+class MutationDSL(name: String) : AbstractOperationDSL(name) {
 
     internal fun toKQLMutation(): MutationDef<out Any?> {
         val function = requireNotNull(functionWrapper) {

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/operations/QueryDSL.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/operations/QueryDSL.kt
@@ -2,9 +2,7 @@ package com.apurebase.kgraphql.schema.dsl.operations
 
 import com.apurebase.kgraphql.schema.model.QueryDef
 
-class QueryDSL(
-    name: String
-) : AbstractOperationDSL(name) {
+class QueryDSL(name: String) : AbstractOperationDSL(name) {
 
     internal fun toKQLQuery(): QueryDef<out Any?> {
         val function = requireNotNull(functionWrapper) {

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/operations/SubscriptionDSL.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/dsl/operations/SubscriptionDSL.kt
@@ -11,9 +11,7 @@ import kotlin.reflect.full.isSubtypeOf
 import kotlin.reflect.full.memberProperties
 import kotlin.reflect.full.starProjectedType
 
-class SubscriptionDSL(
-    name: String
-) : AbstractOperationDSL(name) {
+class SubscriptionDSL(name: String) : AbstractOperationDSL(name) {
 
     internal fun toKQLSubscription(): SubscriptionDef<out Any?> {
         val function = requireNotNull(functionWrapper) {

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/ArgumentTransformer.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/ArgumentTransformer.kt
@@ -47,7 +47,7 @@ open class ArgumentTransformer(val genericTypeResolver: GenericTypeResolver) {
                 value == null && parameter.type.kind != TypeKind.NON_NULL -> parameter.default
                 value == null && parameter.type.kind == TypeKind.NON_NULL -> {
                     parameter.default ?: throw InvalidInputValueException(
-                        "argument '${parameter.name}' of type ${parameter.type.typeReference()} on field '$funName' is not nullable, value cannot be null",
+                        "Argument '${parameter.name}' of type ${parameter.type.typeReference()} on field '$funName' is not nullable, value cannot be null",
                         executionNode.selectionNode
                     )
                 }
@@ -56,7 +56,7 @@ open class ArgumentTransformer(val genericTypeResolver: GenericTypeResolver) {
                     val transformedValue = transformValue(parameter.type, value!!, variables, true, parameter.default)
                     if (transformedValue == null && parameter.type.isNotNullable()) {
                         throw InvalidInputValueException(
-                            "argument ${parameter.name} is not optional, value cannot be null",
+                            "Argument ${parameter.name} is not optional, value cannot be null",
                             executionNode.selectionNode
                         )
                     }
@@ -94,7 +94,7 @@ open class ArgumentTransformer(val genericTypeResolver: GenericTypeResolver) {
                     transformToCollection(type.listType(), listOf(value), variables, true)
                 } else {
                     throw InvalidInputValueException(
-                        "argument '${value.valueNodeName}' is not valid value of type List",
+                        "Cannot coerce '${value.valueNodeName}' to List",
                         value
                     )
                 }
@@ -172,7 +172,7 @@ open class ArgumentTransformer(val genericTypeResolver: GenericTypeResolver) {
             value is ValueNode.NullValueNode -> {
                 if (type.isNotNullable()) {
                     throw InvalidInputValueException(
-                        "argument '${value.valueNodeName}' is not valid value of type ${type.unwrapped().name}",
+                        "Cannot coerce '${value.valueNodeName}' to ${type.unwrapped().name}",
                         value
                     )
                 } else {
@@ -183,7 +183,7 @@ open class ArgumentTransformer(val genericTypeResolver: GenericTypeResolver) {
             value is ValueNode.ListValueNode -> {
                 if (type.isNotList()) {
                     throw InvalidInputValueException(
-                        "argument '${value.valueNodeName}' is not valid value of type ${type.unwrapped().name}",
+                        "Cannot coerce '${value.valueNodeName}' to ${type.unwrapped().name}",
                         value
                     )
                 } else {
@@ -220,14 +220,14 @@ open class ArgumentTransformer(val genericTypeResolver: GenericTypeResolver) {
                 )
             } else {
                 throw InvalidInputValueException(
-                    "String literal '${value.valueNodeName}' is invalid value for enum type ${enumType.name}",
+                    "Cannot coerce string literal '${value.valueNodeName}' to enum ${enumType.name}",
                     value
                 )
             }
         } ?: (type as? Type.Scalar<*>)?.let { scalarType ->
             deserializeScalar(scalarType, value)
         } ?: throw InvalidInputValueException(
-            "Invalid argument value '${value.valueNodeName}' for type ${type.name}",
+            "Cannot coerce '${value.valueNodeName}' to enum ${type.name}",
             value
         )
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/scalar/Coercion.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/scalar/Coercion.kt
@@ -48,7 +48,7 @@ fun <T : Any> deserializeScalar(scalar: Type.Scalar<T>, value: ValueNode): T {
         throw e
     } catch (e: Exception) {
         throw InvalidInputValueException(
-            message = "argument '${value.valueNodeName}' is not valid value of type ${scalar.name}",
+            message = "Cannot coerce '${value.valueNodeName}' to ${scalar.name}",
             node = value,
             originalError = e
         )
@@ -86,5 +86,5 @@ fun <T> serializeScalar(
         jsonNodeFactory.booleanNode((scalar.coercion as BooleanScalarCoercion<T>).serialize(value))
     }
 
-    else -> throw ExecutionException("Unsupported coercion for scalar type ${scalar.name}", executionNode)
+    else -> throw ExecutionException("Unsupported coercion for scalar ${scalar.name}", executionNode)
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/RequestInterpreter.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/RequestInterpreter.kt
@@ -181,7 +181,7 @@ class RequestInterpreter(private val schemaModel: SchemaModel) {
             else -> {
                 validatePropertyArguments(this, field, node)
 
-                return Execution.Node(
+                Execution.Node(
                     selectionNode = node,
                     field = field,
                     children = handleReturnType(ctx, field.returnType, node),

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/Validation.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/Validation.kt
@@ -10,7 +10,7 @@ import kotlin.reflect.full.isSubclassOf
 
 private val namePattern = Regex("[_a-zA-Z][_a-zA-Z0-9]*")
 
-fun validatePropertyArguments(parentType: Type, field: Field, requestNode: FieldNode) {
+internal fun validatePropertyArguments(parentType: Type, field: Field, requestNode: FieldNode) {
     val argumentValidationExceptions = field.validateArguments(requestNode.arguments, parentType.name)
 
     if (argumentValidationExceptions.isNotEmpty()) {
@@ -20,7 +20,7 @@ fun validatePropertyArguments(parentType: Type, field: Field, requestNode: Field
     }
 }
 
-fun Field.validateArguments(selectionArgs: List<ArgumentNode>?, parentTypeName: String?): List<ValidationException> {
+private fun Field.validateArguments(selectionArgs: List<ArgumentNode>?, parentTypeName: String?): List<ValidationException> {
     if (!(args.isNotEmpty() || selectionArgs?.isNotEmpty() != true)) {
         return listOf(
             ValidationException(
@@ -48,7 +48,7 @@ fun Field.validateArguments(selectionArgs: List<ArgumentNode>?, parentTypeName: 
         if (value == null && arg.type.kind == TypeKind.NON_NULL && arg.defaultValue == null) {
             exceptions.add(
                 ValidationException(
-                    message = "Missing value for non-nullable argument ${arg.name} on the field '$name'"
+                    message = "Missing value for non-nullable argument '${arg.name}' on the field '$name'"
                 )
             )
         } // else is valid
@@ -60,7 +60,7 @@ fun Field.validateArguments(selectionArgs: List<ArgumentNode>?, parentTypeName: 
 /**
  * validate that only typed fragments or __typename are present
  */
-fun validateUnionRequest(field: Field.Union<*>, selectionNode: FieldNode) {
+internal fun validateUnionRequest(field: Field.Union<*>, selectionNode: FieldNode) {
     val illegalChildren =
         selectionNode.selectionSet?.selections?.filterIsInstance<FieldNode>()?.filter { it.name.value != "__typename" }
 
@@ -90,7 +90,7 @@ fun validateName(name: String) {
 }
 
 // function before generic, because it is its subset
-fun assertValidObjectType(kClass: KClass<*>) = when {
+internal fun assertValidObjectType(kClass: KClass<*>) = when {
     kClass.isSubclassOf(Function::class) -> throw SchemaException("Cannot handle function class '${kClass.qualifiedName}' as object type")
     kClass.isSubclassOf(Enum::class) -> throw SchemaException("Cannot handle enum class '${kClass.qualifiedName}' as object type")
     else -> Unit

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/access/AccessRulesTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/access/AccessRulesTest.kt
@@ -16,7 +16,13 @@ class AccessRulesTest {
     val schema = defaultSchema {
         query("black_mamba") {
             resolver { -> Player("KOBE") }
-            accessRule { ctx -> if (ctx.get<String>().equals("LAKERS")) null else IllegalAccessException() }
+            accessRule { ctx ->
+                if (ctx.get<String>() == "LAKERS") {
+                    null
+                } else {
+                    IllegalAccessException()
+                }
+            }
         }
 
         query("white_mamba") {
@@ -25,7 +31,11 @@ class AccessRulesTest {
 
         type<Player> {
             val accessRuleBlock = { player: Player, _: Context ->
-                if (player.name != "BONNER") IllegalAccessException("ILLEGAL ACCESS") else null
+                if (player.name != "BONNER") {
+                    IllegalAccessException("ILLEGAL ACCESS")
+                } else {
+                    null
+                }
             }
             property(Player::id) {
                 accessRule(accessRuleBlock)

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/BaseSchemaTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/BaseSchemaTest.kt
@@ -39,7 +39,7 @@ abstract class BaseSchemaTest {
     // new actors created via mutations in schema
     val createdActors = mutableListOf<Actor>()
 
-    private val testedSchema = defaultSchema {
+    protected val testedSchema = defaultSchema {
         configure {
             useDefaultPrettyPrinter = true
         }
@@ -314,6 +314,23 @@ abstract class BaseSchemaTest {
                 newActor
             }
         }
+
+        data class Inner(val name: String)
+        data class Outer(val inner1: Inner, val inner2: Inner)
+
+        query("outer") {
+            resolver { ->
+                Outer(Inner("test1"), Inner("test2"))
+            }
+        }
+        type<Inner> {
+            property("testProperty1") {
+                resolver { "${it.name}.testProperty1" }
+            }
+            property("testProperty2") {
+                resolver { "${it.name}.testProperty2" }
+            }
+        }
     }
 
     @AfterEach
@@ -323,7 +340,7 @@ abstract class BaseSchemaTest {
         query: String,
         variables: String? = null,
         context: Context = Context(emptyMap()),
-        operationName: String? = null,
+        operationName: String? = null
     ) = testedSchema
         .executeBlocking(query, variables, context, operationName)
         .deserialize()

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/MutationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/integration/MutationTest.kt
@@ -40,28 +40,28 @@ class MutationTest : BaseSchemaTest() {
     @Test
     fun `invalid mutation name`() {
         expect<ValidationException>("Property 'createBanana' on 'Mutation' does not exist") {
-            execute("mutation {createBanana(name: \"${testActor.name}\", age: ${testActor.age}){age}}")
+            testedSchema.executeBlocking("mutation {createBanana(name: \"${testActor.name}\", age: ${testActor.age}){age}}")
         }
     }
 
     @Test
     fun `invalid argument type`() {
-        expect<InvalidInputValueException>("Cannot coerce \"fwfwf\" to numeric constant") {
-            execute("mutation {createActor(name: \"${testActor.name}\", age: \"fwfwf\"){age}}")
+        expect<InvalidInputValueException>("Cannot coerce '\"fwfwf\"' to Int") {
+            testedSchema.executeBlocking("mutation {createActor(name: \"${testActor.name}\", age: \"fwfwf\"){age}}")
         }
     }
 
     @Test
     fun `invalid arguments number`() {
         expect<ValidationException>("'createActor' does support arguments: [name, age], found: [name, age, bananan]") {
-            execute("mutation {createActor(name: \"${testActor.name}\", age: ${testActor.age}, bananan: \"fwfwf\"){age}}")
+            testedSchema.executeBlocking("mutation {createActor(name: \"${testActor.name}\", age: ${testActor.age}, bananan: \"fwfwf\"){age}}")
         }
     }
 
     @Test
     fun `invalid arguments number with NotIntrospected class`() {
         expect<ValidationException>("'createActorWithContext' does support arguments: [name, age], found: [name, age, bananan]") {
-            execute("mutation {createActorWithContext(name: \"${testActor.name}\", age: ${testActor.age}, bananan: \"fwfwf\"){age}}")
+            testedSchema.executeBlocking("mutation {createActorWithContext(name: \"${testActor.name}\", age: ${testActor.age}, bananan: \"fwfwf\"){age}}")
         }
     }
 

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaBuilderTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaBuilderTest.kt
@@ -418,10 +418,10 @@ class SchemaBuilderTest {
             it.extract<String>("data/definedValue") shouldBe "good!"
         }
         expect<IllegalArgumentException>("Requested value is not defined!") {
-            deserialize(schema.executeBlocking("{undefinedValue}"))
+            schema.executeBlocking("{undefinedValue}")
         }
         expect<IllegalArgumentException>("Requested value is not defined!") {
-            deserialize(schema.executeBlocking("{undefinedValueProp {value}}"))
+            schema.executeBlocking("{undefinedValueProp {value}}")
         }
     }
 

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaInheritanceTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaInheritanceTest.kt
@@ -2,7 +2,6 @@ package com.apurebase.kgraphql.schema
 
 import com.apurebase.kgraphql.KGraphQL
 import com.apurebase.kgraphql.ValidationException
-import com.apurebase.kgraphql.deserialize
 import com.apurebase.kgraphql.expect
 import org.junit.jupiter.api.Test
 import java.util.UUID
@@ -32,11 +31,11 @@ class SchemaInheritanceTest {
         }
 
         expect<ValidationException>("Property 'id' on 'B' does not exist") {
-            deserialize(schema.executeBlocking("{b{id, name, age}}"))
+            schema.executeBlocking("{b{id, name, age}}")
         }
 
         expect<ValidationException>("Property 'id' on 'C' does not exist") {
-            deserialize(schema.executeBlocking("{c{id, name, age}}"))
+            schema.executeBlocking("{c{id, name, age}}")
         }
     }
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/InputValuesSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/InputValuesSpecificationTest.kt
@@ -48,13 +48,13 @@ class InputValuesSpecificationTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = ["42.0", "\"foo\"", "bar"])
+    @ValueSource(strings = ["null", "42.0", "\"foo\"", "bar"])
     @Specification("2.9.1 Int Value")
     fun `Invalid Int input value`(value: String) {
         val exception = shouldThrowExactly<InvalidInputValueException> {
-            deserialize(schema.executeBlocking("{ Int(value: $value) }"))
+            schema.executeBlocking("{ Int(value: $value) }")
         }
-        exception shouldHaveMessage "Cannot coerce $value to numeric constant"
+        exception shouldHaveMessage "Cannot coerce '$value' to Int"
         exception.extensions shouldBe mapOf(
             "type" to "BAD_USER_INPUT"
         )
@@ -112,9 +112,9 @@ class InputValuesSpecificationTest {
     @Specification("2.9.3 Boolean Value")
     fun `Invalid Boolean input value`(value: String) {
         val exception = shouldThrowExactly<InvalidInputValueException> {
-            deserialize(schema.executeBlocking("{ Boolean(value: $value) }"))
+            schema.executeBlocking("{ Boolean(value: $value) }")
         }
-        exception shouldHaveMessage "argument '$value' is not valid value of type Boolean"
+        exception shouldHaveMessage "Cannot coerce '$value' to Boolean"
         exception.extensions shouldBe mapOf(
             "type" to "BAD_USER_INPUT"
         )
@@ -143,9 +143,9 @@ class InputValuesSpecificationTest {
     @Specification("2.9.4 String Value")
     fun `Invalid String input value`(value: String) {
         val exception = shouldThrowExactly<InvalidInputValueException> {
-            deserialize(schema.executeBlocking("{ String(value: $value) }"))
+            schema.executeBlocking("{ String(value: $value) }")
         }
-        exception shouldHaveMessage "argument '$value' is not valid value of type String"
+        exception shouldHaveMessage "Cannot coerce '$value' to String"
         exception.extensions shouldBe mapOf(
             "type" to "BAD_USER_INPUT"
         )
@@ -170,7 +170,7 @@ class InputValuesSpecificationTest {
     @Specification("2.9.6 Enum Value")
     fun `Invalid Enum input value`(value: String) {
         val exception = shouldThrowExactly<InvalidInputValueException> {
-            deserialize(schema.executeBlocking("{ Enum(value: $value) }"))
+            schema.executeBlocking("{ Enum(value: $value) }")
         }
         exception shouldHaveMessage "Invalid enum ${FakeEnum::class.simpleName} value. Expected one of [ENUM1, ENUM2]"
         exception.extensions shouldBe mapOf(
@@ -186,13 +186,13 @@ class InputValuesSpecificationTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = ["true", "\"foo\""])
+    @ValueSource(strings = ["null", "true", "\"foo\""])
     @Specification("2.9.7 List Value")
     fun `Invalid List input value`(value: String) {
         val exception = shouldThrowExactly<InvalidInputValueException> {
-            deserialize(schema.executeBlocking("{ List(value: $value) }"))
+            schema.executeBlocking("{ List(value: $value) }")
         }
-        exception shouldHaveMessage "Cannot coerce $value to numeric constant"
+        exception shouldHaveMessage "Cannot coerce '$value' to Int"
         exception.extensions shouldBe mapOf(
             "type" to "BAD_USER_INPUT"
         )
@@ -214,7 +214,7 @@ class InputValuesSpecificationTest {
         val exception = shouldThrowExactly<InvalidInputValueException> {
             schema.executeBlocking("{ Object(value: { number: 232, description: \"little number\", list: $value }) }")
         }
-        exception shouldHaveMessage "argument '$value' is not valid value of type String"
+        exception shouldHaveMessage "Cannot coerce '$value' to String"
         exception.extensions shouldBe mapOf(
             "type" to "BAD_USER_INPUT"
         )
@@ -226,7 +226,7 @@ class InputValuesSpecificationTest {
         val exception = shouldThrowExactly<InvalidInputValueException> {
             schema.executeBlocking("{ Object(value: null) }")
         }
-        exception shouldHaveMessage "argument 'null' is not valid value of type FakeData"
+        exception shouldHaveMessage "Cannot coerce 'null' to FakeData"
         exception.extensions shouldBe mapOf(
             "type" to "BAD_USER_INPUT"
         )
@@ -306,7 +306,7 @@ class InputValuesSpecificationTest {
         val exception = shouldThrowExactly<InvalidInputValueException> {
             schema.executeBlocking("query(\$object: FakeDate) { Object(value: \$object) }")
         }
-        exception shouldHaveMessage "Invalid variable \$object argument type FakeDate, expected FakeData!"
+        exception shouldHaveMessage "Invalid variable '\$object' argument type 'FakeDate', expected 'FakeData!'"
         exception.extensions shouldBe mapOf(
             "type" to "BAD_USER_INPUT"
         )

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/ListInputCoercionTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/ListInputCoercionTest.kt
@@ -42,15 +42,15 @@ class ListInputCoercionTest {
 
     @Test
     fun `a list of mixed types should not be valid for a nullable list of Int`() {
-        expect<InvalidInputValueException>("Cannot coerce \"b\" to numeric constant") {
-            deserialize(schema.executeBlocking("{ NullableList(value: [1, \"b\", true]) }"))
+        expect<InvalidInputValueException>("Cannot coerce '\"b\"' to Int") {
+            schema.executeBlocking("{ NullableList(value: [1, \"b\", true]) }")
         }
     }
 
     @Test
     fun `foo should not be valid for a nullable list of Int`() {
-        expect<InvalidInputValueException>("Cannot coerce \"foo\" to numeric constant") {
-            deserialize(schema.executeBlocking("{ RequiredList(value: \"foo\") }"))
+        expect<InvalidInputValueException>("Cannot coerce '\"foo\"' to Int") {
+            schema.executeBlocking("{ RequiredList(value: \"foo\") }")
         }
     }
 
@@ -74,15 +74,15 @@ class ListInputCoercionTest {
 
     @Test
     fun `a non-nested list should not be valid for a nullable nested list of Int`() {
-        expect<InvalidInputValueException>("argument '1' is not valid value of type List") {
-            deserialize(schema.executeBlocking("{ NullableNestedList(value: [1, 2, 3]) }"))
+        expect<InvalidInputValueException>("Cannot coerce '1' to List") {
+            schema.executeBlocking("{ NullableNestedList(value: [1, 2, 3]) }")
         }
     }
 
     @Test
     fun `null should not be valid for a required list of Int`() {
-        expect<InvalidInputValueException>("argument 'null' is not valid value of type Int") {
-            deserialize(schema.executeBlocking("{ RequiredList(value: null) }"))
+        expect<InvalidInputValueException>("Cannot coerce 'null' to Int") {
+            schema.executeBlocking("{ RequiredList(value: null) }")
         }
     }
 
@@ -118,15 +118,15 @@ class ListInputCoercionTest {
 
     @Test
     fun `a list of mixed types should not be valid for a nullable set of Int`() {
-        expect<InvalidInputValueException>("Cannot coerce \"b\" to numeric constant") {
-            deserialize(schema.executeBlocking("{ NullableSet(value: [1, \"b\", true]) }"))
+        expect<InvalidInputValueException>("Cannot coerce '\"b\"' to Int") {
+            schema.executeBlocking("{ NullableSet(value: [1, \"b\", true]) }")
         }
     }
 
     @Test
     fun `foo should not be valid for a nullable set of Int`() {
-        expect<InvalidInputValueException>("Cannot coerce \"foo\" to numeric constant") {
-            deserialize(schema.executeBlocking("{ RequiredSet(value: \"foo\") }"))
+        expect<InvalidInputValueException>("Cannot coerce '\"foo\"' to Int") {
+            schema.executeBlocking("{ RequiredSet(value: \"foo\") }")
         }
     }
 
@@ -161,15 +161,15 @@ class ListInputCoercionTest {
 
     @Test
     fun `a non-nested list should not be valid for a nullable nested set of Int`() {
-        expect<InvalidInputValueException>("argument '1' is not valid value of type List") {
-            deserialize(schema.executeBlocking("{ NullableNestedSet(value: [1, 2, 3]) }"))
+        expect<InvalidInputValueException>("Cannot coerce '1' to List") {
+            schema.executeBlocking("{ NullableNestedSet(value: [1, 2, 3]) }")
         }
     }
 
     @Test
     fun `null should not be valid for a required set of Int`() {
-        expect<InvalidInputValueException>("argument 'null' is not valid value of type Int") {
-            deserialize(schema.executeBlocking("{ RequiredSet(value: null) }"))
+        expect<InvalidInputValueException>("Cannot coerce 'null' to Int") {
+            schema.executeBlocking("{ RequiredSet(value: null) }")
         }
     }
 

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/QueryDocumentSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/QueryDocumentSpecificationTest.kt
@@ -27,14 +27,14 @@ class QueryDocumentSpecificationTest {
     @Test
     fun `anonymous operation must be the only defined operation`() {
         expect<ValidationException>("Anonymous operation must be the only defined operation") {
-            deserialize(schema.executeBlocking("query {fizz} mutation BUZZ {createActor(name : \"Kurt Russel\"){name}}"))
+            schema.executeBlocking("query {fizz} mutation BUZZ {createActor(name : \"Kurt Russel\"){name}}")
         }
     }
 
     @Test
     fun `must provide operation name when multiple named operations`() {
         expect<ValidationException>("Must provide an operation name from: [FIZZ, BUZZ], found: null") {
-            deserialize(schema.executeBlocking("query FIZZ {fizz} mutation BUZZ {createActor(name : \"Kurt Russel\"){name}}"))
+            schema.executeBlocking("query FIZZ {fizz} mutation BUZZ {createActor(name : \"Kurt Russel\"){name}}")
         }
     }
 

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/SourceTextSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/SourceTextSpecificationTest.kt
@@ -29,7 +29,7 @@ class SourceTextSpecificationTest {
     @Test
     fun `invalid unicode character`() {
         expect<InvalidSyntaxException>("Syntax Error: Cannot contain the invalid character \"\\u0003\".") {
-            deserialize(schema.executeBlocking("\u0003"))
+            schema.executeBlocking("\u0003")
         }
     }
 
@@ -98,11 +98,11 @@ class SourceTextSpecificationTest {
     @Specification("2.1.9 Names")
     fun `names should be case sensitive`() {
         expect<ValidationException>("Property 'FIZZ' on 'Query' does not exist") {
-            deserialize(schema.executeBlocking("{FIZZ}"))
+            schema.executeBlocking("{FIZZ}")
         }
 
         expect<ValidationException>("Property 'Fizz' on 'Query' does not exist") {
-            deserialize(schema.executeBlocking("{Fizz}"))
+            schema.executeBlocking("{Fizz}")
         }
 
         val mapLowerCase = deserialize(schema.executeBlocking("{fizz}"))

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/VariablesSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/VariablesSpecificationTest.kt
@@ -45,8 +45,11 @@ class VariablesSpecificationTest : BaseSchemaTest() {
 
     @Test
     fun `query with int variable should not allow floating point numbers that are not whole`() {
-        expect<InvalidInputValueException>("Cannot coerce 1.01 to numeric constant") {
-            execute(query = "query(\$rank: Int!) {filmByRank(rank: \$rank) {title}}", variables = "{\"rank\": 1.01}")
+        expect<InvalidInputValueException>("Cannot coerce '1.01' to Int") {
+            testedSchema.executeBlocking(
+                request = "query(\$rank: Int!) {filmByRank(rank: \$rank) {title}}",
+                variables = "{\"rank\": 1.01}"
+            )
         }
     }
 
@@ -62,9 +65,9 @@ class VariablesSpecificationTest : BaseSchemaTest() {
 
     @Test
     fun `query with custom int scalar variable should not allow floating point numbers that are not whole`() {
-        expect<InvalidInputValueException>("argument '1.01' is not valid value of type Rank") {
-            execute(
-                query = "query(\$rank: Rank!) {filmByCustomRank(rank: \$rank) {title}}",
+        expect<InvalidInputValueException>("Cannot coerce '1.01' to Rank") {
+            testedSchema.executeBlocking(
+                request = "query(\$rank: Rank!) {filmByCustomRank(rank: \$rank) {title}}",
                 variables = "{\"rank\": 1.01}"
             )
         }
@@ -84,9 +87,9 @@ class VariablesSpecificationTest : BaseSchemaTest() {
 
     @Test
     fun `query with long variable should not allow floating point numbers that are not whole`() {
-        expect<InvalidInputValueException>("Cannot coerce 1.01 to numeric constant") {
-            execute(
-                query = "query(\$rank: Long!) {filmByRankLong(rank: \$rank) {title}}",
+        expect<InvalidInputValueException>("Cannot coerce '1.01' to Long") {
+            testedSchema.executeBlocking(
+                request = "query(\$rank: Long!) {filmByRankLong(rank: \$rank) {title}}",
                 variables = "{\"rank\": 1.01}"
             )
         }
@@ -106,9 +109,9 @@ class VariablesSpecificationTest : BaseSchemaTest() {
 
     @Test
     fun `query with short variable should not allow floating point numbers that are not whole`() {
-        expect<InvalidInputValueException>("Cannot coerce 1.01 to numeric constant") {
-            execute(
-                query = "query(\$rank: Short!) {filmByRankShort(rank: \$rank) {title}}",
+        expect<InvalidInputValueException>("Cannot coerce '1.01' to Short") {
+            testedSchema.executeBlocking(
+                request = "query(\$rank: Short!) {filmByRankShort(rank: \$rank) {title}}",
                 variables = "{\"rank\": 1.01}"
             )
         }
@@ -160,15 +163,21 @@ class VariablesSpecificationTest : BaseSchemaTest() {
 
     @Test
     fun `query with boolean variable and variable default value but explicit null provided`() {
-        expect<InvalidInputValueException>("argument 'null' is not valid value of type Boolean") {
-            execute(query = "query(\$big: Boolean = true) {number(big: \$big)}", variables = "{\"big\": null}")
+        expect<InvalidInputValueException>("Cannot coerce 'null' to Boolean") {
+            testedSchema.executeBlocking(
+                request = "query(\$big: Boolean = true) {number(big: \$big)}",
+                variables = "{\"big\": null}"
+            )
         }
     }
 
     @Test
     fun `query with boolean variable and location default value but explicit null provided`() {
-        expect<InvalidInputValueException>("argument 'null' is not valid value of type Boolean") {
-            execute(query = "query(\$big: Boolean) {bigNumber(big: \$big)}", variables = "{\"big\": null}")
+        expect<InvalidInputValueException>("Cannot coerce 'null' to Boolean") {
+            testedSchema.executeBlocking(
+                request = "query(\$big: Boolean) {bigNumber(big: \$big)}",
+                variables = "{\"big\": null}"
+            )
         }
     }
 
@@ -188,9 +197,9 @@ class VariablesSpecificationTest : BaseSchemaTest() {
 
     @Test
     fun `query with list variable and variable default value but explicit null list provided`() {
-        expect<InvalidInputValueException>("argument 'null' is not valid value of type String") {
-            execute(
-                query = "query(\$tags: [String] = []) {actorsByTags(tags: \$tags) { name }}",
+        expect<InvalidInputValueException>("Cannot coerce 'null' to String") {
+            testedSchema.executeBlocking(
+                request = "query(\$tags: [String] = []) {actorsByTags(tags: \$tags) { name }}",
                 variables = "{\"tags\": null}"
             )
         }
@@ -198,9 +207,9 @@ class VariablesSpecificationTest : BaseSchemaTest() {
 
     @Test
     fun `query with list variable and variable default value but explicit null element provided`() {
-        expect<InvalidInputValueException>("argument 'null' is not valid value of type String") {
-            execute(
-                query = "query(\$tags: [String] = []) {actorsByTags(tags: \$tags) { name }}",
+        expect<InvalidInputValueException>("Cannot coerce 'null' to String") {
+            testedSchema.executeBlocking(
+                request = "query(\$tags: [String] = []) {actorsByTags(tags: \$tags) { name }}",
                 variables = "{\"tags\": [null]}"
             )
         }
@@ -208,15 +217,15 @@ class VariablesSpecificationTest : BaseSchemaTest() {
 
     @Test
     fun `query with list variable and location default value but explicit null list provided`() {
-        expect<InvalidInputValueException>("argument 'null' is not valid value of type String") {
-            execute(query = "query(\$tags: [String] = null) {actorsByTags(tags: \$tags) { name }}")
+        expect<InvalidInputValueException>("Cannot coerce 'null' to String") {
+            testedSchema.executeBlocking(request = "query(\$tags: [String] = null) {actorsByTags(tags: \$tags) { name }}")
         }
     }
 
     @Test
     fun `query with list variable and location default value but explicit null element provided`() {
-        expect<InvalidInputValueException>("argument 'null' is not valid value of type String") {
-            execute(query = "query(\$tags: [String] = [null]) {actorsByTags(tags: \$tags) { name }}")
+        expect<InvalidInputValueException>("Cannot coerce 'null' to String") {
+            testedSchema.executeBlocking(request = "query(\$tags: [String] = [null]) {actorsByTags(tags: \$tags) { name }}")
         }
     }
 
@@ -247,7 +256,7 @@ class VariablesSpecificationTest : BaseSchemaTest() {
     fun `fragment with variable`() {
         val result = execute(
             query = "mutation(\$name: String = \"Boguś Linda\", \$age : Int!, \$big: Boolean!) {createActor(name: \$name, age: \$age){...Linda}}" +
-                "fragment Linda on Actor {picture(big: \$big)}",
+                    "fragment Linda on Actor {picture(big: \$big)}",
             variables = "{\"age\": 22, \"big\": true}"
         )
         assertNoErrors(result)
@@ -257,9 +266,9 @@ class VariablesSpecificationTest : BaseSchemaTest() {
     @Test
     fun `fragment with missing variable`() {
         expect<ValidationException>("Variable '\$big' was not declared for this operation") {
-            execute(
-                query = "mutation(\$name: String = \"Boguś Linda\", \$age : Int!) {createActor(name: \$name, age: \$age){...Linda}}" +
-                    "fragment Linda on Actor {picture(big: \$big)}",
+            testedSchema.executeBlocking(
+                request = "mutation(\$name: String = \"Boguś Linda\", \$age : Int!) {createActor(name: \$name, age: \$age){...Linda}}" +
+                        "fragment Linda on Actor {picture(big: \$big)}",
                 variables = "{\"age\": 22}"
             )
         }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/DirectivesSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/DirectivesSpecificationTest.kt
@@ -83,7 +83,7 @@ class DirectivesSpecificationTest : BaseSchemaTest() {
     @Test
     fun `missing directive should result in an error`() {
         expect<ValidationException>("Directive 'nonExisting' does not exist") {
-            execute("{film{title year @nonExisting}}")
+            testedSchema.executeBlocking("{film{title year @nonExisting}}")
         }
     }
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/EnumsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/EnumsSpecificationTest.kt
@@ -32,7 +32,7 @@ class EnumsSpecificationTest {
 
     @Test
     fun `string literals must not be accepted as an enum input`() {
-        expect<InvalidInputValueException>("String literal '\"COOL\"' is invalid value for enum type Coolness") {
+        expect<InvalidInputValueException>("Cannot coerce string literal '\"COOL\"' to enum Coolness") {
             schema.executeBlocking("{cool(cool : \"COOL\")}")
         }
     }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/ListsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/ListsSpecificationTest.kt
@@ -62,7 +62,7 @@ class ListsSpecificationTest {
             { "list": ["GAGA", null, "DADA", "PADA"] }
         """.trimIndent()
 
-        expect<InvalidInputValueException>("argument 'null' is not valid value of type String") {
+        expect<InvalidInputValueException>("Cannot coerce 'null' to String") {
             schema.executeBlocking("query(\$list: [String!]!) { list(list: \$list) }", variables)
         }
     }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/NonNullSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/NonNullSpecificationTest.kt
@@ -51,7 +51,7 @@ class NonNullSpecificationTest {
                 resolver { input: String -> input }
             }
         }
-        expect<ValidationException>("Missing value for non-nullable argument input on the field 'nonNull'") {
+        expect<ValidationException>("Missing value for non-nullable argument 'input' on the field 'nonNull'") {
             schema.executeBlocking("{nonNull}")
         }
     }
@@ -64,7 +64,7 @@ class NonNullSpecificationTest {
             }
         }
 
-        expect<InvalidInputValueException>("Invalid variable ${'$'}arg argument type String, expected String!\n") {
+        expect<InvalidInputValueException>("Invalid variable '${'$'}arg' argument type 'String', expected 'String!'\n") {
             schema.executeBlocking("query(\$arg: String){nonNull(input: \$arg)}", "{\"arg\":\"SAD\"}")
         }
     }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/ScalarsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/ScalarsSpecificationTest.kt
@@ -132,7 +132,7 @@ class ScalarsSpecificationTest {
             }
         }
 
-        expect<InvalidInputValueException>("Cannot coerce to type of Int as '${Integer.MAX_VALUE.toLong() + 2L}' is greater than (2^-31)-1") {
+        expect<InvalidInputValueException>("Cannot coerce '${Integer.MAX_VALUE.toLong() + 2L}' to Int as it is greater than (2^-31)-1") {
             schema.executeBlocking("mutation { Int(int: ${Integer.MAX_VALUE.toLong() + 2L}) }")
         }
     }
@@ -156,7 +156,7 @@ class ScalarsSpecificationTest {
         val testedSchema = KGraphQL.schema {
             stringScalar<UUID> {
                 name = "UUID"
-                description = "the unique identifier of object"
+                description = "The unique identifier of object"
                 deserialize = UUID::fromString
                 serialize = UUID::toString
             }
@@ -231,17 +231,17 @@ class ScalarsSpecificationTest {
         """.trimIndent()
 
         // Double (should fail)
-        expect<InvalidInputValueException>("Cannot coerce 4.0 to ID") {
+        expect<InvalidInputValueException>("Cannot coerce '4.0' to ID") {
             testedSchema.executeBlocking("query(\$id: ID! = 4.0) { personById(id: \$id) { id, name } }")
         }
 
         // Boolean (should fail)
-        expect<InvalidInputValueException>("Cannot coerce true to ID") {
+        expect<InvalidInputValueException>("Cannot coerce 'true' to ID") {
             testedSchema.executeBlocking("query(\$id: ID! = true) { personById(id: \$id) { id, name } }")
         }
 
         // List of strings (should fail)
-        expect<InvalidInputValueException>("argument '[\"4\", \"5\"]' is not valid value of type ID") {
+        expect<InvalidInputValueException>("Cannot coerce '[\"4\", \"5\"]' to ID") {
             testedSchema.executeBlocking("query(\$id: ID! = [\"4\", \"5\"]) { personById(id: \$id) { id, name } }")
         }
 
@@ -251,7 +251,7 @@ class ScalarsSpecificationTest {
         }
 
         // Null (should fail)
-        expect<InvalidInputValueException>("argument 'null' is not valid value of type ID") {
+        expect<InvalidInputValueException>("Cannot coerce 'null' to ID") {
             testedSchema.executeBlocking("query(\$id: ID! = null) { personById(id: \$id) { id, name } }")
         }
 
@@ -272,7 +272,7 @@ class ScalarsSpecificationTest {
             }
         }
 
-        expect<InvalidInputValueException>("Cannot coerce \"223\" to numeric constant") {
+        expect<InvalidInputValueException>("Cannot coerce '\"223\"' to Int") {
             schema.executeBlocking("mutation { Int(int: \"223\") }")
         }
     }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/UnionsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/UnionsSpecificationTest.kt
@@ -64,7 +64,7 @@ class UnionsSpecificationTest : BaseSchemaTest() {
     @Test
     fun `query union property with invalid selection set`() {
         expect<ValidationException>("Invalid selection set with properties: [name] on union type property favourite : [Actor, Scenario, Director]") {
-            execute("{actors{name, favourite{ name }}}")
+            testedSchema.executeBlocking("{actors{name, favourite{ name }}}")
         }
     }
 
@@ -117,7 +117,7 @@ class UnionsSpecificationTest : BaseSchemaTest() {
     @Test
     fun `a union type should require a selection for all potential types`() {
         expect<ValidationException>("Missing selection set for type 'Scenario'") {
-            execute(
+            testedSchema.executeBlocking(
                 """{
                 actors {
                     name
@@ -153,9 +153,9 @@ class UnionsSpecificationTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `Non nullable union types should fail`() {
-        expect<ExecutionException>("Unexpected type of union property value, expected one of [Actor, Scenario, Director] but was null") {
-            execute(
+    fun `non-nullable union types should fail`() {
+        expect<ExecutionException>("Unexpected type of union property value, expected one of [Actor, Scenario, Director] but was 'null'") {
+            testedSchema.executeBlocking(
                 """{
                     actors(all: true) {
                         name


### PR DESCRIPTION
- Improve formatting
- Improve error messages by adding single quotes around dynamic values (leftovers from #445)
- Clarify error messages of some coercions by mentioning the specific expected type (leftovers from #445): ``` Old: "Cannot coerce 1.5 to numeric constant" New: "Cannot coerce '1.5' to Int" ```
- Align wording of similar errors (leftovers from #445): ``` Old: "foo does not represent valid Boolean value" New: "Cannot coerce 'foo' to Boolean"

  Old: "argument 'null' is not valid value of type ID" New: "Cannot coerce 'null' to ID ```
- Fix wording of Short coercion errors (leftovers from #445): ``` Old: "Cannot coerce to type of Int as 'value' is greater than..." New: "Cannot coerce 'value' to Short as it is greater than..." ```
- Reduce visibility of some functions that were not supposed to be `public`
- Preserve `originalError` as `cause` in `GraphQLError`
- Make `FragmentsSpecificationTest` extend `BaseSchemaTest` as well
- Remove deserialization in tests that expect an exception anyway