### PR TITLE
feat: support `Char` scalars

### DIFF
--- a/docs/content/Reference/Type System/scalars.md
+++ b/docs/content/Reference/Type System/scalars.md
@@ -36,8 +36,8 @@ correct subtype of `com.apurebase.kgraphql.schema.scalar.ScalarCoercion`:
     }
     ```
 
-In addition to the built-in scalars, KGraphQL provides support for `Long` and `Short` which can be added to a schema
-using `extendedScalars()`.
+In addition to the built-in scalars, KGraphQL provides support for `Long`, `Short`, and `Char` which can be added to
+a schema using `extendedScalars()`.
 
 === "Example"
     ```kotlin

--- a/kgraphql/api/kgraphql.api
+++ b/kgraphql/api/kgraphql.api
@@ -240,6 +240,14 @@ public final class com/apurebase/kgraphql/schema/builtin/BuiltInScalars : java/l
 	public static fun values ()[Lcom/apurebase/kgraphql/schema/builtin/BuiltInScalars;
 }
 
+public final class com/apurebase/kgraphql/schema/builtin/CHAR_COERCION : com/apurebase/kgraphql/schema/scalar/StringScalarCoercion {
+	public static final field INSTANCE Lcom/apurebase/kgraphql/schema/builtin/CHAR_COERCION;
+	public synthetic fun deserialize (Ljava/lang/Object;Lcom/apurebase/kgraphql/schema/model/ast/ValueNode;)Ljava/lang/Object;
+	public fun deserialize (Ljava/lang/String;Lcom/apurebase/kgraphql/schema/model/ast/ValueNode;)Ljava/lang/Character;
+	public fun serialize (C)Ljava/lang/String;
+	public synthetic fun serialize (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
 public final class com/apurebase/kgraphql/schema/builtin/DOUBLE_COERCION : com/apurebase/kgraphql/schema/scalar/StringScalarCoercion {
 	public static final field INSTANCE Lcom/apurebase/kgraphql/schema/builtin/DOUBLE_COERCION;
 	public synthetic fun deserialize (Ljava/lang/Object;Lcom/apurebase/kgraphql/schema/model/ast/ValueNode;)Ljava/lang/Object;
@@ -249,6 +257,7 @@ public final class com/apurebase/kgraphql/schema/builtin/DOUBLE_COERCION : com/a
 }
 
 public final class com/apurebase/kgraphql/schema/builtin/ExtendedBuiltInScalars : java/lang/Enum {
+	public static final field CHAR Lcom/apurebase/kgraphql/schema/builtin/ExtendedBuiltInScalars;
 	public static final field LONG Lcom/apurebase/kgraphql/schema/builtin/ExtendedBuiltInScalars;
 	public static final field SHORT Lcom/apurebase/kgraphql/schema/builtin/ExtendedBuiltInScalars;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/builtin/BuiltInScalars.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/builtin/BuiltInScalars.kt
@@ -22,6 +22,8 @@ private const val INT_DESCRIPTION = "The Int scalar type represents a signed 32-
 
 private const val LONG_DESCRIPTION = "The Long scalar type represents a signed 64-bit numeric non-fractional value"
 
+private const val CHAR_DESCRIPTION = "The Char scalar type represents a 16-bit Unicode character"
+
 private const val FLOAT_DESCRIPTION =
     "The Float scalar type represents signed double-precision fractional values as specified by IEEE 754"
 
@@ -54,7 +56,8 @@ enum class BuiltInScalars(val typeDef: TypeDef.Scalar<*>) {
 
 enum class ExtendedBuiltInScalars(val typeDef: TypeDef.Scalar<*>) {
     SHORT(TypeDef.Scalar(Short::class.defaultKQLTypeName(), Short::class, SHORT_COERCION, SHORT_DESCRIPTION)),
-    LONG(TypeDef.Scalar(Long::class.defaultKQLTypeName(), Long::class, LONG_COERCION, LONG_DESCRIPTION))
+    LONG(TypeDef.Scalar(Long::class.defaultKQLTypeName(), Long::class, LONG_COERCION, LONG_DESCRIPTION)),
+    CHAR(TypeDef.Scalar(Char::class.defaultKQLTypeName(), Char::class, CHAR_COERCION, CHAR_DESCRIPTION))
 }
 
 object STRING_COERCION : StringScalarCoercion<String> {
@@ -173,5 +176,18 @@ object ID_COERCION : StringScalarCoercion<ID> {
         is NumberValueNode -> ID(valueNode.value.toString())
 
         else -> throw InvalidInputValueException("Cannot coerce '${valueNode.valueNodeName}' to ID", valueNode)
+    }
+}
+
+object CHAR_COERCION : StringScalarCoercion<Char> {
+    override fun serialize(instance: Char): String = instance.toString()
+
+    override fun deserialize(raw: String, valueNode: ValueNode) = when {
+        valueNode is StringValueNode && valueNode.value.length == 1 -> valueNode.value[0]
+        valueNode is NumberValueNode && valueNode.value.toInt() >= Char.MIN_VALUE.code && valueNode.value.toInt() <= Char.MAX_VALUE.code -> Char(
+            valueNode.value.toInt()
+        )
+
+        else -> throw InvalidInputValueException("Cannot coerce '${valueNode.valueNodeName}' to Char", valueNode)
     }
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaPrinterTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/schema/SchemaPrinterTest.kt
@@ -611,6 +611,9 @@ class SchemaPrinterTest {
               subscription: Subscription
             }
             
+            "The Char scalar type represents a 16-bit Unicode character"
+            scalar Char
+
             "The Long scalar type represents a signed 64-bit numeric non-fractional value"
             scalar Long
 

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/ScalarsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/typesystem/ScalarsSpecificationTest.kt
@@ -67,6 +67,14 @@ class ScalarsSpecificationTest {
                 }
             }
         }
+
+        expect<SchemaException>("Unable to handle 'query(\"char\")': An object type must define one or more fields. Found none on type 'Char'") {
+            KGraphQL.schema {
+                query("char") {
+                    resolver<Char> { Char(65) }
+                }
+            }
+        }
     }
 
     @Test
@@ -79,11 +87,15 @@ class ScalarsSpecificationTest {
             query("short") {
                 resolver<Short> { 2.toShort() }
             }
+            query("char") {
+                resolver<Char> { Char(65) }
+            }
         }
 
-        val response = deserialize(schema.executeBlocking("{ long short }"))
+        val response = deserialize(schema.executeBlocking("{ long short char }"))
         response.extract<Long>("data/long") shouldBe 9223372036854775807L
         response.extract<Int>("data/short") shouldBe 2
+        response.extract<Char>("data/char") shouldBe "A"
     }
 
     data class Person(val uuid: UUID, val name: String)


### PR DESCRIPTION
Adds support for the `Char` type as extended scalar. The `Char` type represents a 16-bit Unicode character.

Coercion supports strings of length 1 and integers between 0 and 65535.