### PR TITLE
refactor!: split up `__Described` interface

### DIFF
--- a/kgraphql/api/kgraphql.api
+++ b/kgraphql/api/kgraphql.api
@@ -901,6 +901,14 @@ public final class com/apurebase/kgraphql/schema/execution/TypeCondition {
 	public final fun getOnType ()Lcom/apurebase/kgraphql/schema/structure/Type;
 }
 
+public abstract interface class com/apurebase/kgraphql/schema/introspection/Describable {
+	public abstract fun getDescription ()Ljava/lang/String;
+}
+
+public abstract interface class com/apurebase/kgraphql/schema/introspection/Named {
+	public abstract fun getName ()Ljava/lang/String;
+}
+
 public abstract interface annotation class com/apurebase/kgraphql/schema/introspection/NotIntrospected : java/lang/annotation/Annotation {
 }
 
@@ -936,26 +944,21 @@ public final class com/apurebase/kgraphql/schema/introspection/TypeKind : java/l
 	public static fun values ()[Lcom/apurebase/kgraphql/schema/introspection/TypeKind;
 }
 
-public abstract interface class com/apurebase/kgraphql/schema/introspection/__Described {
-	public abstract fun getDescription ()Ljava/lang/String;
-	public abstract fun getName ()Ljava/lang/String;
-}
-
-public abstract interface class com/apurebase/kgraphql/schema/introspection/__Directive : com/apurebase/kgraphql/schema/introspection/__Described {
+public abstract interface class com/apurebase/kgraphql/schema/introspection/__Directive : com/apurebase/kgraphql/schema/introspection/Describable, com/apurebase/kgraphql/schema/introspection/Named {
 	public abstract fun getArgs ()Ljava/util/List;
 	public abstract fun getLocations ()Ljava/util/List;
 	public abstract fun isRepeatable ()Z
 }
 
-public abstract interface class com/apurebase/kgraphql/schema/introspection/__EnumValue : com/apurebase/kgraphql/schema/introspection/__Described, com/apurebase/kgraphql/schema/model/Depreciable {
+public abstract interface class com/apurebase/kgraphql/schema/introspection/__EnumValue : com/apurebase/kgraphql/schema/introspection/Describable, com/apurebase/kgraphql/schema/introspection/Named, com/apurebase/kgraphql/schema/model/Depreciable {
 }
 
-public abstract interface class com/apurebase/kgraphql/schema/introspection/__Field : com/apurebase/kgraphql/schema/introspection/__Described, com/apurebase/kgraphql/schema/model/Depreciable {
+public abstract interface class com/apurebase/kgraphql/schema/introspection/__Field : com/apurebase/kgraphql/schema/introspection/Describable, com/apurebase/kgraphql/schema/introspection/Named, com/apurebase/kgraphql/schema/model/Depreciable {
 	public abstract fun getArgs ()Ljava/util/List;
 	public abstract fun getType ()Lcom/apurebase/kgraphql/schema/introspection/__Type;
 }
 
-public abstract interface class com/apurebase/kgraphql/schema/introspection/__InputValue : com/apurebase/kgraphql/schema/introspection/__Described, com/apurebase/kgraphql/schema/model/Depreciable {
+public abstract interface class com/apurebase/kgraphql/schema/introspection/__InputValue : com/apurebase/kgraphql/schema/introspection/Describable, com/apurebase/kgraphql/schema/introspection/Named, com/apurebase/kgraphql/schema/model/Depreciable {
 	public abstract fun getDefaultValue ()Ljava/lang/String;
 	public abstract fun getType ()Lcom/apurebase/kgraphql/schema/introspection/__Type;
 }
@@ -968,8 +971,7 @@ public abstract interface class com/apurebase/kgraphql/schema/introspection/__Sc
 	public abstract fun getTypes ()Ljava/util/List;
 }
 
-public abstract interface class com/apurebase/kgraphql/schema/introspection/__Type {
-	public abstract fun getDescription ()Ljava/lang/String;
+public abstract interface class com/apurebase/kgraphql/schema/introspection/__Type : com/apurebase/kgraphql/schema/introspection/Describable {
 	public abstract fun getEnumValues ()Ljava/util/List;
 	public abstract fun getFields ()Ljava/util/List;
 	public abstract fun getInputFields ()Ljava/util/List;

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/SchemaPrinter.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/SchemaPrinter.kt
@@ -2,8 +2,9 @@ package com.apurebase.kgraphql.schema
 
 import com.apurebase.kgraphql.request.isIntrospectionType
 import com.apurebase.kgraphql.schema.directive.Directive
+import com.apurebase.kgraphql.schema.introspection.Describable
+import com.apurebase.kgraphql.schema.introspection.Named
 import com.apurebase.kgraphql.schema.introspection.TypeKind
-import com.apurebase.kgraphql.schema.introspection.__Described
 import com.apurebase.kgraphql.schema.introspection.__Directive
 import com.apurebase.kgraphql.schema.introspection.__InputValue
 import com.apurebase.kgraphql.schema.introspection.__Schema
@@ -254,8 +255,7 @@ class SchemaPrinter(private val config: SchemaPrinterConfig = SchemaPrinterConfi
             ?.joinToString(separator = " & ", prefix = " implements ") ?: ""
 
     private fun Any.description(): String? = when (this) {
-        is __Described -> description?.takeIf { it.isNotBlank() }
-        is __Type -> description?.takeIf { it.isNotBlank() }
+        is Describable -> description?.takeIf { it.isNotBlank() }
         else -> null
     }
 
@@ -309,7 +309,7 @@ class SchemaPrinter(private val config: SchemaPrinterConfig = SchemaPrinterConfi
     private fun List<__Type>?.sortedByName() =
         orEmpty().sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.name.toString() })
 
-    @JvmName("sortedDescribedByName")
-    private fun <T : __Described> List<T>?.sortedByName() =
+    @JvmName("sortedByName")
+    private fun <T : Named> List<T>?.sortedByName() =
         orEmpty().sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.name })
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/introspection/Describable.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/introspection/Describable.kt
@@ -1,7 +1,5 @@
 package com.apurebase.kgraphql.schema.introspection
 
-interface __Described {
-    val name: String
-
+interface Describable {
     val description: String?
 }

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/introspection/Named.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/introspection/Named.kt
@@ -1,0 +1,5 @@
+package com.apurebase.kgraphql.schema.introspection
+
+interface Named {
+    val name: String
+}

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/introspection/__Directive.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/introspection/__Directive.kt
@@ -2,7 +2,7 @@ package com.apurebase.kgraphql.schema.introspection
 
 import com.apurebase.kgraphql.schema.directive.DirectiveLocation
 
-interface __Directive : __Described {
+interface __Directive : Describable, Named {
 
     val locations: List<DirectiveLocation>
 

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/introspection/__EnumValue.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/introspection/__EnumValue.kt
@@ -2,4 +2,4 @@ package com.apurebase.kgraphql.schema.introspection
 
 import com.apurebase.kgraphql.schema.model.Depreciable
 
-interface __EnumValue : Depreciable, __Described
+interface __EnumValue : Depreciable, Describable, Named

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/introspection/__Field.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/introspection/__Field.kt
@@ -2,7 +2,7 @@ package com.apurebase.kgraphql.schema.introspection
 
 import com.apurebase.kgraphql.schema.model.Depreciable
 
-interface __Field : Depreciable, __Described {
+interface __Field : Depreciable, Describable, Named {
 
     val type: __Type
 

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/introspection/__InputValue.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/introspection/__InputValue.kt
@@ -2,7 +2,7 @@ package com.apurebase.kgraphql.schema.introspection
 
 import com.apurebase.kgraphql.schema.model.Depreciable
 
-interface __InputValue : Depreciable, __Described {
+interface __InputValue : Depreciable, Describable, Named {
 
     val type: __Type
 

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/introspection/__Type.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/introspection/__Type.kt
@@ -4,10 +4,9 @@ package com.apurebase.kgraphql.schema.introspection
  * GraphQL introspection system defines __Type to represent all of TypeKinds
  * If some field does not apply to given type, it returns null
  */
-interface __Type {
+interface __Type : Describable {
     val kind: TypeKind
     val name: String?
-    val description: String?
 
     // OBJECT and INTERFACE only
     val fields: List<__Field>?


### PR DESCRIPTION
Splits up the `__Described` interface into `Describable` for the description part, and `Named` for the name part. Also removes the `__` prefix because those are marker interfaces and not introspection types.

BREAKING CHANGE: `__Described` interface no longer exists, and is replaced by `Describable` and `Named`.