### PR TITLE
fix: coerce single values to lists

### DIFF
--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/ArgumentTransformer.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/ArgumentTransformer.kt
@@ -125,7 +125,7 @@ open class ArgumentTransformer(val genericTypeResolver: GenericTypeResolver) {
                         paramType,
                         valueField.value,
                         variables,
-                        coerceSingleValueAsList,
+                        coerceSingleValueAsList = true,
                         locationDefaultValue
                     )
                 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/ListInputCoercionTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/specification/language/ListInputCoercionTest.kt
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.Test
 @Specification("3.11 List", "3.12 Non-Null")
 // See also ListsSpecificationTest
 class ListInputCoercionTest {
+    data class ListWrapper(val innerValue: List<Int>)
+
     private val schema = defaultSchema {
         query("NullableList") { resolver { value: List<Int?>? -> value } }
         query("NullableNestedList") { resolver { value: List<List<Int?>?>? -> value } }
@@ -20,6 +22,7 @@ class ListInputCoercionTest {
         query("NullableNestedSet") { resolver { value: Set<Set<Int?>?>? -> value } }
         query("NullableNestedSetListSet") { resolver { value: Set<List<Set<Int?>?>?>? -> value } }
         query("RequiredSet") { resolver { value: Set<Int?> -> value } }
+        query("RequiredListInObjectInList") { resolver { value: List<ListWrapper> -> value } }
     }
 
     @Test
@@ -183,5 +186,23 @@ class ListInputCoercionTest {
     fun `a list with null value should be valid for a required set of Int`() {
         val response = deserialize(schema.executeBlocking("{ RequiredSet(value: [1, 2, null]) }"))
         response.extract<List<Int?>>("data/RequiredSet") shouldBe listOf(1, 2, null)
+    }
+
+    @Test
+    fun `list argument inside object inside list should accept list value`() {
+        val response = deserialize(schema.executeBlocking("{ RequiredListInObjectInList(value: [{innerValue: [1]}]) { innerValue } }"))
+        response.extract<List<Map<String, List<Int>>>>("data/RequiredListInObjectInList") shouldBe listOf(mapOf("innerValue" to listOf(1)))
+    }
+
+    @Test
+    fun `list argument inside object inside list should coerce single value to list`() {
+        val response = deserialize(schema.executeBlocking("{ RequiredListInObjectInList(value: [{innerValue: 1}]) { innerValue } }"))
+        response.extract<List<Map<String, List<Int>>>>("data/RequiredListInObjectInList") shouldBe listOf(mapOf("innerValue" to listOf(1)))
+    }
+
+    @Test
+    fun `single value and single object should be coerced to list`() {
+        val response = deserialize(schema.executeBlocking("{ RequiredListInObjectInList(value: {innerValue: 1}) { innerValue } }"))
+        response.extract<List<Map<String, List<Int>>>>("data/RequiredListInObjectInList") shouldBe listOf(mapOf("innerValue" to listOf(1)))
     }
 }


### PR DESCRIPTION
Allows the ArgumentTransformer to coerce single values for a list into a list, even when the object itself is in a list.

The limitations to not coerce nested lists (3.1.1 in the spec) should not be applied, when two lists aren't directly nested, but there are object in between. For example `[{someObjectsInnerList: 1}]` should be coerced to `[{someObjectsInnerList: [1]}]`

Maybe related to #112 