### PR TITLE
feat: provide proper path in errors

### DIFF
--- a/docs/content/Plugins/ktor.md
+++ b/docs/content/Plugins/ktor.md
@@ -107,8 +107,8 @@ but you can override it to map specific exception types to `GraphQLError` or oth
     ```kotlin
     errorHandler { e ->
         when (e) {
-            is ValidationException -> GraphQLError(e.message, extensions = mapOf("type" to "VALIDATION_ERROR"))
-            is DomainException -> GraphQLError(e.message, extensions = mapOf("type" to "DOMAIN_ERROR"))
+            is ValidationException -> RequestError(e.message, extensions = mapOf("type" to "VALIDATION_ERROR"))
+            is DomainException -> RequestError(e.message, extensions = mapOf("type" to "DOMAIN_ERROR"))
             is GraphQLError -> e
             else -> ExecutionException(e.message ?: "Unknown execution error", cause = e)
         }

--- a/docs/content/Reference/errorHandling.md
+++ b/docs/content/Reference/errorHandling.md
@@ -6,21 +6,22 @@ Error handling is currently implemented in a basic way only, and does for exampl
 
 When an exception occurs, request execution is aborted and results in an error response depending on the type of exception.
 
-Exceptions that extend `GraphQLError` will be mapped to a response that contains an `errors` key:
+Exceptions that extend `GraphQLError` via either `RequestError` or `ExecutionError` will be mapped to a response that contains
+an `errors` key with optional `locations` and `path` keys detailing where it occurred.
+Sub classes can also provide arbitrary `extensions`, by default an error `type` will be added:
 
 === "Example"
     ```json
     {
         "errors": [
             {
-                "message": "Property nonexisting on MyType does not exist",
+                "message": "Property 'nonexisting' on 'MyType' does not exist",
                 "locations": [
                     {
-                        "line": 2,
-                        "column": 13
+                        "line": 3,
+                        "column": 1
                     }
                 ],
-                "path": [],
                 "extensions": {
                     "type": "GRAPHQL_VALIDATION_FAILED"
                 }
@@ -65,7 +66,6 @@ With `wrapErrors = true` (which is the default), exceptions are wrapped as `Exec
                         "column": 1
                     }
                 ],
-                "path": [],
                 "extensions": {
                     "type": "INTERNAL_SERVER_ERROR"
                 }

--- a/docs/content/Reference/errorHandling.md
+++ b/docs/content/Reference/errorHandling.md
@@ -66,6 +66,9 @@ With `wrapErrors = true` (which is the default), exceptions are wrapped as `Exec
                         "column": 1
                     }
                 ],
+                "path": [
+                    "throwError"
+                ],
                 "extensions": {
                     "type": "INTERNAL_SERVER_ERROR"
                 }

--- a/kgraphql-ktor-stitched/api/kgraphql-ktor-stitched.api
+++ b/kgraphql-ktor-stitched/api/kgraphql-ktor-stitched.api
@@ -1,4 +1,4 @@
-public final class com/apurebase/kgraphql/stitched/RemoteExecutionException : com/apurebase/kgraphql/GraphQLError {
+public final class com/apurebase/kgraphql/stitched/RemoteExecutionException : com/apurebase/kgraphql/ExecutionError {
 	public fun <init> (Ljava/lang/String;Lcom/apurebase/kgraphql/schema/execution/Execution$Remote;)V
 }
 

--- a/kgraphql-ktor-stitched/src/main/kotlin/com/apurebase/kgraphql/stitched/RemoteExecutionException.kt
+++ b/kgraphql-ktor-stitched/src/main/kotlin/com/apurebase/kgraphql/stitched/RemoteExecutionException.kt
@@ -1,15 +1,15 @@
 package com.apurebase.kgraphql.stitched
 
 import com.apurebase.kgraphql.BuiltInErrorCodes
+import com.apurebase.kgraphql.ExecutionError
 import com.apurebase.kgraphql.ExperimentalAPI
-import com.apurebase.kgraphql.GraphQLError
 import com.apurebase.kgraphql.schema.execution.Execution
 
 // TODO: support multiple remote errors
 @ExperimentalAPI
-class RemoteExecutionException(message: String, node: Execution.Remote) : GraphQLError(
+class RemoteExecutionException(message: String, node: Execution.Remote) : ExecutionError(
     message = message,
-    nodes = listOf(node.selectionNode),
+    node = node,
     extensions = mapOf(
         "type" to BuiltInErrorCodes.INTERNAL_SERVER_ERROR.name,
         "detail" to mapOf("remoteUrl" to node.remoteUrl, "remoteOperation" to node.remoteOperation)

--- a/kgraphql-ktor-stitched/src/main/kotlin/com/apurebase/kgraphql/stitched/schema/execution/AbstractRemoteRequestExecutor.kt
+++ b/kgraphql-ktor-stitched/src/main/kotlin/com/apurebase/kgraphql/stitched/schema/execution/AbstractRemoteRequestExecutor.kt
@@ -17,7 +17,10 @@ import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.IntNode
+import com.fasterxml.jackson.databind.node.LongNode
 import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.databind.node.TextNode
 
 @ExperimentalAPI
 abstract class AbstractRemoteRequestExecutor(private val objectMapper: ObjectMapper) : RemoteRequestExecutor {
@@ -42,7 +45,6 @@ abstract class AbstractRemoteRequestExecutor(private val objectMapper: ObjectMap
             """.trimIndent()
         }
         val responseJson = objectMapper.readTree(response)
-        // TODO: properly transfer errors from the remote execution
         responseJson["errors"]?.let { errors ->
             (errors as? ArrayNode)?.forEach { error ->
                 val objectNode = error as? ObjectNode
@@ -50,12 +52,33 @@ abstract class AbstractRemoteRequestExecutor(private val objectMapper: ObjectMap
                     ?: "Error(s) during remote execution"
                 val extensionsNode = objectNode?.get("extensions") as? ObjectNode
                 val extensions = mapOf("remoteUrl" to node.remoteUrl, "remoteOperation" to node.remoteOperation) +
-                    extensionsNode?.let {
-                        objectMapper.convertValue(it, object : TypeReference<Map<String, Any?>>() {})
-                    }.orEmpty()
+                        extensionsNode?.let {
+                            objectMapper.convertValue(it, object : TypeReference<Map<String, Any?>>() {})
+                        }.orEmpty()
+                // Build a custom node for the remote error that includes the returned path
+                val executionErrorNode = object : Execution.Node(
+                    node.selectionNode,
+                    node.field,
+                    node.children,
+                    node.arguments,
+                    node.directives,
+                    node.variables,
+                    node.arrayIndex,
+                    node
+                ) {
+                    // The first path segment of the remote error is the executed query. As this is transparent from our
+                    // stitched schema, we need to remove that segment for a proper path.
+                    override val fullPath: List<Any> = node.fullPath + ((objectNode?.get("path") as? ArrayNode)?.map {
+                        when (it) {
+                            is IntNode, is LongNode -> it.longValue()
+                            is TextNode -> it.textValue()
+                            else -> it.toString()
+                        }
+                    }?.drop(1) ?: emptyList())
+                }
                 throw ExecutionError(
                     message = message,
-                    node = node,
+                    node = executionErrorNode,
                     extensions = extensions
                 )
             }

--- a/kgraphql-ktor-stitched/src/main/kotlin/com/apurebase/kgraphql/stitched/schema/execution/AbstractRemoteRequestExecutor.kt
+++ b/kgraphql-ktor-stitched/src/main/kotlin/com/apurebase/kgraphql/stitched/schema/execution/AbstractRemoteRequestExecutor.kt
@@ -1,8 +1,8 @@
 package com.apurebase.kgraphql.stitched.schema.execution
 
 import com.apurebase.kgraphql.Context
+import com.apurebase.kgraphql.ExecutionError
 import com.apurebase.kgraphql.ExperimentalAPI
-import com.apurebase.kgraphql.GraphQLError
 import com.apurebase.kgraphql.GraphqlRequest
 import com.apurebase.kgraphql.request.Variables
 import com.apurebase.kgraphql.schema.execution.Execution
@@ -53,9 +53,9 @@ abstract class AbstractRemoteRequestExecutor(private val objectMapper: ObjectMap
                     extensionsNode?.let {
                         objectMapper.convertValue(it, object : TypeReference<Map<String, Any?>>() {})
                     }.orEmpty()
-                throw GraphQLError(
+                throw ExecutionError(
                     message = message,
-                    nodes = listOf(node.selectionNode),
+                    node = node,
                     extensions = extensions
                 )
             }

--- a/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/execution/StitchedSchemaExecutionTest.kt
+++ b/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/execution/StitchedSchemaExecutionTest.kt
@@ -3021,7 +3021,7 @@ class StitchedSchemaExecutionTest {
     }
 
     @Test
-    fun `errors from remote execution should be propagated correctly`() = testApplication {
+    fun `error responses from remote execution should be propagated correctly`() = testApplication {
         data class LocalType(val name: String)
         data class RemoteType(val localName: String, val name: String)
 
@@ -3124,28 +3124,85 @@ class StitchedSchemaExecutionTest {
             header(HttpHeaders.ContentType, ContentType.Application.Json)
             setBody(graphqlRequest("{ failLocal }"))
         }.bodyAsText() shouldBe """
-            {"errors":[{"message":"don't call me local!","locations":[{"line":1,"column":3}],"extensions":{"type":"INTERNAL_SERVER_ERROR","detail":{"localErrorKey":"localErrorValue"}}}]}
+            {"errors":[{"message":"don't call me local!","locations":[{"line":1,"column":3}],"path":["failLocal"],"extensions":{"type":"INTERNAL_SERVER_ERROR","detail":{"localErrorKey":"localErrorValue"}}}]}
         """.trimIndent()
 
         client.post("local") {
             header(HttpHeaders.ContentType, ContentType.Application.Json)
             setBody(graphqlRequest("{ failRemote }"))
         }.bodyAsText() shouldBe """
-            {"errors":[{"message":"don't call me remote!","locations":[{"line":1,"column":3}],"extensions":{"remoteUrl":"remote","remoteOperation":"failRemote","type":"BAD_USER_INPUT","remoteErrorKey":["remoteErrorValue1","remoteErrorValue2"]}}]}
+            {"errors":[{"message":"don't call me remote!","locations":[{"line":1,"column":3}],"path":["failRemote"],"extensions":{"remoteUrl":"remote","remoteOperation":"failRemote","type":"BAD_USER_INPUT","remoteErrorKey":["remoteErrorValue1","remoteErrorValue2"]}}]}
         """.trimIndent()
 
         client.post("local") {
             header(HttpHeaders.ContentType, ContentType.Application.Json)
             setBody(graphqlRequest("{ failRemote2 }"))
         }.bodyAsText() shouldBe """
-            {"errors":[{"message":"Error(s) during remote execution","locations":[{"line":1,"column":3}],"extensions":{"remoteUrl":"remote","remoteOperation":"failRemote2","type":"INTERNAL_SERVER_ERROR"}}]}
+            {"errors":[{"message":"Error(s) during remote execution","locations":[{"line":1,"column":3}],"path":["failRemote2"],"extensions":{"remoteUrl":"remote","remoteOperation":"failRemote2","type":"INTERNAL_SERVER_ERROR"}}]}
         """.trimIndent()
 
         client.post("local") {
             header(HttpHeaders.ContentType, ContentType.Application.Json)
             setBody(graphqlRequest("{ localTypes { name stitchedProperty { name localName problematic } } }"))
         }.bodyAsText() shouldBe """
-            {"errors":[{"message":"Error(s) during remote execution","locations":[{"line":1,"column":21}],"extensions":{"remoteUrl":"remote","remoteOperation":"failRemoteObject","type":"INTERNAL_SERVER_ERROR"}}]}
+            {"errors":[{"message":"Error(s) during remote execution","locations":[{"line":1,"column":21}],"path":["localTypes",0,"stitchedProperty",1,"problematic"],"extensions":{"remoteUrl":"remote","remoteOperation":"failRemoteObject","type":"INTERNAL_SERVER_ERROR"}}]}
+        """.trimIndent()
+    }
+
+    @Test
+    fun `errors from remote execution should be propagated correctly`() = testApplication {
+        data class LocalType(val name: String)
+
+        fun SchemaBuilder.remoteSchema() = run {
+            query("remoteString") {
+                resolver<String?> { -> "remoteString" }
+            }
+        }
+        install(GraphQL.FeatureInstance("KGraphql - Remote")) {
+            endpoint = "remote"
+            schema {
+                remoteSchema()
+            }
+        }
+        install(StitchedGraphQL.FeatureInstance("KGraphql - Local")) {
+            endpoint = "local"
+            stitchedSchema {
+                configure {
+                    remoteExecutor = TestBrokenRemoteRequestExecutor(objectMapper)
+                }
+                localSchema {
+                    query("localString") {
+                        resolver { -> "localString" }
+                    }
+                    query("localTypes") {
+                        resolver { -> listOf(LocalType("local1")) }
+                    }
+                }
+                remoteSchema("remote") {
+                    getRemoteSchema {
+                        remoteSchema()
+                    }
+                }
+                type("LocalType") {
+                    stitchedProperty("stitchedProperty") {
+                        remoteQuery("remoteString")
+                    }
+                }
+            }
+        }
+
+        client.post("local") {
+            header(HttpHeaders.ContentType, ContentType.Application.Json)
+            setBody(graphqlRequest("{ remoteString }"))
+        }.bodyAsText() shouldBe """
+            {"errors":[{"message":"Connection timed out","locations":[{"line":1,"column":3}],"path":["remoteString"],"extensions":{"remoteUrl":"remote","remoteOperation":"remoteString"}}]}
+        """.trimIndent()
+
+        client.post("local") {
+            header(HttpHeaders.ContentType, ContentType.Application.Json)
+            setBody(graphqlRequest("{ localTypes { name stitchedProperty } }"))
+        }.bodyAsText() shouldBe """
+            {"errors":[{"message":"Connection timed out","locations":[{"line":1,"column":21}],"path":["localTypes",0,"stitchedProperty"],"extensions":{"remoteUrl":"remote","remoteOperation":"remoteString"}}]}
         """.trimIndent()
     }
 

--- a/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/execution/StitchedSchemaExecutionTest.kt
+++ b/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/execution/StitchedSchemaExecutionTest.kt
@@ -1,11 +1,12 @@
 package com.apurebase.kgraphql.stitched.schema.execution
 
 import com.apurebase.kgraphql.BuiltInErrorCodes
+import com.apurebase.kgraphql.ExecutionError
 import com.apurebase.kgraphql.ExperimentalAPI
 import com.apurebase.kgraphql.GraphQL
-import com.apurebase.kgraphql.GraphQLError
 import com.apurebase.kgraphql.GraphqlRequest
 import com.apurebase.kgraphql.schema.dsl.SchemaBuilder
+import com.apurebase.kgraphql.schema.execution.Execution
 import com.apurebase.kgraphql.stitched.StitchedGraphQL
 import com.apurebase.kgraphql.stitched.getRemoteSchema
 import com.apurebase.kgraphql.stitched.schema.structure.StitchedSchemaTest.Face
@@ -1930,7 +1931,7 @@ class StitchedSchemaExecutionTest {
                 )
             )
         }.bodyAsText() shouldBe """
-            {"errors":[{"message":"Property 'nonexisting' on 'Remote2' does not exist","locations":[{"line":2,"column":13}],"path":[],"extensions":{"type":"GRAPHQL_VALIDATION_FAILED"}}]}
+            {"errors":[{"message":"Property 'nonexisting' on 'Remote2' does not exist","locations":[{"line":2,"column":13}],"extensions":{"type":"GRAPHQL_VALIDATION_FAILED"}}]}
         """.trimIndent()
     }
 
@@ -3021,11 +3022,15 @@ class StitchedSchemaExecutionTest {
 
     @Test
     fun `errors from remote execution should be propagated correctly`() = testApplication {
+        data class LocalType(val name: String)
+        data class RemoteType(val localName: String, val name: String)
+
         fun SchemaBuilder.remoteSchema() = run {
             query("failRemote") {
-                resolver<String> {
-                    throw GraphQLError(
+                resolver<String, Execution.Node> { node: Execution.Node ->
+                    throw ExecutionError(
                         message = "don't call me remote!",
+                        node = node,
                         extensions = mapOf(
                             "type" to BuiltInErrorCodes.BAD_USER_INPUT.name,
                             "remoteErrorKey" to listOf(
@@ -3039,6 +3044,25 @@ class StitchedSchemaExecutionTest {
             query("failRemote2") {
                 resolver<String> {
                     throw IllegalStateException()
+                }
+            }
+            query("failRemoteObject") {
+                resolver { localName: String ->
+                    listOf(
+                        RemoteType(localName, "remoteObject1"),
+                        RemoteType(localName, "remoteObject2")
+                    )
+                }
+            }
+            type<RemoteType> {
+                property("problematic") {
+                    resolver { parent: RemoteType ->
+                        if (parent.localName == "local1" && parent.name == "remoteObject2") {
+                            throw Exception()
+                        } else {
+                            "unproblematic"
+                        }
+                    }
                 }
             }
         }
@@ -3056,9 +3080,10 @@ class StitchedSchemaExecutionTest {
                 }
                 localSchema {
                     query("failLocal") {
-                        resolver<String> {
-                            throw GraphQLError(
+                        resolver<String, Execution.Node> { node: Execution.Node ->
+                            throw ExecutionError(
                                 message = "don't call me local!",
+                                node = node,
                                 extensions = mapOf(
                                     "type" to BuiltInErrorCodes.INTERNAL_SERVER_ERROR.name,
                                     "detail" to mapOf("localErrorKey" to "localErrorValue")
@@ -3066,10 +3091,20 @@ class StitchedSchemaExecutionTest {
                             )
                         }
                     }
+                    query("localTypes") {
+                        resolver { -> listOf(LocalType("local1"), LocalType("local2")) }
+                    }
                 }
                 remoteSchema("remote") {
                     getRemoteSchema {
                         remoteSchema()
+                    }
+                }
+                type("LocalType") {
+                    stitchedProperty("stitchedProperty") {
+                        remoteQuery("failRemoteObject").withArgs {
+                            arg { name = "localName"; parentFieldName = "name" }
+                        }
                     }
                 }
             }
@@ -3080,7 +3115,7 @@ class StitchedSchemaExecutionTest {
             header(HttpHeaders.ContentType, ContentType.Application.Json)
             setBody(graphqlRequest("{ failSyntax }"))
         }.bodyAsText() shouldBe """
-            {"errors":[{"message":"Property 'failSyntax' on 'Query' does not exist","locations":[{"line":1,"column":3}],"path":[],"extensions":{"type":"GRAPHQL_VALIDATION_FAILED"}}]}
+            {"errors":[{"message":"Property 'failSyntax' on 'Query' does not exist","locations":[{"line":1,"column":3}],"extensions":{"type":"GRAPHQL_VALIDATION_FAILED"}}]}
         """.trimIndent()
 
         // Query that failed during execution
@@ -3089,27 +3124,31 @@ class StitchedSchemaExecutionTest {
             header(HttpHeaders.ContentType, ContentType.Application.Json)
             setBody(graphqlRequest("{ failLocal }"))
         }.bodyAsText() shouldBe """
-            {"errors":[{"message":"don't call me local!","locations":[],"path":[],"extensions":{"type":"INTERNAL_SERVER_ERROR","detail":{"localErrorKey":"localErrorValue"}}}]}
+            {"errors":[{"message":"don't call me local!","locations":[{"line":1,"column":3}],"extensions":{"type":"INTERNAL_SERVER_ERROR","detail":{"localErrorKey":"localErrorValue"}}}]}
         """.trimIndent()
 
         client.post("local") {
             header(HttpHeaders.ContentType, ContentType.Application.Json)
             setBody(graphqlRequest("{ failRemote }"))
         }.bodyAsText() shouldBe """
-            {"errors":[{"message":"don't call me remote!","locations":[{"line":1,"column":3}],"path":[],"extensions":{"remoteUrl":"remote","remoteOperation":"failRemote","type":"BAD_USER_INPUT","remoteErrorKey":["remoteErrorValue1","remoteErrorValue2"]}}]}
+            {"errors":[{"message":"don't call me remote!","locations":[{"line":1,"column":3}],"extensions":{"remoteUrl":"remote","remoteOperation":"failRemote","type":"BAD_USER_INPUT","remoteErrorKey":["remoteErrorValue1","remoteErrorValue2"]}}]}
         """.trimIndent()
 
         client.post("local") {
             header(HttpHeaders.ContentType, ContentType.Application.Json)
             setBody(graphqlRequest("{ failRemote2 }"))
         }.bodyAsText() shouldBe """
-            {"errors":[{"message":"Error(s) during remote execution","locations":[{"line":1,"column":3}],"path":[],"extensions":{"remoteUrl":"remote","remoteOperation":"failRemote2","type":"INTERNAL_SERVER_ERROR"}}]}
+            {"errors":[{"message":"Error(s) during remote execution","locations":[{"line":1,"column":3}],"extensions":{"remoteUrl":"remote","remoteOperation":"failRemote2","type":"INTERNAL_SERVER_ERROR"}}]}
+        """.trimIndent()
+
+        client.post("local") {
+            header(HttpHeaders.ContentType, ContentType.Application.Json)
+            setBody(graphqlRequest("{ localTypes { name stitchedProperty { name localName problematic } } }"))
+        }.bodyAsText() shouldBe """
+            {"errors":[{"message":"Error(s) during remote execution","locations":[{"line":1,"column":21}],"extensions":{"remoteUrl":"remote","remoteOperation":"failRemoteObject","type":"INTERNAL_SERVER_ERROR"}}]}
         """.trimIndent()
     }
 
     private fun graphqlRequest(query: String, variables: JsonObject? = null): String =
         encodeToString<GraphqlRequest>(GraphqlRequest(query = query, variables = variables))
 }
-
-// TODO:
-//  test some error cases (like field validation on remote properties etc)

--- a/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/execution/TestRemoteRequestExecutor.kt
+++ b/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/execution/TestRemoteRequestExecutor.kt
@@ -5,6 +5,7 @@ import com.apurebase.kgraphql.ExperimentalAPI
 import com.apurebase.kgraphql.stitched.StitchedGraphqlRequest
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.ktor.client.HttpClient
+import io.ktor.client.network.sockets.SocketTimeoutException
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
@@ -19,4 +20,10 @@ class TestRemoteRequestExecutor(private val client: HttpClient, val objectMapper
             contentType(ContentType.Application.Json)
             setBody(objectMapper.writeValueAsString(request))
         }.bodyAsText()
+}
+
+@OptIn(ExperimentalAPI::class)
+class TestBrokenRemoteRequestExecutor(objectMapper: ObjectMapper) : AbstractRemoteRequestExecutor(objectMapper) {
+    override suspend fun executeRequest(url: String, request: StitchedGraphqlRequest, ctx: Context): String =
+        throw SocketTimeoutException("Connection timed out")
 }

--- a/kgraphql-ktor/src/test/kotlin/com/apurebase/kgraphql/KtorFeatureTest.kt
+++ b/kgraphql-ktor/src/test/kotlin/com/apurebase/kgraphql/KtorFeatureTest.kt
@@ -56,6 +56,8 @@ class KtorFeatureTest : KtorTest() {
 
     data class Actor(val name: String, val age: Int)
     data class UserData(val username: String, val stuff: String)
+    data class Movie(val title: String, val actors: List<Actor>)
+    data class Person(val name: String, val age: Int, val favouriteMovie: Movie)
 
     @Test
     fun `Simple context test`() {
@@ -106,6 +108,7 @@ class KtorFeatureTest : KtorTest() {
         }
     }
 
+    @Suppress("unused")
     enum class MockEnum { M1, M2 }
 
     data class InputOne(val enum: MockEnum, val id: String)
@@ -143,7 +146,7 @@ class KtorFeatureTest : KtorTest() {
     }
 
     @Test
-    fun `Error response test`() {
+    fun `request error response test`() {
         val server = withServer {
             query("actor") {
                 resolver { -> Actor("George", 23) }
@@ -157,7 +160,76 @@ class KtorFeatureTest : KtorTest() {
         }
         runBlocking {
             response.bodyAsText() shouldBe """
-                {"errors":[{"message":"Property 'nickname' on 'Actor' does not exist","locations":[{"line":3,"column":1}],"path":[],"extensions":{"type":"GRAPHQL_VALIDATION_FAILED"}}]}
+                {"errors":[{"message":"Property 'nickname' on 'Actor' does not exist","locations":[{"line":3,"column":1}],"extensions":{"type":"GRAPHQL_VALIDATION_FAILED"}}]}
+            """.trimIndent()
+            response.contentType() shouldBe ContentType.Application.Json
+        }
+    }
+
+    @Test
+    fun `execution error response test`() {
+        val server = withServer {
+            type<Actor> {
+                property("nickname") {
+                    resolver { actor: Actor ->
+                        require(actor.age <= 30) { "Actors above 30 don't have nicknames" }
+                        actor.name.first().toString()
+                    }
+                }
+            }
+            query("actors") {
+                resolver { -> listOf(Actor("George", 23), Actor("John", 42), Actor("Jack", 21)) }
+            }
+        }
+
+        val response = server("query") {
+            field("actors") {
+                field("nickname")
+            }
+        }
+        runBlocking {
+            response.bodyAsText() shouldBe """
+                {"errors":[{"message":"Actors above 30 don't have nicknames","locations":[{"line":3,"column":1}],"extensions":{"type":"INTERNAL_SERVER_ERROR"}}]}
+            """.trimIndent()
+            response.contentType() shouldBe ContentType.Application.Json
+        }
+    }
+
+    @Test
+    fun `nested execution error response test`() {
+        val server = withServer {
+            type<Actor> {
+                property("nickname") {
+                    resolver { actor: Actor ->
+                        require(actor.age <= 30) { "Actors above 30 don't have nicknames" }
+                        actor.name.first().toString()
+                    }
+                }
+            }
+            query("persons") {
+                resolver { ->
+                    listOf(
+                        Person("Mary", 32, Movie("Sharks", listOf(Actor("George", 23), Actor("Jack", 21)))),
+                        Person("Jimmy", 11, Movie("Unknown", listOf(Actor("John", 42))))
+                    )
+                }
+            }
+        }
+
+        val response = server("query") {
+            field("persons") {
+                field("name")
+                field("favouriteMovie") {
+                    field("actors") {
+                        field("name")
+                        field("nickname")
+                    }
+                }
+            }
+        }
+        runBlocking {
+            response.bodyAsText() shouldBe """
+                {"errors":[{"message":"Actors above 30 don't have nicknames","locations":[{"line":9,"column":1}],"extensions":{"type":"INTERNAL_SERVER_ERROR"}}]}
             """.trimIndent()
             response.contentType() shouldBe ContentType.Application.Json
         }
@@ -183,7 +255,13 @@ class KtorFeatureTest : KtorTest() {
 
     @Test
     fun `should work with error handler`() {
-        val errorHandler: (Throwable) -> GraphQLError = { e -> GraphQLError(message = e.message ?: "unknown") }
+        val errorHandler: (Throwable) -> GraphQLError = { e ->
+            RequestError(
+                message = e.message ?: "unknown",
+                node = null,
+                extensions = mapOf("type" to BuiltInErrorCodes.INTERNAL_SERVER_ERROR.name)
+            )
+        }
 
         val server = withServer(errorHandler = errorHandler) {
             query("error") {
@@ -195,7 +273,7 @@ class KtorFeatureTest : KtorTest() {
             field("error")
         }
         runBlocking {
-            response.bodyAsText() shouldBe "{\"errors\":[{\"message\":\"Error message\",\"locations\":[],\"path\":[],\"extensions\":{\"type\":\"INTERNAL_SERVER_ERROR\"}}]}"
+            response.bodyAsText() shouldBe "{\"errors\":[{\"message\":\"Error message\",\"extensions\":{\"type\":\"INTERNAL_SERVER_ERROR\"}}]}"
             response.contentType() shouldBe ContentType.Application.Json
         }
     }
@@ -212,7 +290,7 @@ class KtorFeatureTest : KtorTest() {
             field("error")
         }
         runBlocking {
-            response.bodyAsText() shouldBe "{\"errors\":[{\"message\":\"Error message\",\"locations\":[{\"line\":2,\"column\":1}],\"path\":[],\"extensions\":{\"type\":\"INTERNAL_SERVER_ERROR\"}}]}"
+            response.bodyAsText() shouldBe "{\"errors\":[{\"message\":\"Error message\",\"locations\":[{\"line\":2,\"column\":1}],\"extensions\":{\"type\":\"INTERNAL_SERVER_ERROR\"}}]}"
             response.contentType() shouldBe ContentType.Application.Json
         }
     }

--- a/kgraphql-ktor/src/test/kotlin/com/apurebase/kgraphql/KtorFeatureTest.kt
+++ b/kgraphql-ktor/src/test/kotlin/com/apurebase/kgraphql/KtorFeatureTest.kt
@@ -189,7 +189,7 @@ class KtorFeatureTest : KtorTest() {
         }
         runBlocking {
             response.bodyAsText() shouldBe """
-                {"errors":[{"message":"Actors above 30 don't have nicknames","locations":[{"line":3,"column":1}],"extensions":{"type":"INTERNAL_SERVER_ERROR"}}]}
+                {"errors":[{"message":"Actors above 30 don't have nicknames","locations":[{"line":3,"column":1}],"path":["actors",1,"nickname"],"extensions":{"type":"INTERNAL_SERVER_ERROR"}}]}
             """.trimIndent()
             response.contentType() shouldBe ContentType.Application.Json
         }
@@ -229,7 +229,7 @@ class KtorFeatureTest : KtorTest() {
         }
         runBlocking {
             response.bodyAsText() shouldBe """
-                {"errors":[{"message":"Actors above 30 don't have nicknames","locations":[{"line":9,"column":1}],"extensions":{"type":"INTERNAL_SERVER_ERROR"}}]}
+                {"errors":[{"message":"Actors above 30 don't have nicknames","locations":[{"line":9,"column":1}],"path":["persons",1,"favouriteMovie","actors",0,"nickname"],"extensions":{"type":"INTERNAL_SERVER_ERROR"}}]}
             """.trimIndent()
             response.contentType() shouldBe ContentType.Application.Json
         }
@@ -290,7 +290,7 @@ class KtorFeatureTest : KtorTest() {
             field("error")
         }
         runBlocking {
-            response.bodyAsText() shouldBe "{\"errors\":[{\"message\":\"Error message\",\"locations\":[{\"line\":2,\"column\":1}],\"extensions\":{\"type\":\"INTERNAL_SERVER_ERROR\"}}]}"
+            response.bodyAsText() shouldBe "{\"errors\":[{\"message\":\"Error message\",\"locations\":[{\"line\":2,\"column\":1}],\"path\":[\"error\"],\"extensions\":{\"type\":\"INTERNAL_SERVER_ERROR\"}}]}"
             response.contentType() shouldBe ContentType.Application.Json
         }
     }

--- a/kgraphql/api/kgraphql.api
+++ b/kgraphql/api/kgraphql.api
@@ -24,22 +24,25 @@ public final class com/apurebase/kgraphql/ContextBuilderKt {
 	public static final fun context (Lkotlin/jvm/functions/Function1;)Lcom/apurebase/kgraphql/Context;
 }
 
-public final class com/apurebase/kgraphql/ExecutionException : com/apurebase/kgraphql/GraphQLError {
+public class com/apurebase/kgraphql/ExecutionError : com/apurebase/kgraphql/GraphQLError {
+	public fun <init> (Ljava/lang/String;Lcom/apurebase/kgraphql/schema/execution/Execution;Ljava/lang/Throwable;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/apurebase/kgraphql/schema/execution/Execution;Ljava/lang/Throwable;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class com/apurebase/kgraphql/ExecutionException : com/apurebase/kgraphql/ExecutionError {
 	public fun <init> (Ljava/lang/String;Lcom/apurebase/kgraphql/schema/execution/Execution;Ljava/lang/Throwable;)V
 	public synthetic fun <init> (Ljava/lang/String;Lcom/apurebase/kgraphql/schema/execution/Execution;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (Ljava/lang/String;Lcom/apurebase/kgraphql/schema/model/ast/ASTNode;Ljava/lang/Throwable;)V
-	public synthetic fun <init> (Ljava/lang/String;Lcom/apurebase/kgraphql/schema/model/ast/ASTNode;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public abstract interface annotation class com/apurebase/kgraphql/ExperimentalAPI : java/lang/annotation/Annotation {
 }
 
-public class com/apurebase/kgraphql/GraphQLError : java/lang/Exception {
-	public fun <init> (Ljava/lang/String;Ljava/util/List;Lcom/apurebase/kgraphql/schema/model/ast/Source;Ljava/util/List;Ljava/lang/Throwable;Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lcom/apurebase/kgraphql/schema/model/ast/Source;Ljava/util/List;Ljava/lang/Throwable;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public abstract class com/apurebase/kgraphql/GraphQLError : java/lang/Exception {
+	public synthetic fun <init> (Ljava/lang/String;Lcom/apurebase/kgraphql/schema/model/ast/ASTNode;Lcom/apurebase/kgraphql/schema/model/ast/Source;Ljava/util/List;Ljava/lang/Throwable;Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getExtensions ()Ljava/util/Map;
 	public final fun getLocations ()Ljava/util/List;
-	public final fun getNodes ()Ljava/util/List;
+	public fun getMessage ()Ljava/lang/String;
+	public final fun getNode ()Lcom/apurebase/kgraphql/schema/model/ast/ASTNode;
 	public final fun getOriginalError ()Ljava/lang/Throwable;
 	public final fun getPositions ()Ljava/util/List;
 	public final fun getSource ()Lcom/apurebase/kgraphql/schema/model/ast/Source;
@@ -47,12 +50,12 @@ public class com/apurebase/kgraphql/GraphQLError : java/lang/Exception {
 	public fun serialize ()Ljava/lang/String;
 }
 
-public final class com/apurebase/kgraphql/InvalidInputValueException : com/apurebase/kgraphql/GraphQLError {
+public final class com/apurebase/kgraphql/InvalidInputValueException : com/apurebase/kgraphql/RequestError {
 	public fun <init> (Ljava/lang/String;Lcom/apurebase/kgraphql/schema/model/ast/ASTNode;Ljava/lang/Throwable;)V
 	public synthetic fun <init> (Ljava/lang/String;Lcom/apurebase/kgraphql/schema/model/ast/ASTNode;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
-public final class com/apurebase/kgraphql/InvalidSyntaxException : com/apurebase/kgraphql/GraphQLError {
+public final class com/apurebase/kgraphql/InvalidSyntaxException : com/apurebase/kgraphql/RequestError {
 	public fun <init> (Ljava/lang/String;Lcom/apurebase/kgraphql/schema/model/ast/Source;Ljava/util/List;)V
 }
 
@@ -65,10 +68,14 @@ public final class com/apurebase/kgraphql/KGraphQL$Companion {
 	public final fun schema (Lkotlin/jvm/functions/Function1;)Lcom/apurebase/kgraphql/schema/Schema;
 }
 
-public final class com/apurebase/kgraphql/ValidationException : com/apurebase/kgraphql/GraphQLError {
+public class com/apurebase/kgraphql/RequestError : com/apurebase/kgraphql/GraphQLError {
+	public fun <init> (Ljava/lang/String;Lcom/apurebase/kgraphql/schema/model/ast/Source;Ljava/util/List;Lcom/apurebase/kgraphql/schema/model/ast/ASTNode;Ljava/lang/Throwable;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/apurebase/kgraphql/schema/model/ast/Source;Ljava/util/List;Lcom/apurebase/kgraphql/schema/model/ast/ASTNode;Ljava/lang/Throwable;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class com/apurebase/kgraphql/ValidationException : com/apurebase/kgraphql/RequestError {
 	public fun <init> (Ljava/lang/String;Lcom/apurebase/kgraphql/schema/model/ast/ASTNode;)V
-	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/apurebase/kgraphql/schema/model/ast/ASTNode;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public abstract interface class com/apurebase/kgraphql/configuration/PluginConfiguration {

--- a/kgraphql/api/kgraphql.api
+++ b/kgraphql/api/kgraphql.api
@@ -27,6 +27,7 @@ public final class com/apurebase/kgraphql/ContextBuilderKt {
 public class com/apurebase/kgraphql/ExecutionError : com/apurebase/kgraphql/GraphQLError {
 	public fun <init> (Ljava/lang/String;Lcom/apurebase/kgraphql/schema/execution/Execution;Ljava/lang/Throwable;Ljava/util/Map;)V
 	public synthetic fun <init> (Ljava/lang/String;Lcom/apurebase/kgraphql/schema/execution/Execution;Ljava/lang/Throwable;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getPath ()Ljava/util/List;
 }
 
 public final class com/apurebase/kgraphql/ExecutionException : com/apurebase/kgraphql/ExecutionError {
@@ -44,6 +45,7 @@ public abstract class com/apurebase/kgraphql/GraphQLError : java/lang/Exception 
 	public fun getMessage ()Ljava/lang/String;
 	public final fun getNode ()Lcom/apurebase/kgraphql/schema/model/ast/ASTNode;
 	public final fun getOriginalError ()Ljava/lang/Throwable;
+	public abstract fun getPath ()Ljava/util/List;
 	public final fun getPositions ()Ljava/util/List;
 	public final fun getSource ()Lcom/apurebase/kgraphql/schema/model/ast/Source;
 	public final fun prettyPrint ()Ljava/lang/String;
@@ -71,6 +73,8 @@ public final class com/apurebase/kgraphql/KGraphQL$Companion {
 public class com/apurebase/kgraphql/RequestError : com/apurebase/kgraphql/GraphQLError {
 	public fun <init> (Ljava/lang/String;Lcom/apurebase/kgraphql/schema/model/ast/Source;Ljava/util/List;Lcom/apurebase/kgraphql/schema/model/ast/ASTNode;Ljava/lang/Throwable;Ljava/util/Map;)V
 	public synthetic fun <init> (Ljava/lang/String;Lcom/apurebase/kgraphql/schema/model/ast/Source;Ljava/util/List;Lcom/apurebase/kgraphql/schema/model/ast/ASTNode;Ljava/lang/Throwable;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getPath ()Ljava/lang/Void;
+	public synthetic fun getPath ()Ljava/util/List;
 }
 
 public final class com/apurebase/kgraphql/ValidationException : com/apurebase/kgraphql/RequestError {

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/GraphQLError.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/GraphQLError.kt
@@ -14,40 +14,44 @@ enum class BuiltInErrorCodes {
     GRAPHQL_PARSE_FAILED, GRAPHQL_VALIDATION_FAILED, BAD_USER_INPUT, INTERNAL_SERVER_ERROR
 }
 
-open class GraphQLError(
+/**
+ * The base class for all GraphQL errors, will either be a [RequestError] or an [ExecutionError].
+ */
+sealed class GraphQLError(
     /**
-     * A message describing the Error for debugging purposes.
+     * A message describing the error intended for the developer as a guide to understand
+     * and correct the error.
      */
-    message: String,
+    override val message: String,
 
     /**
-     * An array of GraphQL AST Nodes corresponding to this error.
+     * GraphQL AST Node corresponding to this error.
      */
-    val nodes: List<ASTNode>? = null,
+    val node: ASTNode?,
 
     /**
      * The source GraphQL document for the first location of this error.
      *
-     * Note that if this Error represents more than one node, the source may not
+     * Note that if this error represents more than one node, the source may not
      * represent nodes after the first node.
      */
-    val source: Source? = null,
+    val source: Source?,
 
     /**
      * An array of character offsets within the source GraphQL document
      * which correspond to this error.
      */
-    val positions: List<Int>? = null,
+    val positions: List<Int>?,
 
     /**
      * The original error thrown from a field resolver during execution.
      */
-    val originalError: Throwable? = null,
+    val originalError: Throwable?,
 
     /**
      * Custom error extensions.
      */
-    open val extensions: Map<String, Any?>? = mapOf("type" to BuiltInErrorCodes.INTERNAL_SERVER_ERROR.name)
+    open val extensions: Map<String, Any?>?
 ) : Exception(message, originalError) {
 
     /**
@@ -60,23 +64,17 @@ open class GraphQLError(
      */
     val locations: List<Source.LocationSource>? by lazy {
         if (positions != null && source != null) {
-            positions.map { pos -> getLocation(source, pos) }
+            positions.map { position -> getLocation(source, position) }
         } else {
-            nodes?.mapNotNull { node ->
-                node.loc?.let { getLocation(it.source, it.start) }
-            }
+            node?.loc?.let { listOf(getLocation(it.source, it.start)) }
         }
     }
 
     fun prettyPrint(): String {
-        var output = message ?: ""
+        var output = message
 
-        if (nodes != null) {
-            for (node in nodes) {
-                if (node.loc != null) {
-                    output += "\n\n" + node.loc!!.printLocation()
-                }
-            }
+        if (node?.loc != null) {
+            output += "\n\n" + node.loc!!.printLocation()
         } else if (source != null && locations != null) {
             for (location in locations!!) {
                 output += "\n\n" + source.print(location)
@@ -90,17 +88,16 @@ open class GraphQLError(
         put("errors", buildJsonArray {
             addJsonObject {
                 put("message", message)
-                put("locations", buildJsonArray {
-                    locations?.forEach {
-                        addJsonObject {
-                            put("line", it.line)
-                            put("column", it.column)
+                locations?.let {
+                    put("locations", buildJsonArray {
+                        it.forEach { location ->
+                            addJsonObject {
+                                put("line", location.line)
+                                put("column", location.column)
+                            }
                         }
-                    }
-                })
-                put("path", buildJsonArray {
-                    // TODO: Build this path. https://spec.graphql.org/June2018/#example-90475
-                })
+                    })
+                }
                 extensions?.let {
                     put("extensions", it.toJsonElement())
                 }
@@ -109,37 +106,82 @@ open class GraphQLError(
     }.toString()
 }
 
-class ExecutionException(message: String, node: ASTNode? = null, cause: Throwable? = null) :
-    GraphQLError(
-        message = message,
-        nodes = node?.let(::listOf),
-        originalError = cause,
-        extensions = mapOf("type" to BuiltInErrorCodes.INTERNAL_SERVER_ERROR.name)
-    ) {
-    constructor(message: String, node: Execution, cause: Throwable? = null) : this(message, node.selectionNode, cause)
-}
+/**
+ * An execution error is an error raised during the execution of a particular field which results in partial response
+ * data. This may occur due to failure to coerce the arguments for the field, an internal error during value resolution,
+ * or failure to coerce the resulting value.
+ *
+ * The result of field execution will be `null` and, if the field is declared as `Non-Null`, bubble up to the next
+ * nullable parent. Partial responses will always contain a "data" entry.
+ *
+ * An execution error is typically the fault of a GraphQL service.
+ *
+ * cf. https://spec.graphql.org/September2025/#execution-error
+ */
+open class ExecutionError(
+    message: String,
+    node: Execution,
+    originalError: Throwable? = null,
+    extensions: Map<String, Any?>? = mapOf("type" to BuiltInErrorCodes.INTERNAL_SERVER_ERROR.name)
+) : GraphQLError(
+    message = message,
+    node = node.selectionNode,
+    source = null,
+    positions = null,
+    originalError = originalError,
+    extensions = extensions
+)
 
-class InvalidInputValueException(message: String, node: ASTNode?, originalError: Throwable? = null) :
-    GraphQLError(
-        message = message,
-        nodes = node?.let(::listOf),
-        originalError = originalError,
-        extensions = mapOf("type" to BuiltInErrorCodes.BAD_USER_INPUT.name)
-    )
+/**
+ * A request error is an error raised during a request which results in no response data. Typically raised before
+ * execution begins, a request error may occur due to a parse grammar or validation error, an inability to determine
+ * which operation to execute, or invalid input values for variables.
+ *
+ * A request error is typically the fault of the requesting client.
+ *
+ * If a request error is raised, request execution will be halted, and the response will not contain a "data" entry.
+ *
+ * cf. https://spec.graphql.org/September2025/#request-error
+ */
+open class RequestError(
+    message: String,
+    source: Source? = null,
+    positions: List<Int>? = null,
+    node: ASTNode? = null,
+    originalError: Throwable? = null,
+    extensions: Map<String, Any?>? = mapOf("type" to BuiltInErrorCodes.BAD_USER_INPUT.name)
+) : GraphQLError(
+    message = message,
+    node = node,
+    source = source,
+    positions = positions,
+    originalError = originalError,
+    extensions = extensions
+)
 
-class InvalidSyntaxException(message: String, source: Source, positions: List<Int>) :
-    GraphQLError(
-        message = message,
-        source = source,
-        positions = positions,
-        extensions = mapOf("type" to BuiltInErrorCodes.GRAPHQL_PARSE_FAILED.name)
-    )
+class ExecutionException(message: String, node: Execution, cause: Throwable? = null) : ExecutionError(
+    message = message,
+    node = node,
+    originalError = cause,
+    extensions = mapOf("type" to BuiltInErrorCodes.INTERNAL_SERVER_ERROR.name)
+)
 
-class ValidationException(message: String, nodes: List<ASTNode>? = null) :
-    GraphQLError(
-        message = message,
-        nodes = nodes,
-        extensions = mapOf("type" to BuiltInErrorCodes.GRAPHQL_VALIDATION_FAILED.name)
-    ) {
-    constructor(message: String, node: ASTNode?) : this(message, node?.let(::listOf))
-}
+class InvalidInputValueException(message: String, node: ASTNode?, originalError: Throwable? = null) : RequestError(
+    message = message,
+    node = node,
+    originalError = originalError,
+    extensions = mapOf("type" to BuiltInErrorCodes.BAD_USER_INPUT.name)
+)
+
+class InvalidSyntaxException(message: String, source: Source, positions: List<Int>) : RequestError(
+    message = message,
+    source = source,
+    positions = positions,
+    extensions = mapOf("type" to BuiltInErrorCodes.GRAPHQL_PARSE_FAILED.name)
+)
+
+class ValidationException(message: String, node: ASTNode? = null) : RequestError(
+    message = message,
+    node = node,
+    extensions = mapOf("type" to BuiltInErrorCodes.GRAPHQL_VALIDATION_FAILED.name)
+)

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/GraphQLError.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/GraphQLError.kt
@@ -5,6 +5,7 @@ import com.apurebase.kgraphql.schema.execution.Execution
 import com.apurebase.kgraphql.schema.model.ast.ASTNode
 import com.apurebase.kgraphql.schema.model.ast.Location.Companion.getLocation
 import com.apurebase.kgraphql.schema.model.ast.Source
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.addJsonObject
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
@@ -70,6 +71,8 @@ sealed class GraphQLError(
         }
     }
 
+    abstract val path: List<Any>?
+
     fun prettyPrint(): String {
         var output = message
 
@@ -95,6 +98,18 @@ sealed class GraphQLError(
                                 put("line", location.line)
                                 put("column", location.column)
                             }
+                        }
+                    })
+                }
+                path?.let { segments ->
+                    put("path", buildJsonArray {
+                        segments.forEach {
+                            val value = when (it) {
+                                is String -> JsonPrimitive(it)
+                                is Number -> JsonPrimitive(it)
+                                else -> JsonPrimitive(it.toString())
+                            }
+                            add(value)
                         }
                     })
                 }
@@ -130,7 +145,11 @@ open class ExecutionError(
     positions = null,
     originalError = originalError,
     extensions = extensions
-)
+) {
+    // https://spec.graphql.org/September2025/#sel-GAPHPHLCAAEDAAR2mH:
+    // "An execution error must occur at a specific response position", so [path] is always present
+    override val path: List<Any> = node.fullPath
+}
 
 /**
  * A request error is an error raised during a request which results in no response data. Typically raised before
@@ -157,7 +176,10 @@ open class RequestError(
     positions = positions,
     originalError = originalError,
     extensions = extensions
-)
+) {
+    // Request errors are raised before execution, so they cannot provide a proper path
+    override val path = null
+}
 
 class ExecutionException(message: String, node: Execution, cause: Throwable? = null) : ExecutionError(
     message = message,

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/request/Variables.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/request/Variables.kt
@@ -14,7 +14,7 @@ data class Variables(private val variablesJson: VariablesJson, private val varia
         if (variable == null) {
             throw ValidationException(
                 "Variable '$${keyNode.name.value}' was not declared for this operation",
-                listOf(keyNode)
+                keyNode
             )
         }
 

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/Validation.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/structure/Validation.kt
@@ -3,7 +3,6 @@ package com.apurebase.kgraphql.schema.structure
 import com.apurebase.kgraphql.ValidationException
 import com.apurebase.kgraphql.schema.SchemaException
 import com.apurebase.kgraphql.schema.introspection.TypeKind
-import com.apurebase.kgraphql.schema.model.ast.ArgumentNode
 import com.apurebase.kgraphql.schema.model.ast.SelectionNode.FieldNode
 import kotlin.reflect.KClass
 import kotlin.reflect.full.isSubclassOf
@@ -11,21 +10,22 @@ import kotlin.reflect.full.isSubclassOf
 private val namePattern = Regex("[_a-zA-Z][_a-zA-Z0-9]*")
 
 internal fun validatePropertyArguments(parentType: Type, field: Field, requestNode: FieldNode) {
-    val argumentValidationExceptions = field.validateArguments(requestNode.arguments, parentType.name)
+    val argumentValidationExceptions = field.validateArguments(requestNode, parentType.name)
 
     if (argumentValidationExceptions.isNotEmpty()) {
         throw ValidationException(argumentValidationExceptions.fold("") { sum, exc ->
             "$sum${exc.message}"
-        }, nodes = argumentValidationExceptions.flatMap { it.nodes ?: listOf() })
+        }, node = requestNode)
     }
 }
 
-private fun Field.validateArguments(selectionArgs: List<ArgumentNode>?, parentTypeName: String?): List<ValidationException> {
+private fun Field.validateArguments(requestNode: FieldNode, parentTypeName: String?): List<ValidationException> {
+    val selectionArgs = requestNode.arguments
     if (!(args.isNotEmpty() || selectionArgs?.isNotEmpty() != true)) {
         return listOf(
             ValidationException(
                 message = "Property '$name' on type '$parentTypeName' has no arguments, found: ${selectionArgs.map { it.name.value }}",
-                nodes = selectionArgs
+                node = requestNode
             )
         )
     }
@@ -71,7 +71,7 @@ internal fun validateUnionRequest(field: Field.Union<*>, selectionNode: FieldNod
                     it.aliasOrName.value
                 }
             } on union type property ${field.name} : ${(field.returnType.unwrapped() as Type.Union).possibleTypes.map { it.name }}",
-            nodes = illegalChildren
+            node = selectionNode
         )
     }
 }

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/GraphQLErrorTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/GraphQLErrorTest.kt
@@ -1,5 +1,10 @@
 package com.apurebase.kgraphql
 
+import com.apurebase.kgraphql.schema.builtin.BuiltInScalars
+import com.apurebase.kgraphql.schema.execution.Execution
+import com.apurebase.kgraphql.schema.model.ast.NameNode
+import com.apurebase.kgraphql.schema.model.ast.SelectionNode
+import com.apurebase.kgraphql.schema.structure.Field
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.json.add
 import kotlinx.serialization.json.addJsonObject
@@ -10,18 +15,42 @@ import org.junit.jupiter.api.Test
 
 class GraphQLErrorTest {
 
+    private val dummyNode = Execution.Node(
+        selectionNode = SelectionNode.FieldNode(
+            parent = null,
+            alias = null,
+            name = NameNode(value = "dummyNode", loc = null),
+            arguments = null,
+            directives = null
+        ),
+        field = Field.Delegated(
+            name = "field",
+            description = null,
+            isDeprecated = false,
+            deprecationReason = null,
+            args = emptyList(),
+            returnType = BuiltInScalars.STRING.typeDef.toScalarType(),
+            argsFromParent = emptyMap()
+        ),
+        children = emptyList(),
+        arguments = null,
+        directives = null,
+        variables = null,
+        arrayIndex = null,
+        parent = null
+    )
+
     @Test
-    fun `graphql error should default to INTERNAL_SERVER_ERROR type`() {
-        val graphqlError = GraphQLError(
-            message = "test"
+    fun `execution error should default to INTERNAL_SERVER_ERROR type`() {
+        val graphqlError = ExecutionError(
+            message = "test",
+            node = dummyNode
         )
 
         val expectedJson = buildJsonObject {
             put("errors", buildJsonArray {
                 addJsonObject {
                     put("message", "test")
-                    put("locations", buildJsonArray {})
-                    put("path", buildJsonArray {})
                     put("extensions", buildJsonObject {
                         put("type", "INTERNAL_SERVER_ERROR")
                     })
@@ -33,9 +62,30 @@ class GraphQLErrorTest {
     }
 
     @Test
+    fun `request error should default to BAD_USER_INPUT type and not have a path key`() {
+        val graphqlError = RequestError(
+            message = "test"
+        )
+
+        val expectedJson = buildJsonObject {
+            put("errors", buildJsonArray {
+                addJsonObject {
+                    put("message", "test")
+                    put("extensions", buildJsonObject {
+                        put("type", "BAD_USER_INPUT")
+                    })
+                }
+            })
+        }.toString()
+
+        graphqlError.serialize() shouldBe expectedJson
+    }
+
+    @Test
     fun `test graphql error with custom extensions`() {
-        val graphqlError = GraphQLError(
+        val graphqlError = ExecutionError(
             message = "test",
+            node = dummyNode,
             extensions = mapOf(
                 "type" to "VALIDATION_ERROR",
                 "listProperty" to listOf("value1", "value2", 3),
@@ -50,8 +100,6 @@ class GraphQLErrorTest {
             put("errors", buildJsonArray {
                 addJsonObject {
                     put("message", "test")
-                    put("locations", buildJsonArray {})
-                    put("path", buildJsonArray {})
                     put("extensions", buildJsonObject {
                         put("type", "VALIDATION_ERROR")
                         put("listProperty", buildJsonArray {

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/GraphQLErrorTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/GraphQLErrorTest.kt
@@ -51,6 +51,9 @@ class GraphQLErrorTest {
             put("errors", buildJsonArray {
                 addJsonObject {
                     put("message", "test")
+                    put("path", buildJsonArray {
+                        add("dummyNode")
+                    })
                     put("extensions", buildJsonObject {
                         put("type", "INTERNAL_SERVER_ERROR")
                     })
@@ -100,6 +103,9 @@ class GraphQLErrorTest {
             put("errors", buildJsonArray {
                 addJsonObject {
                     put("message", "test")
+                    put("path", buildJsonArray {
+                        add("dummyNode")
+                    })
                     put("extensions", buildJsonObject {
                         put("type", "VALIDATION_ERROR")
                         put("listProperty", buildJsonArray {


### PR DESCRIPTION
All GraphQL errors now include a proper path in the response, pointing to the node where it occurred. In combination with partial responses (in a future PR) this allows clients to distinguish `null` values from resolvers from `null` values due to an error.

Resolves #452