### PR TITLE
ci: reduce workflow runs

### DIFF
--- a/.github/workflows/benchmarks-base.yml
+++ b/.github/workflows/benchmarks-base.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**/*'
 
 permissions:
   checks: write

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   coverage:
+    if: github.actor != 'renovate[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**/*'
 
 permissions:
   contents: read


### PR DESCRIPTION
Skips coverage for dependency updates, and no longer runs benchmarks and fossa scan for documentation-only changes.