### PR TITLE
feat: provide proper path in errors

### DIFF
--- a/docs/content/Reference/errorHandling.md
+++ b/docs/content/Reference/errorHandling.md
@@ -66,6 +66,9 @@ With `wrapErrors = true` (which is the default), exceptions are wrapped as `Exec
                         "column": 1
                     }
                 ],
+                "path": [
+                    "throwError"
+                ],
                 "extensions": {
                     "type": "INTERNAL_SERVER_ERROR"
                 }

--- a/kgraphql-ktor-stitched/src/main/kotlin/com/apurebase/kgraphql/stitched/schema/execution/AbstractRemoteRequestExecutor.kt
+++ b/kgraphql-ktor-stitched/src/main/kotlin/com/apurebase/kgraphql/stitched/schema/execution/AbstractRemoteRequestExecutor.kt
@@ -17,7 +17,10 @@ import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.IntNode
+import com.fasterxml.jackson.databind.node.LongNode
 import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.databind.node.TextNode
 
 @ExperimentalAPI
 abstract class AbstractRemoteRequestExecutor(private val objectMapper: ObjectMapper) : RemoteRequestExecutor {
@@ -42,7 +45,6 @@ abstract class AbstractRemoteRequestExecutor(private val objectMapper: ObjectMap
             """.trimIndent()
         }
         val responseJson = objectMapper.readTree(response)
-        // TODO: properly transfer errors from the remote execution
         responseJson["errors"]?.let { errors ->
             (errors as? ArrayNode)?.forEach { error ->
                 val objectNode = error as? ObjectNode
@@ -50,12 +52,33 @@ abstract class AbstractRemoteRequestExecutor(private val objectMapper: ObjectMap
                     ?: "Error(s) during remote execution"
                 val extensionsNode = objectNode?.get("extensions") as? ObjectNode
                 val extensions = mapOf("remoteUrl" to node.remoteUrl, "remoteOperation" to node.remoteOperation) +
-                    extensionsNode?.let {
-                        objectMapper.convertValue(it, object : TypeReference<Map<String, Any?>>() {})
-                    }.orEmpty()
+                        extensionsNode?.let {
+                            objectMapper.convertValue(it, object : TypeReference<Map<String, Any?>>() {})
+                        }.orEmpty()
+                // Build a custom node for the remote error that includes the returned path
+                val executionErrorNode = object : Execution.Node(
+                    node.selectionNode,
+                    node.field,
+                    node.children,
+                    node.arguments,
+                    node.directives,
+                    node.variables,
+                    node.arrayIndex,
+                    node
+                ) {
+                    // The first path segment of the remote error is the executed query. As this is transparent from our
+                    // stitched schema, we need to remove that segment for a proper path.
+                    override val fullPath: List<Any> = node.fullPath + ((objectNode?.get("path") as? ArrayNode)?.map {
+                        when (it) {
+                            is IntNode, is LongNode -> it.longValue()
+                            is TextNode -> it.textValue()
+                            else -> it.toString()
+                        }
+                    }?.drop(1) ?: emptyList())
+                }
                 throw ExecutionError(
                     message = message,
-                    node = node,
+                    node = executionErrorNode,
                     extensions = extensions
                 )
             }

--- a/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/execution/StitchedSchemaExecutionTest.kt
+++ b/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/execution/StitchedSchemaExecutionTest.kt
@@ -3021,7 +3021,7 @@ class StitchedSchemaExecutionTest {
     }
 
     @Test
-    fun `errors from remote execution should be propagated correctly`() = testApplication {
+    fun `error responses from remote execution should be propagated correctly`() = testApplication {
         data class LocalType(val name: String)
         data class RemoteType(val localName: String, val name: String)
 
@@ -3124,28 +3124,85 @@ class StitchedSchemaExecutionTest {
             header(HttpHeaders.ContentType, ContentType.Application.Json)
             setBody(graphqlRequest("{ failLocal }"))
         }.bodyAsText() shouldBe """
-            {"errors":[{"message":"don't call me local!","locations":[{"line":1,"column":3}],"extensions":{"type":"INTERNAL_SERVER_ERROR","detail":{"localErrorKey":"localErrorValue"}}}]}
+            {"errors":[{"message":"don't call me local!","locations":[{"line":1,"column":3}],"path":["failLocal"],"extensions":{"type":"INTERNAL_SERVER_ERROR","detail":{"localErrorKey":"localErrorValue"}}}]}
         """.trimIndent()
 
         client.post("local") {
             header(HttpHeaders.ContentType, ContentType.Application.Json)
             setBody(graphqlRequest("{ failRemote }"))
         }.bodyAsText() shouldBe """
-            {"errors":[{"message":"don't call me remote!","locations":[{"line":1,"column":3}],"extensions":{"remoteUrl":"remote","remoteOperation":"failRemote","type":"BAD_USER_INPUT","remoteErrorKey":["remoteErrorValue1","remoteErrorValue2"]}}]}
+            {"errors":[{"message":"don't call me remote!","locations":[{"line":1,"column":3}],"path":["failRemote"],"extensions":{"remoteUrl":"remote","remoteOperation":"failRemote","type":"BAD_USER_INPUT","remoteErrorKey":["remoteErrorValue1","remoteErrorValue2"]}}]}
         """.trimIndent()
 
         client.post("local") {
             header(HttpHeaders.ContentType, ContentType.Application.Json)
             setBody(graphqlRequest("{ failRemote2 }"))
         }.bodyAsText() shouldBe """
-            {"errors":[{"message":"Error(s) during remote execution","locations":[{"line":1,"column":3}],"extensions":{"remoteUrl":"remote","remoteOperation":"failRemote2","type":"INTERNAL_SERVER_ERROR"}}]}
+            {"errors":[{"message":"Error(s) during remote execution","locations":[{"line":1,"column":3}],"path":["failRemote2"],"extensions":{"remoteUrl":"remote","remoteOperation":"failRemote2","type":"INTERNAL_SERVER_ERROR"}}]}
         """.trimIndent()
 
         client.post("local") {
             header(HttpHeaders.ContentType, ContentType.Application.Json)
             setBody(graphqlRequest("{ localTypes { name stitchedProperty { name localName problematic } } }"))
         }.bodyAsText() shouldBe """
-            {"errors":[{"message":"Error(s) during remote execution","locations":[{"line":1,"column":21}],"extensions":{"remoteUrl":"remote","remoteOperation":"failRemoteObject","type":"INTERNAL_SERVER_ERROR"}}]}
+            {"errors":[{"message":"Error(s) during remote execution","locations":[{"line":1,"column":21}],"path":["localTypes",0,"stitchedProperty",1,"problematic"],"extensions":{"remoteUrl":"remote","remoteOperation":"failRemoteObject","type":"INTERNAL_SERVER_ERROR"}}]}
+        """.trimIndent()
+    }
+
+    @Test
+    fun `errors from remote execution should be propagated correctly`() = testApplication {
+        data class LocalType(val name: String)
+
+        fun SchemaBuilder.remoteSchema() = run {
+            query("remoteString") {
+                resolver<String?> { -> "remoteString" }
+            }
+        }
+        install(GraphQL.FeatureInstance("KGraphql - Remote")) {
+            endpoint = "remote"
+            schema {
+                remoteSchema()
+            }
+        }
+        install(StitchedGraphQL.FeatureInstance("KGraphql - Local")) {
+            endpoint = "local"
+            stitchedSchema {
+                configure {
+                    remoteExecutor = TestBrokenRemoteRequestExecutor(objectMapper)
+                }
+                localSchema {
+                    query("localString") {
+                        resolver { -> "localString" }
+                    }
+                    query("localTypes") {
+                        resolver { -> listOf(LocalType("local1")) }
+                    }
+                }
+                remoteSchema("remote") {
+                    getRemoteSchema {
+                        remoteSchema()
+                    }
+                }
+                type("LocalType") {
+                    stitchedProperty("stitchedProperty") {
+                        remoteQuery("remoteString")
+                    }
+                }
+            }
+        }
+
+        client.post("local") {
+            header(HttpHeaders.ContentType, ContentType.Application.Json)
+            setBody(graphqlRequest("{ remoteString }"))
+        }.bodyAsText() shouldBe """
+            {"errors":[{"message":"Connection timed out","locations":[{"line":1,"column":3}],"path":["remoteString"],"extensions":{"remoteUrl":"remote","remoteOperation":"remoteString"}}]}
+        """.trimIndent()
+
+        client.post("local") {
+            header(HttpHeaders.ContentType, ContentType.Application.Json)
+            setBody(graphqlRequest("{ localTypes { name stitchedProperty } }"))
+        }.bodyAsText() shouldBe """
+            {"errors":[{"message":"Connection timed out","locations":[{"line":1,"column":21}],"path":["localTypes",0,"stitchedProperty"],"extensions":{"remoteUrl":"remote","remoteOperation":"remoteString"}}]}
         """.trimIndent()
     }
 

--- a/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/execution/TestRemoteRequestExecutor.kt
+++ b/kgraphql-ktor-stitched/src/test/kotlin/com/apurebase/kgraphql/stitched/schema/execution/TestRemoteRequestExecutor.kt
@@ -5,6 +5,7 @@ import com.apurebase.kgraphql.ExperimentalAPI
 import com.apurebase.kgraphql.stitched.StitchedGraphqlRequest
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.ktor.client.HttpClient
+import io.ktor.client.network.sockets.SocketTimeoutException
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
@@ -19,4 +20,10 @@ class TestRemoteRequestExecutor(private val client: HttpClient, val objectMapper
             contentType(ContentType.Application.Json)
             setBody(objectMapper.writeValueAsString(request))
         }.bodyAsText()
+}
+
+@OptIn(ExperimentalAPI::class)
+class TestBrokenRemoteRequestExecutor(objectMapper: ObjectMapper) : AbstractRemoteRequestExecutor(objectMapper) {
+    override suspend fun executeRequest(url: String, request: StitchedGraphqlRequest, ctx: Context): String =
+        throw SocketTimeoutException("Connection timed out")
 }

--- a/kgraphql-ktor/src/test/kotlin/com/apurebase/kgraphql/KtorFeatureTest.kt
+++ b/kgraphql-ktor/src/test/kotlin/com/apurebase/kgraphql/KtorFeatureTest.kt
@@ -189,7 +189,7 @@ class KtorFeatureTest : KtorTest() {
         }
         runBlocking {
             response.bodyAsText() shouldBe """
-                {"errors":[{"message":"Actors above 30 don't have nicknames","locations":[{"line":3,"column":1}],"extensions":{"type":"INTERNAL_SERVER_ERROR"}}]}
+                {"errors":[{"message":"Actors above 30 don't have nicknames","locations":[{"line":3,"column":1}],"path":["actors",1,"nickname"],"extensions":{"type":"INTERNAL_SERVER_ERROR"}}]}
             """.trimIndent()
             response.contentType() shouldBe ContentType.Application.Json
         }
@@ -229,7 +229,7 @@ class KtorFeatureTest : KtorTest() {
         }
         runBlocking {
             response.bodyAsText() shouldBe """
-                {"errors":[{"message":"Actors above 30 don't have nicknames","locations":[{"line":9,"column":1}],"extensions":{"type":"INTERNAL_SERVER_ERROR"}}]}
+                {"errors":[{"message":"Actors above 30 don't have nicknames","locations":[{"line":9,"column":1}],"path":["persons",1,"favouriteMovie","actors",0,"nickname"],"extensions":{"type":"INTERNAL_SERVER_ERROR"}}]}
             """.trimIndent()
             response.contentType() shouldBe ContentType.Application.Json
         }
@@ -290,7 +290,7 @@ class KtorFeatureTest : KtorTest() {
             field("error")
         }
         runBlocking {
-            response.bodyAsText() shouldBe "{\"errors\":[{\"message\":\"Error message\",\"locations\":[{\"line\":2,\"column\":1}],\"extensions\":{\"type\":\"INTERNAL_SERVER_ERROR\"}}]}"
+            response.bodyAsText() shouldBe "{\"errors\":[{\"message\":\"Error message\",\"locations\":[{\"line\":2,\"column\":1}],\"path\":[\"error\"],\"extensions\":{\"type\":\"INTERNAL_SERVER_ERROR\"}}]}"
             response.contentType() shouldBe ContentType.Application.Json
         }
     }

--- a/kgraphql/api/kgraphql.api
+++ b/kgraphql/api/kgraphql.api
@@ -27,6 +27,7 @@ public final class com/apurebase/kgraphql/ContextBuilderKt {
 public class com/apurebase/kgraphql/ExecutionError : com/apurebase/kgraphql/GraphQLError {
 	public fun <init> (Ljava/lang/String;Lcom/apurebase/kgraphql/schema/execution/Execution;Ljava/lang/Throwable;Ljava/util/Map;)V
 	public synthetic fun <init> (Ljava/lang/String;Lcom/apurebase/kgraphql/schema/execution/Execution;Ljava/lang/Throwable;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getPath ()Ljava/util/List;
 }
 
 public final class com/apurebase/kgraphql/ExecutionException : com/apurebase/kgraphql/ExecutionError {
@@ -44,6 +45,7 @@ public abstract class com/apurebase/kgraphql/GraphQLError : java/lang/Exception 
 	public fun getMessage ()Ljava/lang/String;
 	public final fun getNode ()Lcom/apurebase/kgraphql/schema/model/ast/ASTNode;
 	public final fun getOriginalError ()Ljava/lang/Throwable;
+	public abstract fun getPath ()Ljava/util/List;
 	public final fun getPositions ()Ljava/util/List;
 	public final fun getSource ()Lcom/apurebase/kgraphql/schema/model/ast/Source;
 	public final fun prettyPrint ()Ljava/lang/String;
@@ -71,6 +73,8 @@ public final class com/apurebase/kgraphql/KGraphQL$Companion {
 public class com/apurebase/kgraphql/RequestError : com/apurebase/kgraphql/GraphQLError {
 	public fun <init> (Ljava/lang/String;Lcom/apurebase/kgraphql/schema/model/ast/Source;Ljava/util/List;Lcom/apurebase/kgraphql/schema/model/ast/ASTNode;Ljava/lang/Throwable;Ljava/util/Map;)V
 	public synthetic fun <init> (Ljava/lang/String;Lcom/apurebase/kgraphql/schema/model/ast/Source;Ljava/util/List;Lcom/apurebase/kgraphql/schema/model/ast/ASTNode;Ljava/lang/Throwable;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getPath ()Ljava/lang/Void;
+	public synthetic fun getPath ()Ljava/util/List;
 }
 
 public final class com/apurebase/kgraphql/ValidationException : com/apurebase/kgraphql/RequestError {

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/GraphQLError.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/GraphQLError.kt
@@ -5,6 +5,7 @@ import com.apurebase.kgraphql.schema.execution.Execution
 import com.apurebase.kgraphql.schema.model.ast.ASTNode
 import com.apurebase.kgraphql.schema.model.ast.Location.Companion.getLocation
 import com.apurebase.kgraphql.schema.model.ast.Source
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.addJsonObject
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
@@ -70,6 +71,8 @@ sealed class GraphQLError(
         }
     }
 
+    abstract val path: List<Any>?
+
     fun prettyPrint(): String {
         var output = message
 
@@ -95,6 +98,18 @@ sealed class GraphQLError(
                                 put("line", location.line)
                                 put("column", location.column)
                             }
+                        }
+                    })
+                }
+                path?.let { segments ->
+                    put("path", buildJsonArray {
+                        segments.forEach {
+                            val value = when (it) {
+                                is String -> JsonPrimitive(it)
+                                is Number -> JsonPrimitive(it)
+                                else -> JsonPrimitive(it.toString())
+                            }
+                            add(value)
                         }
                     })
                 }
@@ -130,7 +145,11 @@ open class ExecutionError(
     positions = null,
     originalError = originalError,
     extensions = extensions
-)
+) {
+    // https://spec.graphql.org/September2025/#sel-GAPHPHLCAAEDAAR2mH:
+    // "An execution error must occur at a specific response position", so [path] is always present
+    override val path: List<Any> = node.fullPath
+}
 
 /**
  * A request error is an error raised during a request which results in no response data. Typically raised before
@@ -157,7 +176,10 @@ open class RequestError(
     positions = positions,
     originalError = originalError,
     extensions = extensions
-)
+) {
+    // Request errors are raised before execution, so they cannot provide a proper path
+    override val path = null
+}
 
 class ExecutionException(message: String, node: Execution, cause: Throwable? = null) : ExecutionError(
     message = message,

--- a/kgraphql/src/test/kotlin/com/apurebase/kgraphql/GraphQLErrorTest.kt
+++ b/kgraphql/src/test/kotlin/com/apurebase/kgraphql/GraphQLErrorTest.kt
@@ -51,6 +51,9 @@ class GraphQLErrorTest {
             put("errors", buildJsonArray {
                 addJsonObject {
                     put("message", "test")
+                    put("path", buildJsonArray {
+                        add("dummyNode")
+                    })
                     put("extensions", buildJsonObject {
                         put("type", "INTERNAL_SERVER_ERROR")
                     })
@@ -100,6 +103,9 @@ class GraphQLErrorTest {
             put("errors", buildJsonArray {
                 addJsonObject {
                     put("message", "test")
+                    put("path", buildJsonArray {
+                        add("dummyNode")
+                    })
                     put("extensions", buildJsonObject {
                         put("type", "VALIDATION_ERROR")
                         put("listProperty", buildJsonArray {


### PR DESCRIPTION
All GraphQL errors now include a proper path in the response, pointing to the node where it occurred. In combination with partial responses (tbd) this allows clients to distinguish `null` values from resolvers from `null` values due to an error.

Resolves #452