### PR TITLE
refactor!: slightly improve scalar coercion

### DIFF
--- a/docs/content/Reference/Type System/scalars.md
+++ b/docs/content/Reference/Type System/scalars.md
@@ -4,7 +4,7 @@ weight: 1
 ---
 
 As defined by specification, scalar represents a primitive value in GraphQL. In KGraphQL, besides built-in scalar types,
-client code can declare custom scalar types, which can coerce to `String`, `Boolean`, `Int`, `Long` or `Float` (`kotlin.Double`).
+client code can declare custom scalar types, which can coerce to `String`, `Boolean`, `Int`, `Long`, `Short` or `Float` (`kotlin.Double`).
 
 KGraphQL provides a group of DSL methods to define scalars:
 
@@ -12,6 +12,7 @@ KGraphQL provides a group of DSL methods to define scalars:
 * `booleanScalar { }`
 * `intScalar { }`
 * `longScalar { }`
+* `shortScalar { }`
 * `floatScalar { }`
 
 They differ only by the Kotlin primitive type they coerce to.

--- a/kgraphql/api/kgraphql.api
+++ b/kgraphql/api/kgraphql.api
@@ -2020,11 +2020,6 @@ public final class com/apurebase/kgraphql/schema/model/ast/VariableDefinitionNod
 public abstract interface class com/apurebase/kgraphql/schema/scalar/BooleanScalarCoercion : com/apurebase/kgraphql/schema/scalar/ScalarCoercion {
 }
 
-public final class com/apurebase/kgraphql/schema/scalar/CoercionKt {
-	public static final fun deserializeScalar (Lcom/apurebase/kgraphql/schema/structure/Type$Scalar;Lcom/apurebase/kgraphql/schema/model/ast/ValueNode;Lcom/apurebase/kgraphql/schema/execution/Execution;)Ljava/lang/Object;
-	public static final fun serializeScalar (Lcom/fasterxml/jackson/databind/node/JsonNodeFactory;Lcom/apurebase/kgraphql/schema/structure/Type$Scalar;Ljava/lang/Object;Lcom/apurebase/kgraphql/schema/execution/Execution;)Lcom/fasterxml/jackson/databind/node/ValueNode;
-}
-
 public abstract interface class com/apurebase/kgraphql/schema/scalar/DoubleScalarCoercion : com/apurebase/kgraphql/schema/scalar/ScalarCoercion {
 }
 

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/ParallelRequestExecutor.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/execution/ParallelRequestExecutor.kt
@@ -280,7 +280,7 @@ class ParallelRequestExecutor(val schema: DefaultSchema) : RequestExecutor {
     private fun <T> createSimpleValueNode(returnType: Type, value: T, node: Execution.Node): JsonNode =
         when (val unwrapped = returnType.unwrapped()) {
             is Type.Scalar<*> -> {
-                serializeScalar(jsonNodeFactory, unwrapped, value, node)
+                serializeScalar(jsonNodeFactory, unwrapped, value)
             }
 
             is Type.Enum<*> -> {

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/scalar/Coercion.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/scalar/Coercion.kt
@@ -1,7 +1,5 @@
 package com.apurebase.kgraphql.schema.scalar
 
-import com.apurebase.kgraphql.ExecutionError
-import com.apurebase.kgraphql.ExecutionException
 import com.apurebase.kgraphql.GraphQLError
 import com.apurebase.kgraphql.InvalidInputValueException
 import com.apurebase.kgraphql.dropQuotes
@@ -21,9 +19,9 @@ private typealias JsonValueNode = com.fasterxml.jackson.databind.node.ValueNode
 
 @Suppress("UNCHECKED_CAST")
 // TODO: Re-structure scalars, as it's a bit too complicated now.
-fun <T : Any> deserializeScalar(scalar: Type.Scalar<T>, value: ValueNode, executionNode: Execution): T {
+internal fun <T : Any> deserializeScalar(scalar: Type.Scalar<T>, value: ValueNode, executionNode: Execution): T =
     try {
-        return when (scalar.coercion) {
+        when (scalar.coercion) {
             // built-in scalars
             STRING_COERCION -> STRING_COERCION.deserialize(value.valueNodeName, value) as T
             FLOAT_COERCION -> FLOAT_COERCION.deserialize(value.valueNodeName, value) as T
@@ -39,10 +37,6 @@ fun <T : Any> deserializeScalar(scalar: Type.Scalar<T>, value: ValueNode, execut
             is DoubleScalarCoercion<T> -> scalar.coercion.deserialize(value.valueNodeName.toDouble(), value)
             is BooleanScalarCoercion<T> -> scalar.coercion.deserialize(value.valueNodeName.toBoolean(), value)
             is LongScalarCoercion<T> -> scalar.coercion.deserialize(value.valueNodeName.toLong(), value)
-            else -> throw ExecutionError(
-                message = "Unsupported coercion for scalar type ${scalar.name}",
-                node = executionNode
-            )
         }
     } catch (e: Exception) {
         throw InvalidInputValueException(
@@ -51,41 +45,31 @@ fun <T : Any> deserializeScalar(scalar: Type.Scalar<T>, value: ValueNode, execut
             originalError = e
         )
     }
-}
 
 @Suppress("UNCHECKED_CAST")
-fun <T> serializeScalar(
-    jsonNodeFactory: JsonNodeFactory,
-    scalar: Type.Scalar<*>,
-    value: T,
-    executionNode: Execution
-): JsonValueNode = when (scalar.coercion) {
-    is StringScalarCoercion<*> -> {
-        jsonNodeFactory.textNode((scalar.coercion as StringScalarCoercion<T>).serialize(value))
-    }
+internal fun <T> serializeScalar(jsonNodeFactory: JsonNodeFactory, scalar: Type.Scalar<*>, value: T): JsonValueNode =
+    when (scalar.coercion) {
+        is StringScalarCoercion<*> -> {
+            jsonNodeFactory.textNode((scalar.coercion as StringScalarCoercion<T>).serialize(value))
+        }
 
-    is ShortScalarCoercion<*> -> {
-        jsonNodeFactory.numberNode((scalar.coercion as ShortScalarCoercion<T>).serialize(value))
-    }
+        is ShortScalarCoercion<*> -> {
+            jsonNodeFactory.numberNode((scalar.coercion as ShortScalarCoercion<T>).serialize(value))
+        }
 
-    is IntScalarCoercion<*> -> {
-        jsonNodeFactory.numberNode((scalar.coercion as IntScalarCoercion<T>).serialize(value))
-    }
+        is IntScalarCoercion<*> -> {
+            jsonNodeFactory.numberNode((scalar.coercion as IntScalarCoercion<T>).serialize(value))
+        }
 
-    is DoubleScalarCoercion<*> -> {
-        jsonNodeFactory.numberNode((scalar.coercion as DoubleScalarCoercion<T>).serialize(value))
-    }
+        is DoubleScalarCoercion<*> -> {
+            jsonNodeFactory.numberNode((scalar.coercion as DoubleScalarCoercion<T>).serialize(value))
+        }
 
-    is LongScalarCoercion<*> -> {
-        jsonNodeFactory.numberNode((scalar.coercion as LongScalarCoercion<T>).serialize(value))
-    }
+        is LongScalarCoercion<*> -> {
+            jsonNodeFactory.numberNode((scalar.coercion as LongScalarCoercion<T>).serialize(value))
+        }
 
-    is BooleanScalarCoercion<*> -> {
-        jsonNodeFactory.booleanNode((scalar.coercion as BooleanScalarCoercion<T>).serialize(value))
+        is BooleanScalarCoercion<*> -> {
+            jsonNodeFactory.booleanNode((scalar.coercion as BooleanScalarCoercion<T>).serialize(value))
+        }
     }
-
-    else -> throw ExecutionException(
-        message = "Unsupported coercion for scalar ${scalar.name}",
-        node = executionNode
-    )
-}

--- a/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/scalar/ScalarCoercion.kt
+++ b/kgraphql/src/main/kotlin/com/apurebase/kgraphql/schema/scalar/ScalarCoercion.kt
@@ -6,7 +6,7 @@ import com.apurebase.kgraphql.schema.model.ast.ValueNode
  * Scalar resolves to a single scalar object, and can't have sub-selections in the request.
  * ScalarSupport defines strategy of handling supported scalar type.
  */
-interface ScalarCoercion<Scalar, Raw> {
+sealed interface ScalarCoercion<Scalar, Raw> {
 
     /**
      * strategy for scalar serialization


### PR DESCRIPTION
Adds missing DSL method to documentation, and makes `ScalarCoercion` a `sealed interface` to get rid of unnecessary `else` branches.

BREAKING CHANGE: `serializeScalar` and `deserializeScalar` are now `internal` functions