### PR TITLE
feat!: support fragments on query level

### DIFF
--- a/kgraphql/api/kgraphql.api
+++ b/kgraphql/api/kgraphql.api
@@ -843,47 +843,6 @@ public final class de/stuebingerb/kgraphql/schema/execution/ExecutionMode : java
 	public static fun values ()[Lde/stuebingerb/kgraphql/schema/execution/ExecutionMode;
 }
 
-public final class de/stuebingerb/kgraphql/schema/execution/ExecutionPlan : java/util/List, kotlin/jvm/internal/markers/KMappedMarker {
-	public fun <init> (ZLde/stuebingerb/kgraphql/schema/execution/ExecutionMode;Ljava/util/List;)V
-	public fun add (ILde/stuebingerb/kgraphql/schema/execution/Execution$Node;)V
-	public synthetic fun add (ILjava/lang/Object;)V
-	public fun add (Lde/stuebingerb/kgraphql/schema/execution/Execution$Node;)Z
-	public synthetic fun add (Ljava/lang/Object;)Z
-	public fun addAll (ILjava/util/Collection;)Z
-	public fun addAll (Ljava/util/Collection;)Z
-	public fun clear ()V
-	public fun contains (Lde/stuebingerb/kgraphql/schema/execution/Execution$Node;)Z
-	public final fun contains (Ljava/lang/Object;)Z
-	public fun containsAll (Ljava/util/Collection;)Z
-	public fun get (I)Lde/stuebingerb/kgraphql/schema/execution/Execution$Node;
-	public synthetic fun get (I)Ljava/lang/Object;
-	public final fun getExecutionMode ()Lde/stuebingerb/kgraphql/schema/execution/ExecutionMode;
-	public final fun getOperations ()Ljava/util/List;
-	public fun getSize ()I
-	public fun indexOf (Lde/stuebingerb/kgraphql/schema/execution/Execution$Node;)I
-	public final fun indexOf (Ljava/lang/Object;)I
-	public fun isEmpty ()Z
-	public final fun isSubscription ()Z
-	public fun iterator ()Ljava/util/Iterator;
-	public fun lastIndexOf (Lde/stuebingerb/kgraphql/schema/execution/Execution$Node;)I
-	public final fun lastIndexOf (Ljava/lang/Object;)I
-	public fun listIterator ()Ljava/util/ListIterator;
-	public fun listIterator (I)Ljava/util/ListIterator;
-	public fun remove (I)Lde/stuebingerb/kgraphql/schema/execution/Execution$Node;
-	public synthetic fun remove (I)Ljava/lang/Object;
-	public fun remove (Ljava/lang/Object;)Z
-	public fun removeAll (Ljava/util/Collection;)Z
-	public fun replaceAll (Ljava/util/function/UnaryOperator;)V
-	public fun retainAll (Ljava/util/Collection;)Z
-	public fun set (ILde/stuebingerb/kgraphql/schema/execution/Execution$Node;)Lde/stuebingerb/kgraphql/schema/execution/Execution$Node;
-	public synthetic fun set (ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun size ()I
-	public fun sort (Ljava/util/Comparator;)V
-	public fun subList (II)Ljava/util/List;
-	public fun toArray ()[Ljava/lang/Object;
-	public fun toArray ([Ljava/lang/Object;)[Ljava/lang/Object;
-}
-
 public abstract interface class de/stuebingerb/kgraphql/schema/execution/GenericTypeResolver {
 	public static final field Companion Lde/stuebingerb/kgraphql/schema/execution/GenericTypeResolver$Companion;
 	public abstract fun box (Ljava/lang/Object;Lkotlin/reflect/KType;)Ljava/lang/Object;
@@ -897,23 +856,6 @@ public final class de/stuebingerb/kgraphql/schema/execution/GenericTypeResolver$
 
 public final class de/stuebingerb/kgraphql/schema/execution/GenericTypeResolver$DefaultImpls {
 	public static fun box (Lde/stuebingerb/kgraphql/schema/execution/GenericTypeResolver;Ljava/lang/Object;Lkotlin/reflect/KType;)Ljava/lang/Object;
-}
-
-public final class de/stuebingerb/kgraphql/schema/execution/ParallelRequestExecutor : de/stuebingerb/kgraphql/schema/execution/RequestExecutor {
-	public fun <init> (Lde/stuebingerb/kgraphql/schema/DefaultSchema;)V
-	public final fun getSchema ()Lde/stuebingerb/kgraphql/schema/DefaultSchema;
-	public fun suspendExecute (Lde/stuebingerb/kgraphql/schema/execution/ExecutionPlan;Lde/stuebingerb/kgraphql/request/VariablesJson;Lde/stuebingerb/kgraphql/Context;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public final class de/stuebingerb/kgraphql/schema/execution/ParallelRequestExecutor$ExecutionContext {
-	public fun <init> (Lde/stuebingerb/kgraphql/request/Variables;Lde/stuebingerb/kgraphql/Context;Ljava/util/Map;)V
-	public final fun getLoaders ()Ljava/util/Map;
-	public final fun getRequestContext ()Lde/stuebingerb/kgraphql/Context;
-	public final fun getVariables ()Lde/stuebingerb/kgraphql/request/Variables;
-}
-
-public abstract interface class de/stuebingerb/kgraphql/schema/execution/RequestExecutor {
-	public abstract fun suspendExecute (Lde/stuebingerb/kgraphql/schema/execution/ExecutionPlan;Lde/stuebingerb/kgraphql/request/VariablesJson;Lde/stuebingerb/kgraphql/Context;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class de/stuebingerb/kgraphql/schema/execution/TypeCondition {
@@ -2180,11 +2122,6 @@ public final class de/stuebingerb/kgraphql/schema/structure/InputValue : de/stue
 	public synthetic fun getType ()Lde/stuebingerb/kgraphql/schema/introspection/__Type;
 	public fun getType ()Lde/stuebingerb/kgraphql/schema/structure/Type;
 	public fun isDeprecated ()Z
-}
-
-public final class de/stuebingerb/kgraphql/schema/structure/RequestInterpreter {
-	public fun <init> (Lde/stuebingerb/kgraphql/schema/structure/SchemaModel;)V
-	public final fun createExecutionPlan (Lde/stuebingerb/kgraphql/schema/model/ast/DocumentNode;Ljava/lang/String;Lde/stuebingerb/kgraphql/request/VariablesJson;)Lde/stuebingerb/kgraphql/schema/execution/ExecutionPlan;
 }
 
 public class de/stuebingerb/kgraphql/schema/structure/SchemaCompilation {

--- a/kgraphql/src/main/kotlin/de/stuebingerb/kgraphql/schema/execution/ExecutionPlan.kt
+++ b/kgraphql/src/main/kotlin/de/stuebingerb/kgraphql/schema/execution/ExecutionPlan.kt
@@ -1,5 +1,8 @@
 package de.stuebingerb.kgraphql.schema.execution
 
+import de.stuebingerb.kgraphql.schema.model.ast.VariableDefinitionNode
+import de.stuebingerb.kgraphql.schema.structure.Type
+
 /**
  * Execution mode to use when executing the plan. "Normal" mode is in fact parallel mode but we
  * stick to the name used in the spec.
@@ -10,8 +13,9 @@ enum class ExecutionMode {
     Normal, Serial
 }
 
-class ExecutionPlan(
-    val isSubscription: Boolean,
+internal class ExecutionPlan(
     val executionMode: ExecutionMode,
-    val operations: List<Execution.Node>
-) : List<Execution.Node> by operations
+    val operations: List<Execution>,
+    val root: Type,
+    val declaredVariables: List<VariableDefinitionNode>?
+) : List<Execution> by operations

--- a/kgraphql/src/main/kotlin/de/stuebingerb/kgraphql/schema/execution/ParallelRequestExecutor.kt
+++ b/kgraphql/src/main/kotlin/de/stuebingerb/kgraphql/schema/execution/ParallelRequestExecutor.kt
@@ -30,7 +30,7 @@ import kotlin.coroutines.cancellation.CancellationException
 import kotlin.reflect.KProperty1
 
 @Suppress("UNCHECKED_CAST") // For valid structure there is no risk of ClassCastException
-class ParallelRequestExecutor(val schema: DefaultSchema) : RequestExecutor {
+internal class ParallelRequestExecutor(val schema: DefaultSchema) : RequestExecutor {
 
     class ExecutionContext(
         val variables: Variables,
@@ -76,51 +76,13 @@ class ParallelRequestExecutor(val schema: DefaultSchema) : RequestExecutor {
 
     override suspend fun suspendExecute(plan: ExecutionPlan, variables: VariablesJson, context: Context): String {
         val root = jsonNodeFactory.objectNode()
-        val loaders = plan.constructLoaders()
+        val ctx = ExecutionContext(
+            Variables(variables, plan.declaredVariables),
+            context,
+            plan.constructLoaders()
+        )
 
-        suspend fun executeOperation(operation: Execution.Node): Pair<Execution.Node, Deferred<JsonNode>?> =
-            coroutineScope {
-                val ctx = ExecutionContext(Variables(variables, operation.variables), context, loaders)
-                if (shouldInclude(ctx, operation)) {
-                    try {
-                        operation to writeOperation(
-                            isSubscription = plan.isSubscription,
-                            ctx = ctx,
-                            node = operation,
-                            operation = operation.field as Field.Function<*, *>
-                        )
-                    } catch (e: ExecutionError) {
-                        context.raiseError(e)
-                        if (operation.field.returnType.isNullable()) {
-                            operation to CompletableDeferred(jsonNodeFactory.nullNode())
-                        } else {
-                            operation to null
-                        }
-                    }
-                } else {
-                    operation to null
-                }
-            }
-
-        // TODO: we might want a SerialRequestExecutor or at least rename *Parallel*RequestExecutor
-        val resultMap = if (plan.executionMode == ExecutionMode.Normal) {
-            plan.mapIndexedParallel(dispatcher) { _, operation -> executeOperation(operation) }.toMap()
-        } else {
-            plan.associate { operation -> executeOperation(operation) }
-        }
-
-        val data = if (resultMap.values.any { it != null }) {
-            jsonNodeFactory.objectNode()
-        } else {
-            jsonNodeFactory.nullNode()
-        }
-
-        for (operation in plan) {
-            // Remove all by skip/include directives
-            if (resultMap[operation] != null) {
-                (data as ObjectNode).merge(operation.aliasOrKey, resultMap[operation]!!.await())
-            }
-        }
+        val data = executePlan(ctx, plan)
 
         // https://spec.graphql.org/September2025/#note-19ca4
         // "When "errors" is present in an execution result, it may be helpful for it to appear first when serialized to make it more apparent that errors are present."
@@ -133,33 +95,34 @@ class ParallelRequestExecutor(val schema: DefaultSchema) : RequestExecutor {
         return objectWriter.writeValueAsString(root)
     }
 
-    private suspend fun <T> writeOperation(
-        isSubscription: Boolean,
-        ctx: ExecutionContext,
-        node: Execution.Node,
-        operation: FunctionWrapper<T>
-    ): Deferred<JsonNode> {
-        try {
-            node.field.checkAccess(null, ctx.requestContext)
-        } catch (e: Throwable) {
-            return handleException(ctx, node, node.field.returnType, e)
+    private suspend fun executePlan(ctx: ExecutionContext, plan: ExecutionPlan): JsonNode = try {
+        suspend fun executeOperation(operation: Execution) =
+            when (operation) {
+                is Execution.Fragment -> handleFragment(ctx, plan.root, operation)
+                is Execution.Node -> handleProperty(ctx, plan.root, operation, plan.root)?.let { mapOf(it) }
+                    ?: emptyMap()
+            }
+
+        val objectNode = jsonNodeFactory.objectNode()
+        val deferreds = if (plan.executionMode == ExecutionMode.Normal) {
+            plan.mapIndexedParallel(dispatcher) { _, child ->
+                executeOperation(child)
+            }
+        } else {
+            plan.map { child ->
+                executeOperation(child)
+            }
         }
 
-        try {
-            val operationResult = operation.invoke(
-                isSubscription = isSubscription,
-                children = node.children,
-                funName = node.field.name,
-                receiver = null,
-                inputValues = node.field.arguments,
-                args = node.arguments,
-                executionNode = node,
-                ctx = ctx
-            )
-            return createNode(ctx, operationResult, node, node.field.returnType)
-        } catch (e: Throwable) {
-            return handleException(ctx, node, node.field.returnType, e)
+        deferreds.forEach {
+            it.forEach { (key, value) ->
+                objectNode.merge(key, value.await())
+            }
         }
+        objectNode
+    } catch (e: ExecutionError) {
+        ctx.requestContext.raiseError(e)
+        jsonNodeFactory.nullNode()
     }
 
     private suspend fun <T> createUnionOperationNode(
@@ -330,7 +293,7 @@ class ParallelRequestExecutor(val schema: DefaultSchema) : RequestExecutor {
             // Union is subclass of Node so check it first
             is Execution.Union -> {
                 val field = checkNotNull(type.unwrapped()[child.key]) {
-                    "Execution unit '${child.key}' is not contained by operation return type"
+                    "Execution unit '${child.key}' is not contained by operation return type '${type.unwrapped().name}'"
                 }
                 if (field is Field.Union<*>) {
                     return child.aliasOrKey to createUnionOperationNode(ctx, value, child, field as Field.Union<T>)
@@ -353,7 +316,7 @@ class ParallelRequestExecutor(val schema: DefaultSchema) : RequestExecutor {
 
             is Execution.Node -> {
                 val field = checkNotNull(type.unwrapped()[child.key]) {
-                    "Execution unit '${child.key}' is not contained by operation return type"
+                    "Execution unit '${child.key}' is not contained by operation return type '${type.unwrapped().name}'"
                 }
                 return child.aliasOrKey to (createPropertyNode(ctx, value, child, field) ?: return null)
             }
@@ -372,7 +335,7 @@ class ParallelRequestExecutor(val schema: DefaultSchema) : RequestExecutor {
             val expectedType = container.condition.onType
             if (expectedType.kind == TypeKind.OBJECT || expectedType.kind == TypeKind.INTERFACE) {
                 // TODO: for remote objects we now rely on the presence of the __typename. So maybe we should/need to automatically add it if not present already? Can this break something?
-                if (expectedType.isInstance(value) || (value is JsonNode && value["__typename"].textValue() == expectedType.name)) {
+                if (expectedType == value || expectedType.isInstance(value) || (value is JsonNode && value["__typename"]?.textValue() == expectedType.name)) {
                     val childElements = container.elements.flatMap { child ->
                         when (child) {
                             is Execution.Fragment -> handleFragment(ctx, value, child.withParent(container)).toList()
@@ -407,7 +370,8 @@ class ParallelRequestExecutor(val schema: DefaultSchema) : RequestExecutor {
         val include = shouldInclude(ctx, node)
         if (include) {
             try {
-                node.field.checkAccess(parentValue, ctx.requestContext)
+                // checkAccess (only) on operation DSL level does not expect a parentValue
+                node.field.checkAccess(parentValue.takeUnless { it is Type.OperationObject }, ctx.requestContext)
             } catch (e: Throwable) {
                 return handleException(ctx, node, node.field.returnType, e)
             }
@@ -478,7 +442,8 @@ class ParallelRequestExecutor(val schema: DefaultSchema) : RequestExecutor {
             throw exception
         }
 
-        when (val handledError = schema.configuration.errorHandler.handleException(ctx.requestContext, node, exception)) {
+        when (val handledError =
+            schema.configuration.errorHandler.handleException(ctx.requestContext, node, exception)) {
             is RequestError -> throw handledError
             is ExecutionError -> {
                 if (returnType.isNullable()) {
@@ -531,8 +496,6 @@ class ParallelRequestExecutor(val schema: DefaultSchema) : RequestExecutor {
     }
 
     internal suspend fun <T> FunctionWrapper<T>.invoke(
-        isSubscription: Boolean = false,
-        children: Collection<Execution> = emptyList(),
         funName: String,
         receiver: Any?,
         inputValues: List<InputValue<*>>,
@@ -551,11 +514,18 @@ class ParallelRequestExecutor(val schema: DefaultSchema) : RequestExecutor {
             this@invoke
         ) ?: return CompletableDeferred(value = null)
 
+        val isSubscription = receiver != null && receiver == schema.model.subscriptionType
         return when {
             hasReceiver -> CompletableDeferred(invoke(receiver, *transformedArgs.toTypedArray()))
             isSubscription -> {
-                val subscriptionArgs = children.map { (it as Execution.Node).aliasOrKey }
-                CompletableDeferred(invoke(transformedArgs, subscriptionArgs, objectWriter))
+                fun Execution.getSubscriptionArgs(): List<String> = when {
+                    this is Execution.Node && children.isEmpty() -> listOf(aliasOrKey)
+                    this is Execution.Node -> children.flatMap { it.getSubscriptionArgs() }
+                    this is Execution.Fragment -> elements.flatMap { it.getSubscriptionArgs() }
+                    else -> error("Unexpected type of node: $this")
+                }
+
+                CompletableDeferred(invoke(transformedArgs, executionNode.getSubscriptionArgs(), objectWriter))
             }
 
             else -> CompletableDeferred(invoke(*transformedArgs.toTypedArray()))

--- a/kgraphql/src/main/kotlin/de/stuebingerb/kgraphql/schema/execution/RequestExecutor.kt
+++ b/kgraphql/src/main/kotlin/de/stuebingerb/kgraphql/schema/execution/RequestExecutor.kt
@@ -3,6 +3,6 @@ package de.stuebingerb.kgraphql.schema.execution
 import de.stuebingerb.kgraphql.Context
 import de.stuebingerb.kgraphql.request.VariablesJson
 
-interface RequestExecutor {
+internal interface RequestExecutor {
     suspend fun suspendExecute(plan: ExecutionPlan, variables: VariablesJson, context: Context): String
 }

--- a/kgraphql/src/main/kotlin/de/stuebingerb/kgraphql/schema/structure/RequestInterpreter.kt
+++ b/kgraphql/src/main/kotlin/de/stuebingerb/kgraphql/schema/structure/RequestInterpreter.kt
@@ -28,7 +28,7 @@ import de.stuebingerb.kgraphql.schema.model.ast.VariableDefinitionNode
 import de.stuebingerb.kgraphql.schema.model.ast.toArguments
 import java.util.Stack
 
-class RequestInterpreter(private val schemaModel: SchemaModel) {
+internal class RequestInterpreter(private val schemaModel: SchemaModel) {
 
     private val directivesByName = schemaModel.directives.associateBy { it.name }
     private val usedFragments: MutableSet<String> = mutableSetOf()
@@ -95,11 +95,12 @@ class RequestInterpreter(private val schemaModel: SchemaModel) {
         val ctx = InterpreterContext(fragmentDefinitions, operation.variableDefinitions)
 
         return ExecutionPlan(
-            isSubscription = operation.operation == OperationTypeNode.SUBSCRIPTION,
             executionMode = executionMode,
             operations = operation.selectionSet.selections.map {
-                root.handleSelection(it as FieldNode, ctx, operation.variableDefinitions)
-            }
+                root.handleSelectionFieldOrFragment(it, ctx)
+            },
+            root = root,
+            declaredVariables = operation.variableDefinitions
         ).also {
             val unusedFragments = ctx.fragments.keys.filter { fragment -> fragment !in usedFragments }
             if (unusedFragments.isNotEmpty()) {
@@ -166,11 +167,7 @@ class RequestInterpreter(private val schemaModel: SchemaModel) {
             is FieldNode -> handleSelection(node, ctx)
         }
 
-    private fun Type.handleSelection(
-        node: FieldNode,
-        ctx: InterpreterContext,
-        variables: List<VariableDefinitionNode>? = null
-    ): Execution.Node {
+    private fun Type.handleSelection(node: FieldNode, ctx: InterpreterContext): Execution.Node {
         return when (val field = this[node.name.value]) {
             null -> throw ValidationException(
                 "Property '${node.name.value}' on '$name' does not exist",
@@ -190,9 +187,8 @@ class RequestInterpreter(private val schemaModel: SchemaModel) {
                     children = handleReturnType(ctx, field.returnType, node),
                     arguments = node.arguments?.toArguments(),
                     directives = node.directives?.lookup(),
-                    // TODO: can we use ctx.declaredVariables here? currently, variables are only assigned to root
-                    //  and remote operation nodes, not field nodes and others
-                    variables = variables,
+                    // TODO: can we remove variables from Execution.Node? variables are only used with Execution.Remote
+                    variables = null,
                     arrayIndex = null,
                     parent = null
                 )

--- a/kgraphql/src/test/kotlin/de/stuebingerb/kgraphql/integration/BaseSchemaTest.kt
+++ b/kgraphql/src/test/kotlin/de/stuebingerb/kgraphql/integration/BaseSchemaTest.kt
@@ -330,6 +330,9 @@ abstract class BaseSchemaTest {
             property("testProperty2") {
                 resolver { "${it.name}.testProperty2" }
             }
+            property("testProperty3") {
+                resolver { "${it.name}.testProperty3" }
+            }
         }
 
         query("exception") {

--- a/kgraphql/src/test/kotlin/de/stuebingerb/kgraphql/integration/QueryTest.kt
+++ b/kgraphql/src/test/kotlin/de/stuebingerb/kgraphql/integration/QueryTest.kt
@@ -1063,15 +1063,13 @@ class QueryTest : BaseSchemaTest() {
     }
 
     @Test
-    fun `errors during operation execution should not stop other operations`() {
+    fun `errors during nullable operation execution should not stop other operations`() {
         val response = testedSchema.executeBlocking(
             """
             {
               number1: number(big: true)
-              exception1: exception
               nullableException1: nullableException
               number2: number(big: true)
-              exception2: exception
               nullableException2: nullableException
             }
         """.trimIndent()
@@ -1083,6 +1081,22 @@ class QueryTest : BaseSchemaTest() {
             "number2" to 10000,
             "nullableException2" to null
         )
+    }
+
+    @Test
+    fun `errors during non-nullable operation execution should stop other operations`() {
+        val response = testedSchema.executeBlocking(
+            """
+            {
+              number1: number(big: true)
+              exception1: exception
+              number2: number(big: true)
+              exception2: exception
+            }
+        """.trimIndent()
+        )
+
+        response.deserialize()["data"] shouldBe null
     }
 
     @Test

--- a/kgraphql/src/test/kotlin/de/stuebingerb/kgraphql/specification/language/FragmentsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/de/stuebingerb/kgraphql/specification/language/FragmentsSpecificationTest.kt
@@ -12,6 +12,8 @@ import de.stuebingerb.kgraphql.expectRequestError
 import de.stuebingerb.kgraphql.extract
 import de.stuebingerb.kgraphql.integration.BaseSchemaTest
 import de.stuebingerb.kgraphql.request.Introspection
+import de.stuebingerb.kgraphql.schema.dsl.operations.subscribe
+import de.stuebingerb.kgraphql.schema.dsl.operations.unsubscribe
 import io.kotest.assertions.throwables.shouldThrowExactly
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.shouldBe
@@ -528,22 +530,22 @@ class FragmentsSpecificationTest : BaseSchemaTest() {
 
         val deserialized = deserialize(response)
         deserialized shouldBe
-                mapOf(
-                    "data" to mapOf(
-                        "outer" to mapOf(
-                            "inner1" to mapOf(
-                                "name" to "test1",
-                                "testProperty2" to "test1.testProperty2",
-                                "testProperty1" to "test1.testProperty1",
-                            ),
-                            "inner2" to mapOf(
-                                "name" to "test2",
-                                "testProperty1" to "test2.testProperty1",
-                                "testProperty2" to "test2.testProperty2",
-                            ),
-                        )
+            mapOf(
+                "data" to mapOf(
+                    "outer" to mapOf(
+                        "inner1" to mapOf(
+                            "name" to "test1",
+                            "testProperty2" to "test1.testProperty2",
+                            "testProperty1" to "test1.testProperty1",
+                        ),
+                        "inner2" to mapOf(
+                            "name" to "test2",
+                            "testProperty1" to "test2.testProperty1",
+                            "testProperty2" to "test2.testProperty2",
+                        ),
                     )
                 )
+            )
     }
 
     // https://github.com/aPureBase/KGraphQL/issues/197
@@ -557,6 +559,14 @@ class FragmentsSpecificationTest : BaseSchemaTest() {
                     ...TestFragment2
                     inner2 {
                         testProperty2
+                        ... @include(if: false) {
+                            testProperty3
+                        }
+                    }
+                    ... @include(if: true) {
+                        inner1 {
+                            testProperty3
+                        }
                     }
                 } 
             } 
@@ -571,21 +581,199 @@ class FragmentsSpecificationTest : BaseSchemaTest() {
 
         val deserialized = deserialize(response)
         deserialized shouldBe
-                mapOf(
-                    "data" to mapOf(
-                        "outer" to mapOf(
-                            "inner1" to mapOf(
-                                "name" to "test1",
-                                "testProperty2" to "test1.testProperty2",
-                            ),
-                            "inner2" to mapOf(
-                                "name" to "test2",
-                                "testProperty1" to "test2.testProperty1",
-                                "testProperty2" to "test2.testProperty2",
-                            ),
+            mapOf(
+                "data" to mapOf(
+                    "outer" to mapOf(
+                        "inner1" to mapOf(
+                            "name" to "test1",
+                            "testProperty2" to "test1.testProperty2",
+                            "testProperty3" to "test1.testProperty3",
+                        ),
+                        "inner2" to mapOf(
+                            "name" to "test2",
+                            "testProperty1" to "test2.testProperty1",
+                            "testProperty2" to "test2.testProperty2",
+                        ),
+                    )
+                )
+            )
+    }
+
+    // See https://spec.graphql.org/September2025/#example-fdbb7
+    @Test
+    fun `fragments should work on query level`() {
+        val response = testedSchema.executeBlocking(
+            """
+            {
+                film {
+                    id
+                }
+                ...film_title
+            }
+
+            fragment film_title on Query {
+                film {
+                    title
+                }
+            }
+        """
+        )
+
+        val deserialized = deserialize(response)
+        deserialized shouldBe
+            mapOf(
+                "data" to mapOf(
+                    "film" to mapOf(
+                        "id" to "Prestige:2006",
+                        "title" to "Prestige"
+                    )
+                )
+            )
+    }
+
+    @Test
+    fun `fragments should work on mutation level`() {
+        val response = testedSchema.executeBlocking(
+            """
+            mutation {
+                ...CreateActor
+            }
+
+            fragment CreateActor on Mutation {
+                createActor(name: "John", age: 42) {
+                    name
+                }
+            }
+        """
+        )
+
+        val deserialized = deserialize(response)
+        deserialized shouldBe
+            mapOf(
+                "data" to mapOf(
+                    "createActor" to mapOf(
+                        "name" to "John"
+                    )
+                )
+            )
+    }
+
+    // https://spec.graphql.org/September2025/#example-13061
+    @Test
+    fun `fragments should work on subscription level`() {
+        val schema = KGraphQL.schema {
+            query("dummy") {
+                resolver { -> "dummy" }
+            }
+
+            val publisher = mutation("createSubscriptionActor") {
+                resolver { name: String, age: Int -> Actor(name, age) }
+            }
+
+            subscription("subscriptionActor") {
+                resolver { subscription: String ->
+                    subscribe(subscription, publisher, Actor("John", 42)) {
+                        // Noop
+                    }
+                }
+            }
+
+            subscription("unsubscriptionActor") {
+                resolver { subscription: String ->
+                    unsubscribe(subscription, publisher, Actor("John", 42))
+                }
+            }
+        }
+
+        val response = schema.executeBlocking(
+            """
+            subscription {
+                ...ActorSubscription
+            }
+
+            fragment ActorSubscription on Subscription {
+                subscriptionActor(subscription: "my-subscription") {
+                    ...ActorName
+                }
+            }
+            
+            fragment ActorName on Actor {
+                name
+            }
+        """
+        )
+
+        val deserialized = deserialize(response)
+        deserialized shouldBe
+            mapOf(
+                "data" to mapOf(
+                    "subscriptionActor" to mapOf(
+                        "name" to "John"
+                    )
+                )
+            )
+
+        schema.executeBlocking("""
+            subscription {
+                unsubscriptionActor(subscription: "my-subscription") {
+                    name
+                }
+            }
+        """.trimIndent())
+    }
+
+    @Test
+    fun `executor should merge several fragment declarations and field declaration on query level`() {
+        val response = testedSchema.executeBlocking(
+            """
+            {
+                film {
+                    id
+                }
+                ...film_title
+                ...film_director_name @include(if: true)
+            }
+            
+            fragment film_director_name on Query {
+                film {
+                    director {
+                        name
+                    }
+                }
+            }
+
+            fragment film_title on Query {
+                film {
+                    title
+                    year
+                    type
+                }
+                film {
+                    title
+                    director {
+                        age
+                    }
+                }
+            }
+        """
+        )
+
+        val deserialized = deserialize(response)
+        deserialized shouldBe
+            mapOf(
+                "data" to mapOf(
+                    "film" to mapOf(
+                        "id" to "Prestige:2006",
+                        "title" to "Prestige",
+                        "year" to 2006,
+                        "type" to "FULL_LENGTH",
+                        "director" to mapOf(
+                            "name" to "Christopher Nolan",
+                            "age" to 43
                         )
                     )
                 )
+            )
     }
 
     // https://github.com/aPureBase/KGraphQL/issues/189


### PR DESCRIPTION
Resolves #406
Resolves #645 

BREAKING CHANGE: `ExecutionPlan`, `RequestInterpreter` and `ParallelRequestExecutor` are no longer public classes