### PR TITLE
fix!: correctly populate possibleTypes for remote types

### DIFF
--- a/kgraphql-ktor-stitched/src/main/kotlin/de/stuebingerb/kgraphql/stitched/schema/structure/RemoteSchemaCompilation.kt
+++ b/kgraphql-ktor-stitched/src/main/kotlin/de/stuebingerb/kgraphql/stitched/schema/structure/RemoteSchemaCompilation.kt
@@ -23,12 +23,27 @@ import de.stuebingerb.kgraphql.stitched.schema.configuration.StitchedSchemaConfi
 
 @ExperimentalAPI
 class RemoteSchemaCompilation(private val configuration: StitchedSchemaConfiguration) {
+    private val currentTypesByName = mutableMapOf<String, __Type>()
+
     val remoteQueryTypeProxies = mutableMapOf<String, TypeProxy>()
     val remoteInputTypeProxies = mutableMapOf<String, TypeProxy>()
     val remoteQueries = mutableListOf<Field>()
     val remoteMutations = mutableListOf<Field>()
 
+    private fun collectCurrentTypes(schema: __Schema) {
+        // Collect current types into a lookup map from their actual type definition to avoid missing
+        // possibleTypes later on when we have only limited information from the introspection response
+        currentTypesByName.clear()
+        schema.types.forEach { type ->
+            type.name?.let { name ->
+                currentTypesByName[name] = type
+            }
+        }
+    }
+
     fun perform(url: String, schema: __Schema): List<TypeProxy> {
+        collectCurrentTypes(schema)
+
         schema.types.forEach { type ->
             when (type.kind) {
                 TypeKind.OBJECT -> {
@@ -171,14 +186,21 @@ class RemoteSchemaCompilation(private val configuration: StitchedSchemaConfigura
         val typeName = checkNotNull(type.name) {
             "Cannot handle remote type $type without name"
         }
+        // Lookup the actual type because the one we received may not have possibleTypes set
+        val type = currentTypesByName[type.name] ?: type
         val fields = type.fields.orEmpty().map {
             handleRemoteField(it)
         }
         val interfaces = type.interfaces?.map {
             handleRemoteType(it)
         }
+        val possibleTypes = checkNotNull(type.possibleTypes) {
+            "Cannot handle remote interface '$typeName' without possibleTypes"
+        }.map {
+            handleRemoteType(it)
+        }
 
-        val objectType = Type.RemoteInterface(typeName, type.description, fields + typenameField(), interfaces)
+        val objectType = Type.RemoteInterface(typeName, type.description, fields + typenameField(), possibleTypes, interfaces)
         val typeProxy = TypeProxy(objectType)
         remoteQueryTypeProxies[typeName] = typeProxy
         return objectType
@@ -235,12 +257,15 @@ class RemoteSchemaCompilation(private val configuration: StitchedSchemaConfigura
     }
 
     private fun handleRemoteUnionType(type: __Type): Type.Union {
-        val possibleTypes = type.possibleTypes.orEmpty().map {
-            handleRemoteType(it)
-        }
-
         val typeName = checkNotNull(type.name) {
             "Cannot handle remote type $type without name"
+        }
+        // Lookup the actual type because the one we received may not have possibleTypes set
+        val type = currentTypesByName[type.name] ?: type
+        val possibleTypes = checkNotNull(type.possibleTypes) {
+            "Cannot handle remote union '$typeName' without possibleTypes"
+        }.map {
+            handleRemoteType(it)
         }
 
         val objectDef = TypeDef.Union(typeName, emptySet(), type.description)

--- a/kgraphql-ktor-stitched/src/test/kotlin/de/stuebingerb/kgraphql/stitched/schema/structure/IntrospectedSchemaTest.kt
+++ b/kgraphql-ktor-stitched/src/test/kotlin/de/stuebingerb/kgraphql/stitched/schema/structure/IntrospectedSchemaTest.kt
@@ -4,11 +4,28 @@ import de.stuebingerb.kgraphql.KGraphQL
 import de.stuebingerb.kgraphql.request.Introspection
 import de.stuebingerb.kgraphql.schema.SchemaPrinter
 import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import org.junit.jupiter.api.Test
 import java.util.UUID
 
 class IntrospectedSchemaTest {
+    sealed class Union
+    data class SubType1(val name: String) : Union()
+    data class SubType2(val id: Int) : Union()
+
+    interface Interface {
+        val id: Int
+    }
+
+    interface AnotherInterface : Interface {
+        val id2: Int
+    }
+
+    data class Implementation1(override val id: Int, val name: String) : Interface
+    data class Implementation2(override val id: Int, override val id2: Int) : AnotherInterface
+
     data class TestObject(val name: String)
 
     @Suppress("unused")
@@ -36,6 +53,10 @@ class IntrospectedSchemaTest {
                 serialize = UUID::toString
                 specifiedByURL = "https://tools.ietf.org/html/rfc4122"
             }
+            unionType<Union>()
+            type<Interface>()
+            type<Implementation1>()
+            type<Implementation2>()
         }
 
         val schemaFromIntrospection = IntrospectedSchema.fromIntrospectionResponse(
@@ -78,5 +99,45 @@ class IntrospectedSchemaTest {
         shouldNotThrowAny {
             IntrospectedSchema.fromIntrospectionResponse(response = introspectionResponse)
         }
+    }
+
+    @Test
+    fun `introspected schema should have proper possibleTypes`() {
+        val schema = KGraphQL.schema {
+            query("getUnion") {
+                resolver { type: Int ->
+                    if (type == 1) {
+                        SubType1("st1")
+                    } else {
+                        SubType2(2)
+                    }
+                }.returns<Union>()
+            }
+            query("getInterface") {
+                resolver { -> Implementation1(1, "impl1") }.returns<Interface>()
+            }
+            type<Implementation1>()
+            type<Implementation2>()
+            type<AnotherInterface>()
+        }
+
+        val schemaFromIntrospection = IntrospectedSchema.fromIntrospectionResponse(
+            schema.executeBlocking(Introspection.query(Introspection.SpecLevel.WorkingDraft))
+        )
+
+        val unionType = schemaFromIntrospection.types.find { it.name == "Union" }
+        unionType shouldNotBe null
+        unionType?.possibleTypes?.map { it.name } shouldContainExactlyInAnyOrder listOf("SubType1", "SubType2")
+
+        val interfaceType = schemaFromIntrospection.types.find { it.name == "Interface" }
+        interfaceType shouldNotBe null
+        interfaceType?.possibleTypes?.map { it.name } shouldContainExactlyInAnyOrder listOf(
+            "Implementation1",
+            "Implementation2"
+        )
+
+        val anotherInterfaceType = schemaFromIntrospection.types.find { it.name == "AnotherInterface" }
+        anotherInterfaceType shouldNotBe null
+        anotherInterfaceType?.possibleTypes?.map { it.name } shouldContainExactlyInAnyOrder listOf("Implementation2")
     }
 }

--- a/kgraphql-ktor-stitched/src/test/kotlin/de/stuebingerb/kgraphql/stitched/schema/structure/RemoteSchemaCompilationTest.kt
+++ b/kgraphql-ktor-stitched/src/test/kotlin/de/stuebingerb/kgraphql/stitched/schema/structure/RemoteSchemaCompilationTest.kt
@@ -1,0 +1,58 @@
+package de.stuebingerb.kgraphql.stitched.schema.structure
+
+import de.stuebingerb.kgraphql.ExperimentalAPI
+import de.stuebingerb.kgraphql.KGraphQL
+import de.stuebingerb.kgraphql.request.Introspection
+import de.stuebingerb.kgraphql.stitched.schema.dsl.StitchedSchemaConfigurationDSL
+import de.stuebingerb.kgraphql.stitched.schema.structure.IntrospectedSchemaTest.AnotherInterface
+import de.stuebingerb.kgraphql.stitched.schema.structure.IntrospectedSchemaTest.Implementation1
+import de.stuebingerb.kgraphql.stitched.schema.structure.IntrospectedSchemaTest.Implementation2
+import de.stuebingerb.kgraphql.stitched.schema.structure.IntrospectedSchemaTest.Interface
+import de.stuebingerb.kgraphql.stitched.schema.structure.IntrospectedSchemaTest.SubType1
+import de.stuebingerb.kgraphql.stitched.schema.structure.IntrospectedSchemaTest.Union
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldNotBe
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalAPI::class)
+class RemoteSchemaCompilationTest {
+    @Test
+    fun `compiled schema should have proper possibleTypes`() {
+        val schema = KGraphQL.schema {
+            query("getUnion") {
+                resolver { -> SubType1("st1") }.returns<Union>()
+            }
+            query("getInterface") {
+                resolver { -> Implementation1(1, "impl1") }.returns<Interface>()
+            }
+            type<AnotherInterface>()
+            type<Implementation1>()
+            type<Implementation2>()
+        }
+
+        val schemaFromIntrospection = IntrospectedSchema.fromIntrospectionResponse(
+            schema.executeBlocking(Introspection.query(Introspection.SpecLevel.WorkingDraft))
+        )
+
+        val compiledSchema = RemoteSchemaCompilation(StitchedSchemaConfigurationDSL().apply {
+            remoteExecutor = StitchedSchemaTest.DummyRemoteRequestExecutor
+        }.build()).perform("ignored", schemaFromIntrospection)
+
+        val unionType = compiledSchema.find { it.name == "Union" }
+        unionType shouldNotBe null
+        unionType?.possibleTypes?.map { it.name } shouldContainExactlyInAnyOrder listOf("SubType1", "SubType2")
+
+        val interfaceType = compiledSchema.find { it.name == "Interface" }
+        interfaceType shouldNotBe null
+        interfaceType?.possibleTypes?.map { it.name } shouldContainExactlyInAnyOrder listOf(
+            "Implementation1",
+            "Implementation2"
+        )
+
+        val anotherInterfaceType = compiledSchema.find { it.name == "AnotherInterface" }
+        anotherInterfaceType shouldNotBe null
+        anotherInterfaceType?.possibleTypes?.map { it.name } shouldContainExactlyInAnyOrder listOf(
+            "Implementation2"
+        )
+    }
+}

--- a/kgraphql/api/kgraphql.api
+++ b/kgraphql/api/kgraphql.api
@@ -2472,8 +2472,8 @@ public final class de/stuebingerb/kgraphql/schema/structure/Type$RemoteInputObje
 }
 
 public final class de/stuebingerb/kgraphql/schema/structure/Type$RemoteInterface : de/stuebingerb/kgraphql/schema/structure/Type$ComplexType {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getDescription ()Ljava/lang/String;
 	public fun getEnumValues ()Ljava/util/List;
 	public fun getInputFields ()Ljava/util/List;

--- a/kgraphql/src/main/kotlin/de/stuebingerb/kgraphql/schema/structure/Type.kt
+++ b/kgraphql/src/main/kotlin/de/stuebingerb/kgraphql/schema/structure/Type.kt
@@ -404,6 +404,7 @@ interface Type : __Type {
         override val name: String,
         override val description: String?,
         fields: List<Field>,
+        override val possibleTypes: List<Type>,
         override val interfaces: List<Type>? = emptyList()
     ) : ComplexType(fields) {
 
@@ -416,8 +417,6 @@ interface Type : __Type {
         override val inputFields: List<__InputValue>? = null
 
         override val ofType: Type? = null
-
-        override val possibleTypes: List<Type>? = null
     }
 
     class RemoteInputObject(


### PR DESCRIPTION
Fixes #684

BREAKING CHANGE: `RemoteInterface` now expects possible types in its constructor.