### PR TITLE
fix!: implement validation for types in fragment condition

### DIFF
--- a/kgraphql/src/main/kotlin/de/stuebingerb/kgraphql/schema/structure/RequestInterpreter.kt
+++ b/kgraphql/src/main/kotlin/de/stuebingerb/kgraphql/schema/structure/RequestInterpreter.kt
@@ -9,6 +9,7 @@ import de.stuebingerb.kgraphql.schema.execution.Execution
 import de.stuebingerb.kgraphql.schema.execution.ExecutionMode
 import de.stuebingerb.kgraphql.schema.execution.ExecutionPlan
 import de.stuebingerb.kgraphql.schema.execution.TypeCondition
+import de.stuebingerb.kgraphql.schema.introspection.TypeKind
 import de.stuebingerb.kgraphql.schema.model.ast.ASTNode
 import de.stuebingerb.kgraphql.schema.model.ast.DefinitionNode.ExecutableDefinitionNode
 import de.stuebingerb.kgraphql.schema.model.ast.DefinitionNode.ExecutableDefinitionNode.FragmentDefinitionNode
@@ -136,13 +137,14 @@ internal class RequestInterpreter(private val schemaModel: SchemaModel) {
     private fun findFragmentType(
         fragment: FragmentNode,
         ctx: InterpreterContext,
-        enclosingType: Type
+        enclosingType: Type?
     ): Execution.Fragment = when (fragment) {
         is FragmentSpreadNode -> {
-            ctx.get(fragment) ?: throw ValidationException(
-                message = "Fragment '${fragment.name.value}' not found",
-                node = fragment
-            )
+            ctx.get(fragment)?.also { it.condition.onType.validateForFragment(it.selectionNode, enclosingType) }
+                ?: throw ValidationException(
+                    message = "Fragment '${fragment.name.value}' not found",
+                    node = fragment
+                )
         }
 
         is InlineFragmentNode -> {
@@ -150,7 +152,7 @@ internal class RequestInterpreter(private val schemaModel: SchemaModel) {
                 schemaModel.allTypesByName[fragment.typeCondition.name.value]
             } else {
                 enclosingType
-            }.validateForFragment(fragment)
+            }.validateForFragment(fragment, enclosingType)
             Execution.Fragment(
                 selectionNode = fragment,
                 condition = TypeCondition(type),
@@ -204,7 +206,7 @@ internal class RequestInterpreter(private val schemaModel: SchemaModel) {
         fun List<SelectionNode>.namedFragments(): List<Execution.Fragment> = flatMap { selectionNode ->
             when (selectionNode) {
                 is FragmentSpreadNode -> {
-                    val fragment = findFragmentType(selectionNode, ctx, this@handleRemoteOperation)
+                    val fragment = findFragmentType(selectionNode, ctx, null)
                     fragment.elements.map { it.selectionNode }.namedFragments() + fragment
                 }
 
@@ -295,9 +297,10 @@ internal class RequestInterpreter(private val schemaModel: SchemaModel) {
         )
     }
 
-    private fun Type?.validateForFragment(fragment: ASTNode): Type {
+    private fun Type?.validateForFragment(fragment: ASTNode, enclosingType: Type? = null): Type {
         val (typeName, fragmentName) = when (fragment) {
             is InlineFragmentNode -> fragment.typeCondition?.name?.value to "inline fragment"
+            is FragmentSpreadNode -> this?.name to "fragment '${fragment.name.value}'"
             is FragmentDefinitionNode -> fragment.typeCondition.name.value to "fragment '${fragment.name.value}'"
             else -> error("Unsupported fragment type: $fragment")
         }
@@ -311,6 +314,27 @@ internal class RequestInterpreter(private val schemaModel: SchemaModel) {
                 message = "Fragments can only be specified on object types, interfaces, and unions but '$name' is $kind on $fragmentName",
                 node = fragment
             )
+        } else if (enclosingType != null) {
+            // https://spec.graphql.org/September2025/#GetPossibleTypes()
+            fun getPossibleTypes(type: Type): List<Type> {
+                return when (type.kind) {
+                    TypeKind.OBJECT -> listOf(type)
+                    TypeKind.INTERFACE -> checkNotNull(type.possibleTypes)
+                    TypeKind.UNION -> checkNotNull(type.possibleTypes)
+                    else -> emptyList()
+                }
+            }
+
+            // https://spec.graphql.org/September2025/#sec-Fragment-Spread-Is-Possible
+            val possibleTypeNamesFromEnclosingType = getPossibleTypes(enclosingType).map { it.name }
+            val possibleTypeNamesFromThisType = getPossibleTypes(this).map { it.name }
+            val applicableTypeNames = possibleTypeNamesFromEnclosingType.intersect(possibleTypeNamesFromThisType.toSet())
+            if (applicableTypeNames.isEmpty()) {
+                throw ValidationException(
+                    message = "Invalid type '$typeName' in type condition on $fragmentName of type '${enclosingType.name}'; must be one of '$possibleTypeNamesFromEnclosingType'",
+                    node = fragment
+                )
+            }
         }
         return this
     }

--- a/kgraphql/src/test/kotlin/de/stuebingerb/kgraphql/specification/language/FragmentsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/de/stuebingerb/kgraphql/specification/language/FragmentsSpecificationTest.kt
@@ -23,19 +23,28 @@ import org.junit.jupiter.api.Test
 @Specification("2.8 Fragments")
 class FragmentsSpecificationTest : BaseSchemaTest() {
 
-    val age = 232
-
+    private val age = 232
     private val actorName = "Boguś Linda"
+    private val id = "BLinda"
 
-    val id = "BLinda"
-
-    data class ActorWrapper(val id: String, val actualActor: Actor)
-
-    val schema = defaultSchema {
+    private val schema = defaultSchema {
         query("actor") {
             resolver { -> ActorWrapper(id, Actor(actorName, age)) }
         }
     }
+
+    interface Interface {
+        val name: String
+    }
+
+    interface Interface2 : Interface {
+        val id: Int
+    }
+
+    data class Implementation1(override val name: String) : Interface
+    data class Implementation2(override val name: String, override val id: Int) : Interface2
+
+    data class ActorWrapper(val id: String, val actualActor: Actor)
 
     @Test
     fun `fragment's fields are added to the query at the same level as the fragment invocation`() {
@@ -437,6 +446,58 @@ class FragmentsSpecificationTest : BaseSchemaTest() {
         """.trimIndent()
     }
 
+    @Test
+    fun `fragments on incorrect types should be denied`() {
+        // Fragment on `Actor` is invalid because we know that `Film` is returned
+        expectRequestError<ValidationException>("Invalid type 'Actor' in type condition on inline fragment of type 'Film'; must be one of '[Film]'") {
+            testedSchema.executeBlocking(
+                """
+                {
+                    film {
+                        ... on Actor {
+                            __typename
+                        }
+                    }
+                }
+                """.trimIndent()
+            )
+        }
+
+        expectRequestError<ValidationException>("Invalid type 'Actor' in type condition on fragment 'actorFragment' of type 'Film'; must be one of '[Film]'") {
+            testedSchema.executeBlocking(
+                """
+                {
+                    film {
+                        ...actorFragment
+                    }
+                }
+                
+                fragment actorFragment on Actor {
+                    name
+                }
+                """.trimIndent()
+            )
+        }
+
+        expectRequestError<ValidationException>("Invalid type 'Actor' in type condition on inline fragment of type 'Film'; must be one of '[Film]'") {
+            testedSchema.executeBlocking(
+                """
+                {
+                    film {
+                      ...actorInFilmFragment
+                    }
+                }
+                
+                fragment actorInFilmFragment on Film {
+                  ... on Actor {
+                    name
+                  }
+                }
+                """.trimIndent()
+            )
+        }
+    }
+
     sealed class TopUnion(val field: String) {
         class Union1(val names: List<String>) : TopUnion("union1")
         class Union2(val numbers: List<Int>, val booleans: List<Boolean>) : TopUnion("union2")
@@ -492,6 +553,283 @@ class FragmentsSpecificationTest : BaseSchemaTest() {
         ).deserialize()
         numberResult.extract<List<Int>>("data/unions/numbers") shouldBe listOf(1, 2)
         numberResult.extract<List<Boolean>>("data/unions/booleans") shouldBe listOf(true, false)
+    }
+
+    @Test
+    fun `fragments on impossible union types should be denied`() {
+        val schema = KGraphQL.schema {
+            unionType<TopUnion>()
+            type<Actor>()
+
+            query("unions") {
+                resolver { isOne: Boolean ->
+                    if (isOne) {
+                        TopUnion.Union1(listOf("name1", "name2"))
+                    } else {
+                        TopUnion.Union2(listOf(1, 2), listOf(true, false))
+                    }
+                }
+            }
+        }
+
+        expectRequestError<ValidationException>("Invalid type 'Actor' in type condition on inline fragment of type 'TopUnion'; must be one of '[Union1, Union2]'") {
+            schema.executeBlocking(
+                """
+                {
+                    unions(isOne: false) {
+                        ...abc
+                    }
+                }
+                fragment abc on TopUnion {
+                    ... on Union1 { names }
+                    ... on Actor { name }
+                }
+                """.trimIndent()
+            )
+        }
+
+        expectRequestError<ValidationException>("Invalid type 'Actor' in type condition on inline fragment of type 'TopUnion'; must be one of '[Union1, Union2]'") {
+            schema.executeBlocking(
+                """
+                {
+                    unions(isOne: false) {
+                        ... on Union1 { names }
+                        ... on Actor { name }
+                    }
+                }
+                """.trimIndent()
+            )
+        }
+    }
+
+    @Test
+    fun `fragments on impossible interface types should be denied`() {
+        val schema = KGraphQL.schema {
+            type<Actor>()
+            type<Implementation1>()
+            type<Implementation2>()
+
+            query("interfaces") {
+                resolver { isOne: Boolean ->
+                    if (isOne) {
+                        Implementation1("impl1")
+                    } else {
+                        Implementation2("impl2", 42)
+                    }
+                }
+            }
+        }
+
+        expectRequestError<ValidationException>("Invalid type 'Actor' in type condition on inline fragment of type 'Interface'; must be one of '[Implementation1, Implementation2]'") {
+            schema.executeBlocking(
+                """
+                {
+                    interfaces(isOne: false) {
+                        ...abc
+                    }
+                }
+                fragment abc on Interface {
+                    ... on Implementation1 { name }
+                    ... on Actor { name }
+                }
+                """.trimIndent()
+            )
+        }
+
+        expectRequestError<ValidationException>("Invalid type 'Actor' in type condition on inline fragment of type 'Interface'; must be one of '[Implementation1, Implementation2]'") {
+            schema.executeBlocking(
+                """
+                {
+                    interfaces(isOne: false) {
+                        ... on Implementation1 { name }
+                        ... on Actor { name }
+                    }
+                }
+                """.trimIndent()
+            )
+        }
+    }
+
+    interface Animal {
+        val name: String
+    }
+
+    interface Mammal : Animal {
+        val order: String
+    }
+
+    sealed class SeaAnimal : Animal {
+        class Dolphin(override val name: String, override val order: String) : SeaAnimal(), Mammal
+        class Fish(override val name: String) : SeaAnimal()
+    }
+
+    sealed class LandAnimal : Animal {
+        class Bear(override val name: String, override val order: String) : LandAnimal(), Mammal
+        class Ant(override val name: String) : LandAnimal()
+    }
+
+    @Test
+    fun `fragments on impossible intersection of types should be denied`() {
+        val schema = KGraphQL.schema {
+            unionType<LandAnimal>()
+            unionType<SeaAnimal>()
+            type<Mammal>()
+            type<Animal>()
+
+            query("animals") {
+                resolver { ->
+                    listOf(
+                        SeaAnimal.Dolphin("dolphin", "order1"),
+                        SeaAnimal.Fish("fish"),
+                        LandAnimal.Bear("bear", "order2"),
+                        LandAnimal.Ant("ant")
+                    )
+                }
+            }
+        }
+
+        expectRequestError<ValidationException>("Invalid type 'Fish' in type condition on inline fragment of type 'Mammal'; must be one of '[Bear, Dolphin]'") {
+            schema.executeBlocking(
+            """
+                {
+                    animals {
+                        ... on Mammal {
+                            order
+                            ... on Fish { name }
+                        }
+                    }
+                }
+                """.trimIndent()
+            )
+        }
+
+        expectRequestError<ValidationException>("Invalid type 'Bear' in type condition on inline fragment of type 'SeaAnimal'; must be one of '[Dolphin, Fish]'") {
+            schema.executeBlocking(
+                """
+                {
+                    animals {
+                        ... on SeaAnimal {
+                            ... on Bear { name }
+                        }
+                    }
+                }
+                """.trimIndent()
+            )
+        }
+    }
+
+    @Test
+    fun `fragments on possible intersection of types should work`() {
+        val schema = KGraphQL.schema {
+            unionType<LandAnimal>()
+            unionType<SeaAnimal>()
+            type<Mammal>()
+            type<Animal>()
+
+            query("animals") {
+                resolver { ->
+                    listOf(
+                        SeaAnimal.Dolphin("dolphin", "order1"),
+                        SeaAnimal.Fish("fish"),
+                        LandAnimal.Bear("bear", "order2"),
+                        LandAnimal.Ant("ant")
+                    )
+                }
+            }
+        }
+
+        schema.executeBlocking(
+            """
+            {
+                animals {
+                    ... on Dolphin { name order }
+                    ... on Fish { name }
+                    ... on Bear { name order }
+                    ... on Ant { name }
+                }
+            }
+            """.trimIndent()
+        ) shouldBe """
+            {"data":{"animals":[{"name":"dolphin","order":"order1"},{"name":"fish"},{"name":"bear","order":"order2"},{"name":"ant"}]}}
+        """.trimIndent()
+
+        schema.executeBlocking(
+            """
+            {
+                animals {
+                    ... on Animal { name }
+                    ... on Mammal { order }
+                }
+            }
+            """.trimIndent()
+        ) shouldBe """
+            {"data":{"animals":[{"name":"dolphin","order":"order1"},{"name":"fish"},{"name":"bear","order":"order2"},{"name":"ant"}]}}
+        """.trimIndent()
+
+        schema.executeBlocking(
+            """
+            {
+                animals {
+                    ... on Animal {
+                        name
+                        ... on Mammal { order }
+                    }
+                }
+            }
+            """.trimIndent()
+        ) shouldBe """
+            {"data":{"animals":[{"name":"dolphin","order":"order1"},{"name":"fish"},{"name":"bear","order":"order2"},{"name":"ant"}]}}
+        """.trimIndent()
+
+        schema.executeBlocking(
+            """
+            {
+                animals {
+                    ... on LandAnimal {
+                        ... on Bear { name order }
+                    }
+                }
+            }
+            """.trimIndent()
+        ) shouldBe """
+            {"data":{"animals":[{},{},{"name":"bear","order":"order2"},{}]}}
+        """.trimIndent()
+
+        schema.executeBlocking(
+            """
+            {
+                animals {
+                    ... on Mammal {
+                        order
+                        ... on Animal { name }
+                    }
+                }
+            }
+            """.trimIndent()
+        ) shouldBe """
+            {"data":{"animals":[{"order":"order1","name":"dolphin"},{},{"order":"order2","name":"bear"},{}]}}
+        """.trimIndent()
+
+        schema.executeBlocking(
+            """
+            {
+                animals {
+                    ...animalName
+                    ...mammalOrder
+                }
+            }
+            
+            fragment animalName on Animal {
+                name
+            }
+            
+            fragment mammalOrder on Mammal {
+                order
+            }
+            """.trimIndent()
+        ) shouldBe """
+            {"data":{"animals":[{"name":"dolphin","order":"order1"},{"name":"fish"},{"name":"bear","order":"order2"},{"name":"ant"}]}}
+        """.trimIndent()
     }
 
     @Test

--- a/kgraphql/src/test/kotlin/de/stuebingerb/kgraphql/specification/typesystem/InterfacesSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/de/stuebingerb/kgraphql/specification/typesystem/InterfacesSpecificationTest.kt
@@ -16,10 +16,13 @@ class InterfacesSpecificationTest {
     }
 
     data class Simple(override val exe: String, val stuff: String) : SimpleInterface
+    data class Simple2(override val exe: String, val other: String) : SimpleInterface
 
     val schema = KGraphQL.schema {
         type<Simple>()
+        type<Simple2>()
         query("simple") { resolver { -> Simple("EXE", "CMD") as SimpleInterface } }
+        query("simpleList") { resolver { -> listOf(Simple("EXE", "CMD"), Simple2("EXE", "other")) } }
     }
 
     @Test
@@ -39,5 +42,27 @@ class InterfacesSpecificationTest {
     fun `Query for fields of interface implementation can be done only by fragments`() {
         val map = deserialize(schema.executeBlocking("{simple{exe ... on Simple { stuff }}}"))
         map.extract<String>("data/simple/stuff") shouldBe "CMD"
+    }
+
+    @Test
+    fun `fragments on interfaces should work`() {
+        schema.executeBlocking(
+            """
+                {
+                    simpleList {
+                        __typename
+                        exe
+                        ...simpleFragment
+                    }
+                }
+                
+                fragment simpleFragment on SimpleInterface {
+                    ... on Simple { stuff }
+                    ... on Simple2 { other }
+                }
+            """.trimIndent()
+        ) shouldBe """
+            {"data":{"simpleList":[{"__typename":"Simple","exe":"EXE","stuff":"CMD"},{"__typename":"Simple2","exe":"EXE","other":"other"}]}}
+        """.trimIndent()
     }
 }

--- a/kgraphql/src/test/kotlin/de/stuebingerb/kgraphql/specification/typesystem/ObjectsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/de/stuebingerb/kgraphql/specification/typesystem/ObjectsSpecificationTest.kt
@@ -300,8 +300,6 @@ class ObjectsSpecificationTest {
         val active: Boolean = false
     )
 
-    data class FewFields(val name: String = "Boguś", val surname: String = "Linda")
-
     @Test
     fun `fields are conceptually ordered in the same order in which they were encountered during query execution`() {
         val schema = schema {
@@ -340,26 +338,6 @@ class ObjectsSpecificationTest {
 
         val result =
             schema.executeBlocking("{many{active, ...Fields , smooth, id}} fragment Fields on ManyFields { id2, value }")
-        with(result) {
-            indexOf("\"id\"") shouldBeGreaterThan indexOf("\"smooth\"")
-            indexOf("\"smooth\"") shouldBeGreaterThan indexOf("\"value\"")
-            indexOf("\"value\"") shouldBeGreaterThan indexOf("\"id2\"")
-            indexOf("\"id2\"") shouldBeGreaterThan indexOf("\"active\"")
-        }
-    }
-
-    @Test
-    fun `fragments for which the type does not apply does not affect ordering`() {
-        val schema = schema {
-            query("many") { resolver { -> ManyFields() } }
-            type<FewFields>()
-        }
-
-        val result = schema.executeBlocking(
-            "{many{active, ...Fields, ...Few , smooth, id}} " +
-                "fragment Fields on ManyFields { id2, value }" +
-                "fragment Few on FewFields { name } "
-        )
         with(result) {
             indexOf("\"id\"") shouldBeGreaterThan indexOf("\"smooth\"")
             indexOf("\"smooth\"") shouldBeGreaterThan indexOf("\"value\"")

--- a/kgraphql/src/test/kotlin/de/stuebingerb/kgraphql/specification/typesystem/UnionsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/de/stuebingerb/kgraphql/specification/typesystem/UnionsSpecificationTest.kt
@@ -311,7 +311,7 @@ class UnionsSpecificationTest : BaseSchemaTest() {
             query("returnUnion") {
                 resolver { node: Execution.Node ->
                     WithFields.Value1(1, node.getFields())
-                }
+                }.returns<WithFields>()
             }
         }.executeBlocking(
             """
@@ -385,7 +385,7 @@ class UnionsSpecificationTest : BaseSchemaTest() {
             }
             unionType<ContactStatus>()
             query("contactStatus") {
-                resolver { -> ContactStatus.Onboarded(userId = "someUserId") }
+                resolver { -> ContactStatus.Onboarded(userId = "someUserId") }.returns<ContactStatus>()
             }
         }
         val results = schema.executeBlocking(


### PR DESCRIPTION
Fragments can now only be defined on types that are actually possible at their position, e.g. you cannot define a fragment on `Cat` when the return type is known to be `Dog`. Similarly, fragments on interfaces and unions must be for one of the known `possibleTypes`.

Fixes #683

BREAKING CHANGE: invalid fragment conditions were previously simply ignored and now cause the query to fail.