### PR TITLE
refactor!: refactor union properties handling

### DIFF
--- a/kgraphql/api/kgraphql.api
+++ b/kgraphql/api/kgraphql.api
@@ -826,15 +826,6 @@ public final class de/stuebingerb/kgraphql/schema/execution/Execution$Remote : d
 	public synthetic fun withParent$de_stuebingerb_kgraphql (Lde/stuebingerb/kgraphql/schema/execution/Execution;)Lde/stuebingerb/kgraphql/schema/execution/Execution;
 }
 
-public final class de/stuebingerb/kgraphql/schema/execution/Execution$Union : de/stuebingerb/kgraphql/schema/execution/Execution$Node {
-	public fun <init> (Lde/stuebingerb/kgraphql/schema/model/ast/SelectionNode$FieldNode;Lde/stuebingerb/kgraphql/schema/structure/Field$Union;Ljava/util/Map;Ljava/util/Map;Lde/stuebingerb/kgraphql/schema/execution/Execution;)V
-	public final fun getMemberChildren ()Ljava/util/Map;
-	public final fun getUnionField ()Lde/stuebingerb/kgraphql/schema/structure/Field$Union;
-	public final fun memberExecution (Lde/stuebingerb/kgraphql/schema/structure/Type;)Lde/stuebingerb/kgraphql/schema/execution/Execution$Node;
-	public synthetic fun withParent$de_stuebingerb_kgraphql (Lde/stuebingerb/kgraphql/schema/execution/Execution;)Lde/stuebingerb/kgraphql/schema/execution/Execution$Node;
-	public synthetic fun withParent$de_stuebingerb_kgraphql (Lde/stuebingerb/kgraphql/schema/execution/Execution;)Lde/stuebingerb/kgraphql/schema/execution/Execution;
-}
-
 public final class de/stuebingerb/kgraphql/schema/execution/ExecutionMode : java/lang/Enum {
 	public static final field Normal Lde/stuebingerb/kgraphql/schema/execution/ExecutionMode;
 	public static final field Serial Lde/stuebingerb/kgraphql/schema/execution/ExecutionMode;
@@ -2087,27 +2078,6 @@ public final class de/stuebingerb/kgraphql/schema/structure/Field$RemoteOperatio
 	public final fun getRemoteQuery ()Ljava/lang/String;
 	public final fun getRemoteUrl ()Ljava/lang/String;
 	public fun isDeprecated ()Z
-}
-
-public final class de/stuebingerb/kgraphql/schema/structure/Field$Union : de/stuebingerb/kgraphql/schema/structure/Field, de/stuebingerb/kgraphql/schema/model/FunctionWrapper {
-	public fun <init> (Lde/stuebingerb/kgraphql/schema/model/PropertyDef$Union;Lde/stuebingerb/kgraphql/schema/structure/Type;Ljava/util/List;)V
-	public fun arity ()I
-	public fun checkAccess (Ljava/lang/Object;Lde/stuebingerb/kgraphql/Context;)V
-	public fun getArguments ()Ljava/util/List;
-	public fun getArgumentsDescriptor ()Ljava/util/Map;
-	public fun getDeprecationReason ()Ljava/lang/String;
-	public fun getDescription ()Ljava/lang/String;
-	public fun getHasReceiver ()Z
-	public fun getKFunction ()Lkotlin/reflect/KFunction;
-	public fun getName ()Ljava/lang/String;
-	public fun getReturnType ()Lde/stuebingerb/kgraphql/schema/structure/Type;
-	public fun hasReturnType ()Z
-	public fun invoke (Ljava/util/List;Ljava/util/List;Lcom/fasterxml/jackson/databind/ObjectWriter;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun invoke ([Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun isDeprecated ()Z
-	public fun subscribe (Ljava/lang/String;Lde/stuebingerb/kgraphql/schema/Subscriber;)V
-	public fun unsubscribe (Ljava/lang/String;)V
-	public fun valueParameters ()Ljava/util/List;
 }
 
 public final class de/stuebingerb/kgraphql/schema/structure/InputValue : de/stuebingerb/kgraphql/schema/introspection/__InputValue {

--- a/kgraphql/src/main/kotlin/de/stuebingerb/kgraphql/schema/execution/Execution.kt
+++ b/kgraphql/src/main/kotlin/de/stuebingerb/kgraphql/schema/execution/Execution.kt
@@ -7,7 +7,6 @@ import de.stuebingerb.kgraphql.schema.model.ast.OperationTypeNode
 import de.stuebingerb.kgraphql.schema.model.ast.SelectionNode
 import de.stuebingerb.kgraphql.schema.model.ast.VariableDefinitionNode
 import de.stuebingerb.kgraphql.schema.structure.Field
-import de.stuebingerb.kgraphql.schema.structure.Type
 
 sealed class Execution {
     abstract val selectionNode: SelectionNode
@@ -69,44 +68,6 @@ sealed class Execution {
             selectionNode,
             condition,
             elements,
-            directives,
-            parent
-        )
-    }
-
-    class Union(
-        node: SelectionNode.FieldNode,
-        val unionField: Field.Union<*>,
-        val memberChildren: Map<Type, Collection<Execution>>,
-        directives: Map<Directive, ArgumentNodes?>?,
-        parent: Execution?
-    ) : Node(
-        selectionNode = node,
-        field = unionField,
-        children = emptyList(),
-        arguments = null,
-        directives = directives,
-        variables = null,
-        arrayIndex = null,
-        parent = parent
-    ) {
-        fun memberExecution(type: Type): Node = Node(
-            selectionNode = selectionNode,
-            field = field,
-            children = requireNotNull(memberChildren[type]) {
-                "Union ${unionField.name} has no member $type"
-            },
-            arguments = arguments,
-            directives = directives,
-            variables = variables,
-            arrayIndex = arrayIndex,
-            parent = parent
-        )
-
-        override fun withParent(parent: Execution): Union = Union(
-            selectionNode,
-            unionField,
-            memberChildren,
             directives,
             parent
         )

--- a/kgraphql/src/main/kotlin/de/stuebingerb/kgraphql/schema/execution/ParallelRequestExecutor.kt
+++ b/kgraphql/src/main/kotlin/de/stuebingerb/kgraphql/schema/execution/ParallelRequestExecutor.kt
@@ -46,7 +46,6 @@ internal class ParallelRequestExecutor(val schema: DefaultSchema) : RequestExecu
                 forEach { execution ->
                     when (execution) {
                         is Execution.Fragment -> execution.elements.inspect()
-                        is Execution.Union -> execution.memberChildren.values.flatten().inspect()
                         is Execution.Node -> {
                             execution.children.inspect()
                             if (execution.field is Field.DataLoader<*, *, *>) {
@@ -126,40 +125,6 @@ internal class ParallelRequestExecutor(val schema: DefaultSchema) : RequestExecu
         jsonNodeFactory.nullNode()
     }
 
-    private suspend fun <T> createUnionOperationNode(
-        ctx: ExecutionContext,
-        parent: T,
-        node: Execution.Union,
-        unionProperty: Field.Union<T>
-    ): Deferred<JsonNode> {
-        try {
-            node.field.checkAccess(parent, ctx.requestContext)
-        } catch (e: Throwable) {
-            return handleException(ctx, node, node.field.returnType, e)
-        }
-        val operationResult: Any? = unionProperty.invoke(
-            funName = unionProperty.name,
-            receiver = parent,
-            inputValues = node.field.arguments,
-            args = node.arguments,
-            executionNode = node,
-            ctx = ctx
-        ).await()
-
-        val possibleTypes = (unionProperty.returnType.unwrapped() as Type.Union).possibleTypes
-        val returnType = possibleTypes.find { it.isInstance(operationResult) }
-
-        if (returnType == null && unionProperty.returnType.isNotNullable()) {
-            val expectedOneOf = possibleTypes.joinToString { it.name.toString() }
-            throw ExecutionException(
-                "Unexpected type of union property value, expected one of [$expectedOneOf] but was '$operationResult'",
-                node
-            )
-        }
-
-        return createNode(ctx, operationResult, node, returnType ?: unionProperty.returnType)
-    }
-
     private suspend fun <T> createNode(
         ctx: ExecutionContext,
         value: T?,
@@ -212,6 +177,10 @@ internal class ParallelRequestExecutor(val schema: DefaultSchema) : RequestExecu
                     }
                 }
 
+                value is Deferred<*> -> createNode(ctx, value.await(), node, returnType)
+
+                node.children.isNotEmpty() -> createObjectNode(ctx, value, node, returnType)
+
                 value is String -> CompletableDeferred(jsonNodeFactory.textNode(value))
                 value is Int -> CompletableDeferred(jsonNodeFactory.numberNode(value))
                 value is Float -> CompletableDeferred(jsonNodeFactory.numberNode(value))
@@ -219,17 +188,6 @@ internal class ParallelRequestExecutor(val schema: DefaultSchema) : RequestExecu
                 value is Boolean -> CompletableDeferred(jsonNodeFactory.booleanNode(value))
                 value is Long -> CompletableDeferred(jsonNodeFactory.numberNode(value))
                 value is Short -> CompletableDeferred(jsonNodeFactory.numberNode(value))
-
-                value is Deferred<*> -> createNode(ctx, value.await(), node, returnType)
-
-                node.children.isNotEmpty() -> createObjectNode(ctx, value, node, returnType)
-
-                node is Execution.Union -> createObjectNode(
-                    ctx,
-                    value,
-                    node.memberExecution(returnType),
-                    returnType
-                )
 
                 // TODO: do we have to consider more? more validation e.g.?
                 value is JsonNode -> CompletableDeferred(value)
@@ -268,6 +226,16 @@ internal class ParallelRequestExecutor(val schema: DefaultSchema) : RequestExecu
         node: Execution.Node,
         type: Type
     ): Deferred<ObjectNode> {
+        val unwrappedType = type.unwrapped()
+        if (unwrappedType.kind == TypeKind.UNION || unwrappedType.kind == TypeKind.INTERFACE) {
+            if (unwrappedType.possibleTypes?.none { isExpectedType(value, it) } == true) {
+                throw ExecutionError(
+                    "Unexpected value type; expected one of ${unwrappedType.possibleTypes?.map { it.name }} but was '${value?.javaClass?.simpleName}'",
+                    node
+                )
+            }
+        }
+
         val objectNode = jsonNodeFactory.objectNode()
         val deferreds = node.children.mapIndexedParallel(dispatcher) { _, child ->
             when (child) {
@@ -291,21 +259,6 @@ internal class ParallelRequestExecutor(val schema: DefaultSchema) : RequestExecu
         type: Type
     ): Pair<String, Deferred<JsonNode>>? {
         when (child) {
-            // Union is subclass of Node so check it first
-            is Execution.Union -> {
-                val field = checkNotNull(type.unwrapped()[child.key]) {
-                    "Execution unit '${child.key}' is not contained by operation return type '${type.unwrapped().name}'"
-                }
-                if (field is Field.Union<*>) {
-                    return child.aliasOrKey to createUnionOperationNode(ctx, value, child, field as Field.Union<T>)
-                } else {
-                    throw ExecutionException(
-                        "Unexpected non-union field for union execution node '${child.aliasOrKey}'",
-                        child
-                    )
-                }
-            }
-
             is Execution.Remote -> {
                 return child.aliasOrKey to handleFunctionProperty(
                     ctx,
@@ -326,6 +279,11 @@ internal class ParallelRequestExecutor(val schema: DefaultSchema) : RequestExecu
         }
     }
 
+    private fun <T> isExpectedType(value: T, expectedType: Type): Boolean {
+        // TODO: for remote objects we rely on the presence of the __typename. So maybe we should/need to automatically add it if not present already? Can this break something?
+        return expectedType == value || expectedType.isInstance(value) || (value is JsonNode && value["__typename"]?.textValue() == expectedType.name)
+    }
+
     private suspend fun <T> handleFragment(
         ctx: ExecutionContext,
         value: T,
@@ -335,8 +293,7 @@ internal class ParallelRequestExecutor(val schema: DefaultSchema) : RequestExecu
         if (include) {
             val expectedType = container.condition.onType
             if (expectedType.kind == TypeKind.OBJECT || expectedType.kind == TypeKind.INTERFACE) {
-                // TODO: for remote objects we now rely on the presence of the __typename. So maybe we should/need to automatically add it if not present already? Can this break something?
-                if (expectedType == value || expectedType.isInstance(value) || (value is JsonNode && value["__typename"]?.textValue() == expectedType.name)) {
+                if (isExpectedType(value, expectedType)) {
                     val childElements = container.elements.flatMap { child ->
                         when (child) {
                             is Execution.Fragment -> handleFragment(ctx, value, child.withParent(container)).toList()
@@ -407,7 +364,7 @@ internal class ParallelRequestExecutor(val schema: DefaultSchema) : RequestExecu
                     return handleDataProperty(ctx, parentValue, node, field)
                 }
 
-                else -> error("Unexpected field type '$field', should be Field.Kotlin, Field.Function or Field.DataLoader")
+                else -> error("Unexpected field type '$field', should be Field.Kotlin, Field.Function, or Field.DataLoader")
             }
         } else {
             return null
@@ -483,10 +440,7 @@ internal class ParallelRequestExecutor(val schema: DefaultSchema) : RequestExecu
     }
 
     private suspend fun shouldInclude(ctx: ExecutionContext, executionNode: Execution): Boolean {
-        if (executionNode.directives?.isEmpty() == true) {
-            return true
-        }
-        return executionNode.directives?.map { (directive, arguments) ->
+        return executionNode.directives?.isEmpty() == true || executionNode.directives?.map { (directive, arguments) ->
             directive.execution.invoke(
                 funName = directive.name,
                 inputValues = directive.arguments,

--- a/kgraphql/src/main/kotlin/de/stuebingerb/kgraphql/schema/structure/Field.kt
+++ b/kgraphql/src/main/kotlin/de/stuebingerb/kgraphql/schema/structure/Field.kt
@@ -84,25 +84,6 @@ sealed class Field : __Field {
         }
     }
 
-    class Union<T>(
-        private val kql: PropertyDef.Union<T>,
-        override val returnType: Type,
-        override val arguments: List<InputValue<*>>
-    ) : Field(), FunctionWrapper<Any?> by kql {
-
-        override val name: String = kql.name
-
-        override val description: String? = kql.description
-
-        override val isDeprecated: Boolean = kql.isDeprecated
-
-        override val deprecationReason: String? = kql.deprecationReason
-
-        override fun checkAccess(parent: Any?, ctx: Context) {
-            kql.accessRule?.invoke(parent as T?, ctx)?.let { throw it }
-        }
-    }
-
     class RemoteOperation<T, R>(
         private val kql: BaseOperationDef<T, R>,
         val field: Delegated,

--- a/kgraphql/src/main/kotlin/de/stuebingerb/kgraphql/schema/structure/RequestInterpreter.kt
+++ b/kgraphql/src/main/kotlin/de/stuebingerb/kgraphql/schema/structure/RequestInterpreter.kt
@@ -43,9 +43,6 @@ internal class RequestInterpreter(private val schemaModel: SchemaModel) {
         // prevent stack overflow
         private val fragmentsStack = Stack<String>()
 
-        fun getFragment(name: String) =
-            checkNotNull(fragments[name]) { "Fragment '$name' not found" }.also { usedFragments.add(name) }
-
         fun get(node: FragmentSpreadNode): Execution.Fragment? {
             if (fragmentsStack.contains(node.name.value)) {
                 throw ValidationException("Fragment spread circular references are not allowed", node)
@@ -176,8 +173,6 @@ internal class RequestInterpreter(private val schemaModel: SchemaModel) {
                 node
             )
 
-            is Field.Union<*> -> handleUnion(field, node, ctx)
-
             is Field.RemoteOperation<*, *> -> handleRemoteOperation(field, node, ctx)
 
             else -> {
@@ -247,52 +242,6 @@ internal class RequestInterpreter(private val schemaModel: SchemaModel) {
                 this == schemaModel.subscriptionType -> OperationTypeNode.SUBSCRIPTION
                 else -> OperationTypeNode.QUERY
             },
-            parent = null
-        )
-    }
-
-    private fun <T> handleUnion(
-        field: Field.Union<T>,
-        selectionNode: FieldNode,
-        ctx: InterpreterContext
-    ): Execution.Union {
-        validateUnionRequest(field, selectionNode)
-
-        // https://spec.graphql.org/October2021/#sec-Unions
-        //  "With interfaces and objects, only those fields defined on the type can be queried directly; to query
-        //  other fields on an interface, typed fragments must be used. This is the same as for unions, but unions
-        //  do not define any fields, so *no* fields may be queried on this type without the use of type refining
-        //  fragments or inline fragments (with the exception of the meta-field `__typename`)."
-        val unionMembersChildren: Map<Type, List<Execution>> =
-            (field.returnType.unwrapped() as Type.Union).possibleTypes.associateWith { possibleType ->
-                val mergedSelectionsForType = selectionNode.selectionSet?.selections?.flatMap {
-                    when {
-                        // Only __typename is allowed as field selection
-                        it is FieldNode && it.name.value == "__typename"
-                            -> listOf(it)
-
-                        it is FragmentSpreadNode && ctx.getFragment(it.name.value).first.name == possibleType.name
-                            -> ctx.getFragment(it.name.value).second.selections
-
-                        it is InlineFragmentNode && possibleType.name == it.typeCondition?.name?.value
-                            -> it.selectionSet.selections
-
-                        else -> emptyList()
-                    }
-                }
-
-                if (!mergedSelectionsForType.isNullOrEmpty()) {
-                    handleReturnType(ctx, possibleType, SelectionSetNode(null, mergedSelectionsForType))
-                } else {
-                    emptyList()
-                }
-            }
-
-        return Execution.Union(
-            node = selectionNode,
-            unionField = field,
-            memberChildren = unionMembersChildren,
-            directives = selectionNode.directives?.lookup(),
             parent = null
         )
     }

--- a/kgraphql/src/main/kotlin/de/stuebingerb/kgraphql/schema/structure/SchemaCompilation.kt
+++ b/kgraphql/src/main/kotlin/de/stuebingerb/kgraphql/schema/structure/SchemaCompilation.kt
@@ -230,7 +230,7 @@ open class SchemaCompilation(
     private suspend fun handleUnionProperty(unionProperty: PropertyDef.Union<*>): Field {
         val inputValues = handleInputValues(unionProperty, unionProperty.inputValues)
         val type = applyNullability(unionProperty.nullable, handleUnionType(unionProperty.union))
-        return Field.Union(unionProperty, type, inputValues)
+        return Field.Function(unionProperty, type, inputValues)
     }
 
     private suspend fun handlePossiblyWrappedType(kType: KType, typeCategory: TypeCategory): Type = when {

--- a/kgraphql/src/main/kotlin/de/stuebingerb/kgraphql/schema/structure/Validation.kt
+++ b/kgraphql/src/main/kotlin/de/stuebingerb/kgraphql/schema/structure/Validation.kt
@@ -57,25 +57,6 @@ private fun Field.validateArguments(requestNode: FieldNode, parentTypeName: Stri
     return exceptions
 }
 
-/**
- * validate that only typed fragments or __typename are present
- */
-internal fun validateUnionRequest(field: Field.Union<*>, selectionNode: FieldNode) {
-    val illegalChildren =
-        selectionNode.selectionSet?.selections?.filterIsInstance<FieldNode>()?.filter { it.name.value != "__typename" }
-
-    if (!illegalChildren.isNullOrEmpty()) {
-        throw ValidationException(
-            message = "Invalid selection set with properties: ${
-                illegalChildren.joinToString(prefix = "[", postfix = "]") {
-                    it.aliasOrName.value
-                }
-            } on union type property ${field.name} : ${(field.returnType.unwrapped() as Type.Union).possibleTypes.map { it.name }}",
-            node = selectionNode
-        )
-    }
-}
-
 fun validateName(name: String) {
     if (name.startsWith("__")) {
         throw SchemaException(

--- a/kgraphql/src/test/kotlin/de/stuebingerb/kgraphql/schema/SchemaBuilderTest.kt
+++ b/kgraphql/src/test/kotlin/de/stuebingerb/kgraphql/schema/SchemaBuilderTest.kt
@@ -203,7 +203,7 @@ class SchemaBuilderTest {
 
         val unionField = scenarioType["pdf"]
         unionField shouldNotBe null
-        unionField shouldBeInstanceOf Field.Union::class
+        unionField shouldBeInstanceOf Field.Function::class
     }
 
     @Test

--- a/kgraphql/src/test/kotlin/de/stuebingerb/kgraphql/specification/language/FragmentsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/de/stuebingerb/kgraphql/specification/language/FragmentsSpecificationTest.kt
@@ -1,6 +1,8 @@
 package de.stuebingerb.kgraphql.specification.language
 
 import de.stuebingerb.kgraphql.Actor
+import de.stuebingerb.kgraphql.Film
+import de.stuebingerb.kgraphql.FilmType
 import de.stuebingerb.kgraphql.KGraphQL
 import de.stuebingerb.kgraphql.Specification
 import de.stuebingerb.kgraphql.ValidationException
@@ -595,6 +597,103 @@ class FragmentsSpecificationTest : BaseSchemaTest() {
                     unions(isOne: false) {
                         ... on Union1 { names }
                         ... on Actor { name }
+                    }
+                }
+                """.trimIndent()
+            )
+        }
+    }
+
+    @Test
+    fun `fragments on impossible union properties should be denied`() {
+        val schema = KGraphQL.schema {
+            val movieUnion = unionType("MovieUnion") {
+                type<Actor>()
+                type<Film>()
+            }
+
+            enum<FilmType>()
+
+            type<Actor> {
+                unionProperty("favourite") {
+                    returnType = movieUnion
+                    resolver { actor ->
+                        actor
+                    }
+                }
+            }
+
+            query("actors") {
+                resolver { ->
+                    listOf(Actor("John Smith", 42), Actor("Foo Bar", 24))
+                }
+            }
+        }
+
+        expectRequestError<ValidationException>("Invalid type 'Director' in type condition on fragment 'directorFragment' of type 'MovieUnion'; must be one of '[Actor, Film]'") {
+            schema.executeBlocking(
+                """
+                {
+                    actors {
+                        name
+                        favourite {
+                            ...actorFragment
+                            ...directorFragment
+                        }
+                    }
+                }
+                fragment actorFragment on Actor {
+                    name
+                }
+                fragment directorFragment on Director {
+                    name
+                }
+                """.trimIndent()
+            )
+        }
+
+        expectRequestError<ValidationException>("Fragments can only be specified on object types, interfaces, and unions but 'FilmType' is ENUM on inline fragment") {
+            schema.executeBlocking(
+                """
+                {
+                    actors {
+                        name
+                        favourite {
+                            ... on Actor { name }
+                            ... on FilmType { illegal }
+                        }
+                    }
+                }
+                """.trimIndent()
+            )
+        }
+
+        expectRequestError<ValidationException>("Fragments can only be specified on object types, interfaces, and unions but 'String' is SCALAR on inline fragment") {
+            schema.executeBlocking(
+                """
+                {
+                    actors {
+                        name
+                        favourite {
+                            ... on Actor { name }
+                            ... on String { illegal }
+                        }
+                    }
+                }
+                """.trimIndent()
+            )
+        }
+
+        expectRequestError<ValidationException>("Unknown type 'MissingType' in type condition on inline fragment") {
+            schema.executeBlocking(
+                """
+                {
+                    actors {
+                        name
+                        favourite {
+                            ... on Actor { name }
+                            ... on MissingType { illegal }
+                        }
                     }
                 }
                 """.trimIndent()

--- a/kgraphql/src/test/kotlin/de/stuebingerb/kgraphql/specification/language/VariablesSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/de/stuebingerb/kgraphql/specification/language/VariablesSpecificationTest.kt
@@ -34,6 +34,14 @@ class VariablesSpecificationTest : BaseSchemaTest() {
         result.extract<String>("data/filmByRank/title") shouldBe "Prestige"
     }
 
+    @Test
+    fun `query with int variable should allow exponential notation`() {
+        val result =
+            execute(query = "query(\$rank: Int!) {filmByRank(rank: \$rank) {title}}", variables = "{\"rank\": 1e+0}")
+        assertNoErrors(result)
+        result.extract<String>("data/filmByRank/title") shouldBe "Prestige"
+    }
+
     // Json only has one number type, so "1" and "1.0" are the same, and input coercion should be able to handle
     // the value accordingly
     @Test

--- a/kgraphql/src/test/kotlin/de/stuebingerb/kgraphql/specification/typesystem/UnionsSpecificationTest.kt
+++ b/kgraphql/src/test/kotlin/de/stuebingerb/kgraphql/specification/typesystem/UnionsSpecificationTest.kt
@@ -65,7 +65,7 @@ class UnionsSpecificationTest : BaseSchemaTest() {
 
     @Test
     fun `query union property with invalid selection set`() {
-        expectRequestError<ValidationException>("Invalid selection set with properties: [name] on union type property favourite : [Actor, Scenario, Director]") {
+        expectRequestError<ValidationException>("Property 'name' on 'Favourite' does not exist") {
             testedSchema.executeBlocking("{actors{name, favourite{ name }}}")
         }
     }
@@ -189,7 +189,7 @@ class UnionsSpecificationTest : BaseSchemaTest() {
 
     @Test
     fun `non-nullable union types should fail`() {
-        expectExecutionError<ExecutionException>("Unexpected type of union property value, expected one of [Actor, Scenario, Director] but was 'null'") {
+        expectExecutionError<ExecutionException>("Null result for non-nullable operation 'favourite'") {
             testedSchema.executeBlocking(
                 """{
                     actors(all: true) {
@@ -505,5 +505,73 @@ class UnionsSpecificationTest : BaseSchemaTest() {
             it["fields"] shouldBe listOf(mapOf("name" to "id", "type" to mapOf("name" to null)))
             it["possibleTypes"] shouldBe null
         }
+    }
+
+    data class Novel(val authorId: String)
+    data class NonFiction(val topic: String)
+    data class BookShelf(val id: String)
+    data class Other(val name: String)
+
+    @Test
+    fun `union property must only return valid types`() {
+        val schema = KGraphQL.schema {
+            val item = unionType("Item") {
+                type<Novel>()
+                type<NonFiction>()
+            }
+            type<Other>()
+            type<BookShelf> {
+                unionProperty("items") {
+                    returnType = item
+                    resolver { shelf ->
+                        if (shelf.id == "1") {
+                            // `Other` is not part of the defined unionType
+                            Other("a1")
+                        } else if (shelf.id == "3") {
+                            "Invalid scalar"
+                        } else {
+                            NonFiction("GraphQL")
+                        }
+                    }
+                }
+            }
+            query("root") {
+                resolver { ids: List<String> ->
+                    ids.map {
+                        BookShelf(it)
+                    }
+                }.withArgs {
+                    arg<List<String>> { name = "ids"; defaultValue = listOf("1", "2") }
+                }
+            }
+        }
+
+        schema.executeBlocking(
+            """
+            {
+              root {
+                items {
+                    ... on Novel { authorId }
+                    ... on NonFiction { topic } }
+              }
+            }
+        """.trimIndent()
+        ) shouldBe """
+            {"errors":[{"message":"Unexpected value type; expected one of [Novel, NonFiction] but was 'Other'","locations":[{"line":3,"column":5}],"path":["root",0,"items"],"extensions":{"type":"INTERNAL_SERVER_ERROR"}}],"data":null}
+        """.trimIndent()
+
+        schema.executeBlocking(
+            """
+            {
+              root(ids: ["3"]) {
+                items {
+                    ... on Novel { authorId }
+                    ... on NonFiction { topic } }
+              }
+            }
+        """.trimIndent()
+        ) shouldBe """
+            {"errors":[{"message":"Unexpected value type; expected one of [Novel, NonFiction] but was 'String'","locations":[{"line":3,"column":5}],"path":["root",0,"items"],"extensions":{"type":"INTERNAL_SERVER_ERROR"}}],"data":null}
+        """.trimIndent()
     }
 }


### PR DESCRIPTION
Refactors handling of union properties and processes them just like regular fragments, thereby benefitting from all recent bugfixes and simplifying code.

Fixes #697

BREAKING CHANGE: removed `Type.Union`, `Field.Union`, and `Execution.Union`.

BREAKING CHANGE: invalid fragment conditions in union properties were previously simply ignored and now cause the query to fail.